### PR TITLE
feat(openai): add reasoning model support for Completions API

### DIFF
--- a/python/mirascope/llm/providers/openai/completions/_utils/encode.py
+++ b/python/mirascope/llm/providers/openai/completions/_utils/encode.py
@@ -20,6 +20,7 @@ from ...model_info import (
     MODELS_WITHOUT_AUDIO_SUPPORT,
     MODELS_WITHOUT_JSON_OBJECT_SUPPORT,
     MODELS_WITHOUT_JSON_SCHEMA_SUPPORT,
+    NON_REASONING_MODELS,
 )
 
 if TYPE_CHECKING:
@@ -41,6 +42,7 @@ class ChatCompletionCreateKwargs(TypedDict, total=False):
     parallel_tool_calls: bool | Omit
     temperature: float | Omit
     max_tokens: int | Omit
+    max_completion_tokens: int | Omit
     top_p: float | Omit
     seed: int | Omit
     stop: str | list[str] | Omit
@@ -301,28 +303,33 @@ def encode_request(
         )
     base_model_name = model_name(model_id, None)
 
+    is_reasoning_model = base_model_name not in NON_REASONING_MODELS
     kwargs: ChatCompletionCreateKwargs = ChatCompletionCreateKwargs(
-        {
-            "model": base_model_name,
-        }
+        {"model": base_model_name}
     )
     encode_thoughts_as_text = False
 
     with _base_utils.ensure_all_params_accessed(
         params=params,
         provider_id="openai",
-        unsupported_params=["top_k"],
+        unsupported_params=[
+            "top_k",
+            *(["temperature", "top_p", "stop_sequences"] if is_reasoning_model else []),
+        ],
     ) as param_accessor:
-        if param_accessor.temperature is not None:
+        if not is_reasoning_model and param_accessor.temperature is not None:
             kwargs["temperature"] = param_accessor.temperature
         if param_accessor.max_tokens is not None:
-            kwargs["max_tokens"] = param_accessor.max_tokens
-        if param_accessor.top_p is not None:
+            if is_reasoning_model:
+                kwargs["max_completion_tokens"] = param_accessor.max_tokens
+            else:
+                kwargs["max_tokens"] = param_accessor.max_tokens
+        if not is_reasoning_model and param_accessor.top_p is not None:
             kwargs["top_p"] = param_accessor.top_p
 
         if param_accessor.seed is not None:
             kwargs["seed"] = param_accessor.seed
-        if param_accessor.stop_sequences is not None:
+        if not is_reasoning_model and param_accessor.stop_sequences is not None:
             kwargs["stop"] = param_accessor.stop_sequences
         if param_accessor.thinking is not None:
             thinking = param_accessor.thinking

--- a/python/tests/e2e/input/cassettes/test_call_with_params/openai_gpt_5_completions.yaml
+++ b/python/tests/e2e/input/cassettes/test_call_with_params/openai_gpt_5_completions.yaml
@@ -1,0 +1,109 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"gpt-5","max_completion_tokens":500,"seed":42}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '115'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3SSy07DMBBF9/kKy+sGtaHpa42EuoKuQCAUufY0cXFsy54ABfXfkd2HU0E3XsyZ
+        ubp3PD8ZIVQKuiCUNwx5a1V+Vzyv1g/zJTafj6vtqrbb+289We5uZy+TJzoIE2a9BY6nqRtuWqsA
+        pdEHzB0whKA6mk7m4/m0LMoIWiNAhbHaYl7mxbAo8+EsH06Pc42RHDxdkNeMEEJ+4hscagFfdEGG
+        g1OlBe9ZDXRxbiKEOqNChTLvpUemkQ4S5EYj6Gh6XIyLPnKw6TwLxnSnVA8wrQ2yECyaejuS/dnG
+        Rmrpm8oB80YHaY/G0kj3GSFvMVZ34ZRaZ1qLFZp3iLKj8iBH0xoTnJ4gGmQq1efHVVyqVQKQSeV7
+        a6Gc8QZEmkw7ZJ2QpgeyXra/Zv7TPuSWuk4qk/FV/QQ4B4sgKutASH6ZOLU5CFd2re285OiYenAf
+        kkOFElz4CAEb1qnDBVC/8whttZG6BmedjGcQ/jrbZ78AAAD//wMAxS6jYAMDAAA=
+    headers:
+      CF-RAY:
+      - 9c4666c82f5dd77f-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 27 Jan 2026 07:05:27 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=_0h_sMV.LznoWzrpCsW7mFMHKrmh46jMHzMyBiW9yQY-1769497527-1.0.1.1-C3DIuYusrsofHRqWYt9ZiZCNN.O64NabdghHIJQS7fEawWPAy8jH_RlcL5Gjf669gcwUThPS0tDN0QowTQdj1XqNsvJOEmOwS9WaH8Rmriw;
+        path=/; expires=Tue, 27-Jan-26 07:35:27 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=KsXBzFuwLWUuSVaRzD94p1UrqZebeaueKzoEmIn1YiE-1769497527529-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '1855'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '2000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '1999993'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_9f6aa8e6141947399a7c58f3b28de4c1
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_call_with_params/openai_gpt_5_mini_completions.yaml
+++ b/python/tests/e2e/input/cassettes/test_call_with_params/openai_gpt_5_mini_completions.yaml
@@ -1,0 +1,209 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"gpt-5-mini","max_completion_tokens":500,"seed":42,"stop":["4242"]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '136'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"message\": \"Unsupported parameter: 'stop'
+        is not supported with this model.\",\n    \"type\": \"invalid_request_error\",\n
+        \   \"param\": \"stop\",\n    \"code\": \"unsupported_parameter\"\n  }\n}"
+    headers:
+      CF-RAY:
+      - 9c46523119714a26-NRT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 27 Jan 2026 06:51:22 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=65injOoR4JMpTElnxi5QliQIqGk1VhZrTGHKGiqAIIU-1769496682-1.0.1.1-ldor9Z_JLWvispVmtc3IUMqMrVvDPkPHSrfPSvnknWgI1DFfMdAMuRa3VSA4378uDoHMXOnjOsvybZd0jssFz9VTFaJ169kPBp_fTL661w8;
+        path=/; expires=Tue, 27-Jan-26 07:21:22 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=SDNnrgb66z1Dm7SWyvt2ZRHdRKEl.rZS0tIxPM.zlt4-1769496682053-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '9'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999993'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_3855783c722245b6ab7e4e7f7b2d85ce
+    status:
+      code: 400
+      message: Bad Request
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"gpt-5-mini","max_completion_tokens":500,"seed":42}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '120'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4ySTU8CMRCG7/srmp5ZAwssHzcjGr148oAasqntLFS6bdPOqkj476blY5eIiZce
+        5pl5877T2SaEUCnolFC+Ysgrq9JZNp/5u37+Mhf503V9O/6+X9c35vPx2W8eaCdMmLd34HicuuKm
+        sgpQGr3H3AFDCKq9UT4ZTPJRP4+gMgJUGFtaTIdpJbVMs242TLvjtDs6DK+M5ODplLwmhBCyjW+w
+        qQV80Snpdo6VCrxnS6DTUxMh1BkVKpR5Lz0yjbTTQG40go7OB9kgayMHZe1ZcKdrpVqAaW2QhXTR
+        1OJAdicbpdTSrwoHzBsdpD0aSyPdJYQsYqz6zCm1zlQWCzRriLK94V6ONrtswd4BokGmmnqWdy6o
+        FQKQSeVba6Gc8RWIZrLZIauFNC2QtLL9NnNJe59b6uV/5BvAOVgEUVgHQvLzwE2bg3Bpf7WddhwN
+        Uw/uQ3IoUIIL/yCgZLXaHwD1G49QFaXUS3DWyXgF4auTXfIDAAD//wMAkzpzaQcDAAA=
+    headers:
+      CF-RAY:
+      - 9c4653833b318ec0-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 27 Jan 2026 06:52:17 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=CBnfoSOFcU_8xkejVVGPiJl4JSdU.PHtifDwqTUhAQc-1769496737-1.0.1.1-MwZ6CVC5RfFIPsKrW3.EU1Qpz32ek17HTK.z034tIgY09nN0rtUFnpoWzs9.uqGyN5PQZU2xc4_SA2aAOesuca3hXluRmcUcjQrKBFAClCk;
+        path=/; expires=Tue, 27-Jan-26 07:22:17 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=IM6e_JC_VgYO.Q2hOomC45u8eviGuVhxwOpoR7VY9FE-1769496737490-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '1258'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999993'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_6eb7d7fc661d41df9064e70546b7ea3c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/snapshots/test_call_with_params/openai_gpt_5_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_params/openai_gpt_5_completions_snapshots.py
@@ -1,0 +1,64 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": (
+            {
+                "provider_id": "openai",
+                "model_id": "openai/gpt-5:completions",
+                "provider_model_name": "gpt-5:completions",
+                "params": {
+                    "temperature": 0.7,
+                    "max_tokens": 500,
+                    "top_p": 0.3,
+                    "top_k": 50,
+                    "seed": 42,
+                    "stop_sequences": ["4242"],
+                    "thinking": {
+                        "level": "none",
+                        "encode_thoughts_as_text": False,
+                        "include_thoughts": False,
+                    },
+                },
+                "finish_reason": None,
+                "usage": {
+                    "input_tokens": 15,
+                    "output_tokens": 75,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "reasoning_tokens": 64,
+                    "raw": "CompletionUsage(completion_tokens=75, prompt_tokens=15, total_tokens=90, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=64, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))",
+                    "total_tokens": 90,
+                },
+                "messages": [
+                    UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                    AssistantMessage(
+                        content=[Text(text="4242")],
+                        provider_id="openai",
+                        model_id="openai/gpt-5:completions",
+                        provider_model_name="gpt-5:completions",
+                        raw_message={
+                            "content": "4242",
+                            "role": "assistant",
+                            "annotations": [],
+                        },
+                    ),
+                ],
+                "format": None,
+                "tools": [],
+            },
+        ),
+        "logs": [
+            "Skipping unsupported parameter: top_k=50 (provider: openai)",
+            "Skipping unsupported parameter: temperature=0.7 (provider: openai)",
+            "Skipping unsupported parameter: top_p=0.3 (provider: openai)",
+            "Skipping unsupported parameter: stop_sequences=['4242'] (provider: openai)",
+        ],
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_call_with_params/openai_gpt_5_mini_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_params/openai_gpt_5_mini_completions_snapshots.py
@@ -1,0 +1,64 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": (
+            {
+                "provider_id": "openai",
+                "model_id": "openai/gpt-5-mini:completions",
+                "provider_model_name": "gpt-5-mini:completions",
+                "params": {
+                    "temperature": 0.7,
+                    "max_tokens": 500,
+                    "top_p": 0.3,
+                    "top_k": 50,
+                    "seed": 42,
+                    "stop_sequences": ["4242"],
+                    "thinking": {
+                        "level": "none",
+                        "encode_thoughts_as_text": False,
+                        "include_thoughts": False,
+                    },
+                },
+                "finish_reason": None,
+                "usage": {
+                    "input_tokens": 15,
+                    "output_tokens": 11,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "reasoning_tokens": 0,
+                    "raw": "CompletionUsage(completion_tokens=11, prompt_tokens=15, total_tokens=26, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))",
+                    "total_tokens": 26,
+                },
+                "messages": [
+                    UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                    AssistantMessage(
+                        content=[Text(text="4242")],
+                        provider_id="openai",
+                        model_id="openai/gpt-5-mini:completions",
+                        provider_model_name="gpt-5-mini:completions",
+                        raw_message={
+                            "content": "4242",
+                            "role": "assistant",
+                            "annotations": [],
+                        },
+                    ),
+                ],
+                "format": None,
+                "tools": [],
+            },
+        ),
+        "logs": [
+            "Skipping unsupported parameter: top_k=50 (provider: openai)",
+            "Skipping unsupported parameter: temperature=0.7 (provider: openai)",
+            "Skipping unsupported parameter: top_p=0.3 (provider: openai)",
+            "Skipping unsupported parameter: stop_sequences=['4242'] (provider: openai)",
+        ],
+    }
+)

--- a/python/tests/e2e/input/test_call_with_params.py
+++ b/python/tests/e2e/input/test_call_with_params.py
@@ -12,6 +12,13 @@ from tests.utils import (
     snapshot_test,
 )
 
+PARAMS_MODEL_IDS: list[llm.ModelId] = [
+    *E2E_MODEL_IDS,
+    # Include reasoning models to verify unsupported params (temperature, top_p) are logged
+    "openai/gpt-5-mini:completions",
+    "openai/gpt-5:completions",
+]
+
 # ============= ALL PARAMS TESTS =============
 ALL_PARAMS: llm.Params = {
     "temperature": 0.7,
@@ -37,7 +44,7 @@ def test_all_params_includes_every_param() -> None:
     )
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", PARAMS_MODEL_IDS)
 @pytest.mark.vcr
 def test_call_with_params(
     model_id: llm.ModelId,

--- a/python/tests/e2e/output/cassettes/test_max_tokens/openai_gpt_5_mini_completions/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/openai_gpt_5_mini_completions/async.yaml
@@ -1,0 +1,107 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"List all U.S. states."}],"model":"gpt-5-mini","max_completion_tokens":50}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '112'
+      content-type:
+      - application/json
+      cookie:
+      - <filtered>
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RSy2rDMBC8+yvEnuPipIkbciuFUkpPPZSGEowqbWylsiSkdWkI+fci5WGHtBcd
+        dnaGmVntMsZASVgwEA0n0TqdPzj+8vygXXk/fyyeJkv9HrabdhneXn/mbzCKDPu5QUEn1o2wrdNI
+        ypoDLDxywqg6vivL6biYlrMEtFaijrTaUT7LW2VUPikms7yY58XdkdxYJTDAgn1kjDG2S2+0aST+
+        wIIVo9OkxRB4jbA4LzEG3uo4AR6CCsQNwagHhTWEJjkfjj2uu8CjM9NpPQC4MZZ4TJYMrY7I/mxh
+        rYwKTeWRB2uirEZTUwMJ32eMrVKo7sInOG9bRxXZL0zC49uDIPRN9uDsGBjIEtf9vDyRLtQqicSV
+        DoNSQHDRoOyZfYO8k8oOgGyQ7trMX9qH5MrU14b/0O8BIdARysp5lEpcJu7XPMaP9t/aueTkGAL6
+        byWwIoU+nkLimnf6cH8I20DYVmtlavTOq/QJ4rWzffYLAAD//wMAo9oXrAYDAAA=
+    headers:
+      CF-RAY:
+      - 9b1fff1f3f6ac8eb-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 22 Dec 2025 13:34:26 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '1107'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '1131'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999992'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_43f6d161845544ff91d9d765f05755aa
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_max_tokens/openai_gpt_5_mini_completions/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/openai_gpt_5_mini_completions/async_stream.yaml
@@ -1,0 +1,110 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"List all U.S. states."}],"model":"gpt-5-mini","max_completion_tokens":50,"stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '166'
+      content-type:
+      - application/json
+      cookie:
+      - <filtered>
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-CpaLMVkLd9W8G4FgQ4It6eXocXc0S","object":"chat.completion.chunk","created":1766410468,"model":"gpt-5-mini-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"finish_reason":null}],"usage":null,"obfuscation":"dZxXZ"}
+
+
+        data: {"id":"chatcmpl-CpaLMVkLd9W8G4FgQ4It6eXocXc0S","object":"chat.completion.chunk","created":1766410468,"model":"gpt-5-mini-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"length"}],"usage":null,"obfuscation":"rGio071kYz0Asim"}
+
+
+        data: {"id":"chatcmpl-CpaLMVkLd9W8G4FgQ4It6eXocXc0S","object":"chat.completion.chunk","created":1766410468,"model":"gpt-5-mini-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":13,"completion_tokens":50,"total_tokens":63,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":50,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"HH6YP"}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9b1fff310d14d5b7-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 22 Dec 2025 13:34:29 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '914'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '929'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999992'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_3c84f9876cbd4cb78f22b6a39391ac8a
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_max_tokens/openai_gpt_5_mini_completions/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/openai_gpt_5_mini_completions/stream.yaml
@@ -1,0 +1,110 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"List all U.S. states."}],"model":"gpt-5-mini","max_completion_tokens":50,"stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '166'
+      content-type:
+      - application/json
+      cookie:
+      - <filtered>
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-CpaLKsZmiiFPwrb0Ocw5FOVrMV89U","object":"chat.completion.chunk","created":1766410466,"model":"gpt-5-mini-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"finish_reason":null}],"usage":null,"obfuscation":"wvNs5"}
+
+
+        data: {"id":"chatcmpl-CpaLKsZmiiFPwrb0Ocw5FOVrMV89U","object":"chat.completion.chunk","created":1766410466,"model":"gpt-5-mini-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"length"}],"usage":null,"obfuscation":"8A5UdbKK7L2PYtM"}
+
+
+        data: {"id":"chatcmpl-CpaLKsZmiiFPwrb0Ocw5FOVrMV89U","object":"chat.completion.chunk","created":1766410466,"model":"gpt-5-mini-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":13,"completion_tokens":50,"total_tokens":63,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":50,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"9iEYO"}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9b1fff2768a4a72a-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 22 Dec 2025 13:34:27 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '856'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '871'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999992'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_32f2cc1b653e448486542c5f267cf80c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_max_tokens/openai_gpt_5_mini_completions/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/openai_gpt_5_mini_completions/sync.yaml
@@ -1,0 +1,107 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"List all U.S. states."}],"model":"gpt-5-mini","max_completion_tokens":50}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '112'
+      content-type:
+      - application/json
+      cookie:
+      - <filtered>
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RSy07DMBC85yusPTcohT6gRxASCI6IC0KRsbfJgmNb9gbxUP8d2X0kFXDxYWdn
+        NDPr70IIIA0rAaqVrDpvyisv72+a7mp5//FF6vL64mE2f/QX7eft690UJonhXl5R8Z51olznDTI5
+        u4VVQMmYVKfLxWI2rWaLswx0TqNJtMZzOS87slSeVqfzsjovq+WO3DpSGGElngohhPjOb7JpNX7A
+        SlST/aTDGGWDsDosCQHBmTQBGSNFlpZhMoDKWUabnY/HAdd9lMmZ7Y0ZAdJaxzIly4aed8jmYGFN
+        lmJbB5TR2SRr0DbcQsY3hRDPOVR/5BN8cJ3nmt0bZuHp2VYQhiYHcL4LDOxYmmG+2JOO1GqNLMnE
+        USmgpGpRD8yhQdlrciOgGKX7beYv7W1yss1vw3/oD4BS6Bl17QNqUseJh7WA6aP9t3YoOTuGiOGd
+        FNZMGNIpNK5lb7b3h/gZGbt6TbbB4APlT5CuXWyKHwAAAP//AwBwxjiuBgMAAA==
+    headers:
+      CF-RAY:
+      - 9b1fff129e7ba72a-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 22 Dec 2025 13:34:24 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '1406'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '1445'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999992'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_8ac08a2f4b6a4c67826f61c761ef802c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_5_mini_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_5_mini_completions_snapshots.py
@@ -1,0 +1,137 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    FinishReason,
+    Text,
+    UserMessage,
+)
+
+sync_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "openai",
+            "model_id": "openai/gpt-5-mini:completions",
+            "provider_model_name": "gpt-5-mini:completions",
+            "params": {"max_tokens": 50},
+            "finish_reason": FinishReason.MAX_TOKENS,
+            "usage": {
+                "input_tokens": 13,
+                "output_tokens": 50,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 50,
+                "raw": "CompletionUsage(completion_tokens=50, prompt_tokens=13, total_tokens=63, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=50, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))",
+                "total_tokens": 63,
+            },
+            "messages": [
+                UserMessage(content=[Text(text="List all U.S. states.")]),
+                AssistantMessage(
+                    content=[],
+                    provider_id="openai",
+                    model_id="openai/gpt-5-mini:completions",
+                    provider_model_name="gpt-5-mini:completions",
+                    raw_message={"content": "", "role": "assistant", "annotations": []},
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        }
+    }
+)
+async_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "openai",
+            "model_id": "openai/gpt-5-mini:completions",
+            "provider_model_name": "gpt-5-mini:completions",
+            "params": {"max_tokens": 50},
+            "finish_reason": FinishReason.MAX_TOKENS,
+            "usage": {
+                "input_tokens": 13,
+                "output_tokens": 50,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 50,
+                "raw": "CompletionUsage(completion_tokens=50, prompt_tokens=13, total_tokens=63, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=50, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))",
+                "total_tokens": 63,
+            },
+            "messages": [
+                UserMessage(content=[Text(text="List all U.S. states.")]),
+                AssistantMessage(
+                    content=[],
+                    provider_id="openai",
+                    model_id="openai/gpt-5-mini:completions",
+                    provider_model_name="gpt-5-mini:completions",
+                    raw_message={"content": "", "role": "assistant", "annotations": []},
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        }
+    }
+)
+stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "openai",
+            "model_id": "openai/gpt-5-mini:completions",
+            "provider_model_name": "gpt-5-mini:completions",
+            "finish_reason": FinishReason.MAX_TOKENS,
+            "messages": [
+                UserMessage(content=[Text(text="List all U.S. states.")]),
+                AssistantMessage(
+                    content=[],
+                    provider_id="openai",
+                    model_id="openai/gpt-5-mini:completions",
+                    provider_model_name="gpt-5-mini:completions",
+                    raw_message=None,
+                ),
+            ],
+            "format": None,
+            "tools": [],
+            "usage": {
+                "input_tokens": 13,
+                "output_tokens": 50,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 50,
+                "raw": "None",
+                "total_tokens": 63,
+            },
+            "n_chunks": 0,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "openai",
+            "model_id": "openai/gpt-5-mini:completions",
+            "provider_model_name": "gpt-5-mini:completions",
+            "finish_reason": FinishReason.MAX_TOKENS,
+            "messages": [
+                UserMessage(content=[Text(text="List all U.S. states.")]),
+                AssistantMessage(
+                    content=[],
+                    provider_id="openai",
+                    model_id="openai/gpt-5-mini:completions",
+                    provider_model_name="gpt-5-mini:completions",
+                    raw_message=None,
+                ),
+            ],
+            "format": None,
+            "tools": [],
+            "usage": {
+                "input_tokens": 13,
+                "output_tokens": 50,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 50,
+                "raw": "None",
+                "total_tokens": 63,
+            },
+            "n_chunks": 0,
+        }
+    }
+)

--- a/python/tests/e2e/output/test_max_tokens.py
+++ b/python/tests/e2e/output/test_max_tokens.py
@@ -9,8 +9,14 @@ from tests.utils import (
     snapshot_test,
 )
 
+MAX_TOKENS_MODEL_IDS: list[llm.ModelId] = [
+    *E2E_MODEL_IDS,
+    # Include reasoning model to test max_tokens → max_completion_tokens mapping
+    "openai/gpt-5-mini:completions",
+]
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+
+@pytest.mark.parametrize("model_id", MAX_TOKENS_MODEL_IDS)
 @pytest.mark.vcr
 def test_max_tokens_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test synchronous call with token limits."""
@@ -25,7 +31,7 @@ def test_max_tokens_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
         assert response.finish_reason == llm.FinishReason.MAX_TOKENS
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", MAX_TOKENS_MODEL_IDS)
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_max_tokens_async(model_id: llm.ModelId, snapshot: Snapshot) -> None:
@@ -41,7 +47,7 @@ async def test_max_tokens_async(model_id: llm.ModelId, snapshot: Snapshot) -> No
         assert response.finish_reason == llm.FinishReason.MAX_TOKENS
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", MAX_TOKENS_MODEL_IDS)
 @pytest.mark.vcr
 def test_max_tokens_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test streaming call with token limits."""
@@ -57,7 +63,7 @@ def test_max_tokens_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
         assert response.finish_reason == llm.FinishReason.MAX_TOKENS
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", MAX_TOKENS_MODEL_IDS)
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_max_tokens_async_stream(

--- a/python/tests/e2e/output/test_refusal.py
+++ b/python/tests/e2e/output/test_refusal.py
@@ -14,8 +14,11 @@ from tests.utils import (
     snapshot_test,
 )
 
-# These model scopes will have an API-level refusal (finish_reason == "refusal")
-SCOPES_WITH_FORMAL_REFUSAL = {"openai"}
+# Models that return API-level refusal (finish_reason == "refusal")
+MODELS_WITH_FORMAL_REFUSAL: list[llm.ModelId] = [
+    "openai/gpt-4o:completions",
+    "openai/gpt-4o:responses",
+]
 
 
 class FentanylHandbook(BaseModel):
@@ -34,7 +37,7 @@ def test_refusal_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     with snapshot_test(snapshot) as snap:
         response = fentanyl_request()
         snap.set_response(response)
-        if model_id.split("/")[0] in SCOPES_WITH_FORMAL_REFUSAL:
+        if model_id in MODELS_WITH_FORMAL_REFUSAL:
             assert response.finish_reason == llm.FinishReason.REFUSAL
         else:
             assert response.finish_reason is None
@@ -53,7 +56,7 @@ async def test_refusal_async(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     with snapshot_test(snapshot) as snap:
         response = await fentanyl_request()
         snap.set_response(response)
-        if model_id.split("/")[0] in SCOPES_WITH_FORMAL_REFUSAL:
+        if model_id in MODELS_WITH_FORMAL_REFUSAL:
             assert response.finish_reason == llm.FinishReason.REFUSAL
         else:
             assert response.finish_reason is None
@@ -72,7 +75,7 @@ def test_refusal_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
         response = fentanyl_request.stream()
         response.finish()
         snap.set_response(response)
-        if model_id.split("/")[0] in SCOPES_WITH_FORMAL_REFUSAL:
+        if model_id in MODELS_WITH_FORMAL_REFUSAL:
             assert response.finish_reason == llm.FinishReason.REFUSAL
         else:
             assert response.finish_reason is None
@@ -92,7 +95,7 @@ async def test_refusal_async_stream(model_id: llm.ModelId, snapshot: Snapshot) -
         response = await fentanyl_request.stream()
         await response.finish()
         snap.set_response(response)
-        if model_id.split("/")[0] in SCOPES_WITH_FORMAL_REFUSAL:
+        if model_id in MODELS_WITH_FORMAL_REFUSAL:
             assert response.finish_reason == llm.FinishReason.REFUSAL
         else:
             assert response.finish_reason is None


### PR DESCRIPTION
### TL;DR

Add support for OpenAI reasoning models like GPT-5 by using `max_completion_tokens` instead of `max_tokens` and disabling temperature/top_p parameters.

### What changed?

- Added a `NON_REASONING_MODELS` constant to identify models that don't use reasoning
- Modified the OpenAI request encoding to use `max_completion_tokens` instead of `max_tokens` for reasoning models
- Disabled temperature and top_p parameters for reasoning models
- Added test cases for GPT-5 models with appropriate cassettes and snapshots
- Updated test configurations to handle reasoning models differently

### How to test?

1. Run the max_tokens tests with GPT-5 models:
   ```
   pytest python/tests/e2e/output/test_max_tokens.py -v
   ```
2. Verify that reasoning models use `max_completion_tokens` instead of `max_tokens`
3. Check that temperature and top_p parameters are properly disabled for reasoning models

### Why make this change?

OpenAI's reasoning models (like GPT-5) use a different parameter structure than traditional models. They require `max_completion_tokens` instead of `max_tokens` to limit output length, and they don't support temperature or top_p parameters. This change ensures compatibility with these newer models while maintaining backward compatibility with existing models.