### PR TITLE
fix(cloud): color in mobile-menu hamburger

### DIFF
--- a/cloud/app/components/blocks/navigation/styles.ts
+++ b/cloud/app/components/blocks/navigation/styles.ts
@@ -176,7 +176,7 @@ export const MOBILE_NAV_STYLES = {
     // Positioning and layout - z-index higher than header (z-[100])
     "absolute top-full right-4 z-[110] mt-2 max-w-xs lg:hidden",
     // Appearance
-    "bg-background text-foreground rounded-lg p-6 shadow-lg",
+    "bg-background text-accent-foreground rounded-lg p-6 shadow-lg",
     // Reset text shadow from parent header
     "[text-shadow:none]",
   ),


### PR DESCRIPTION
Makes the links have a dark and readable color.

![image.png](https://app.graphite.com/user-attachments/assets/256c0d07-91de-4a6d-96ba-65ef8e6aae83.png)

