### PR TITLE
feat(providers): add Bedrock Anthropic subprovider and routed variant

### DIFF
--- a/python/tests/llm/providers/bedrock/test_bedrock_anthropic_provider.py
+++ b/python/tests/llm/providers/bedrock/test_bedrock_anthropic_provider.py
@@ -184,8 +184,6 @@ def test_bedrock_anthropic_decode_response_with_routed_provider_id() -> None:
         provider_id="bedrock",
     )
     assert assistant_message.provider_id == "bedrock"
-
-
 def test_bedrock_anthropic_provider_initialization_with_api_key() -> None:
     """Test BedrockAnthropicProvider initialization with API key."""
     provider = BedrockAnthropicProvider(


### PR DESCRIPTION
### TL;DR

Added support for Anthropic models on AWS Bedrock with proper model name handling and response decoding.

### What changed?

- Created a new `BedrockAnthropicProvider` class for interacting with Anthropic models via AWS Bedrock
- Added a `BedrockAnthropicRoutedProvider` for routing to Bedrock
- Implemented utility functions to handle model name formatting, request encoding, and response decoding
- Added support for AWS credentials configuration
- Implemented proper handling of inference profile IDs in model names
- Added comprehensive test coverage for all new functionality

### How to test?

1. Run the test suite with `pytest python/tests/llm/providers/bedrock/test_bedrock_anthropic_provider.py`
2. Verify that all tests pass, including initialization, model name handling, request encoding, and response decoding
3. Test with both standard model names and inference profile IDs

### Why make this change?

This change enables users to access Anthropic's Claude models through AWS Bedrock, providing an alternative to direct Anthropic API access. It properly handles the unique model naming conventions in Bedrock and ensures that responses include the correct provider information. This is particularly important for users who prefer to use AWS infrastructure or have existing AWS deployments.