### PR TITLE
feat(providers): add Bedrock OpenAI-compatible subprovider and routed variant

### DIFF
--- a/python/.env.example
+++ b/python/.env.example
@@ -23,4 +23,5 @@ AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key_here
 AWS_REGION=us-east-1
 
 # Bedrock API Key (optional, alternative to IAM credentials)
+# Used for both Anthropic and OpenAI-compatible models on Bedrock
 # AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key_here

--- a/python/examples/bedrock/openai_compatible.py
+++ b/python/examples/bedrock/openai_compatible.py
@@ -11,7 +11,7 @@
 #      - AWS_SECRET_ACCESS_KEY
 #      - AWS_REGION (optional, defaults to us-east-1)
 #    Option B (API key):
-#      - AWS_BEDROCK_OPENAI_API_KEY
+#      - AWS_BEARER_TOKEN_BEDROCK
 #
 # Note: OpenAI-compatible API availability varies by region. Check AWS documentation.
 

--- a/python/mirascope/llm/providers/__init__.py
+++ b/python/mirascope/llm/providers/__init__.py
@@ -31,7 +31,12 @@ from .azure import (
     AzureProvider,
 )
 from .base import BaseProvider, Provider
-from .bedrock import BedrockAnthropicProvider, BedrockModelId, BedrockProvider
+from .bedrock import (
+    BedrockAnthropicProvider,
+    BedrockModelId,
+    BedrockOpenAIProvider,
+    BedrockProvider,
+)
 from .google import GoogleModelId, GoogleProvider
 from .mirascope import MirascopeProvider
 from .mlx import MLXModelId, MLXProvider
@@ -62,6 +67,7 @@ __all__ = [
     "BaseProvider",
     "BedrockAnthropicProvider",
     "BedrockModelId",
+    "BedrockOpenAIProvider",
     "BedrockProvider",
     "GoogleModelId",
     "GoogleProvider",

--- a/python/mirascope/llm/providers/bedrock/__init__.py
+++ b/python/mirascope/llm/providers/bedrock/__init__.py
@@ -3,14 +3,17 @@
 from ...._stubs import stub_module_if_missing
 
 stub_module_if_missing("mirascope.llm.providers.bedrock.anthropic", "anthropic")
+stub_module_if_missing("mirascope.llm.providers.bedrock.openai", "openai")
 
 # ruff: noqa: E402
 from .anthropic import BedrockAnthropicProvider
 from .model_id import BedrockModelId
+from .openai import BedrockOpenAIProvider
 from .provider import BedrockProvider
 
 __all__ = [
     "BedrockAnthropicProvider",
     "BedrockModelId",
+    "BedrockOpenAIProvider",
     "BedrockProvider",
 ]

--- a/python/mirascope/llm/providers/bedrock/_utils.py
+++ b/python/mirascope/llm/providers/bedrock/_utils.py
@@ -79,3 +79,8 @@ def default_anthropic_scopes() -> list[str]:
     for region_prefix in ("us.", "eu.", "apac.", "global."):
         scopes.add(f"bedrock/{region_prefix}anthropic.")
     return sorted(scopes)
+
+
+# Default OpenAI-compatible model ID prefixes for Bedrock routing.
+# e.g. bedrock/openai.gpt-oss-20b-1:0
+BEDROCK_OPENAI_MODEL_PREFIXES = ("bedrock/openai.",)

--- a/python/mirascope/llm/providers/bedrock/openai/__init__.py
+++ b/python/mirascope/llm/providers/bedrock/openai/__init__.py
@@ -1,0 +1,5 @@
+"""Bedrock OpenAI-compatible provider implementation."""
+
+from .provider import BedrockOpenAIProvider, BedrockOpenAIRoutedProvider
+
+__all__ = ["BedrockOpenAIProvider", "BedrockOpenAIRoutedProvider"]

--- a/python/mirascope/llm/providers/bedrock/openai/provider.py
+++ b/python/mirascope/llm/providers/bedrock/openai/provider.py
@@ -1,0 +1,296 @@
+"""Bedrock OpenAI-compatible provider implementation."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from typing import ClassVar, Protocol, cast
+
+import httpx
+from openai import AsyncOpenAI, OpenAI
+
+from ...openai._utils.errors import OPENAI_ERROR_MAP
+from ...openai.completions.base_provider import BaseOpenAICompletionsProvider
+from .. import _utils as bedrock_utils
+
+
+class _FrozenCredentials(Protocol):
+    access_key: str
+    secret_key: str
+    token: str | None
+
+
+class _BotocoreCredentials(Protocol):
+    def get_frozen_credentials(self) -> _FrozenCredentials: ...
+
+
+class _BotocoreSession(Protocol):
+    def get_credentials(self) -> _BotocoreCredentials | None: ...
+
+
+def _build_bedrock_openai_base_url(region: str) -> str:
+    return f"https://bedrock-runtime.{region}.amazonaws.com/openai/v1"
+
+
+class BedrockSigV4Auth(httpx.Auth):
+    """Custom httpx Auth class for AWS SigV4 authentication.
+
+    This class signs each outgoing request with AWS Signature Version 4,
+    which is required for Bedrock's OpenAI-compatible endpoints when not
+    using an API key.
+    """
+
+    requires_request_body = True
+
+    def __init__(
+        self,
+        access_key: str,
+        secret_key: str,
+        region: str,
+        session_token: str | None = None,
+    ) -> None:
+        self._access_key = access_key
+        self._secret_key = secret_key
+        self._region = region
+        self._session_token = session_token
+
+    _HEADERS_TO_EXCLUDE = frozenset(
+        {
+            "authorization",
+            "connection",
+            "accept-encoding",
+            "user-agent",
+            "x-stainless-arch",
+            "x-stainless-async",
+            "x-stainless-lang",
+            "x-stainless-os",
+            "x-stainless-package-version",
+            "x-stainless-read-timeout",
+            "x-stainless-retry-count",
+            "x-stainless-runtime",
+            "x-stainless-runtime-version",
+        }
+    )
+
+    def auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """Sign the request with AWS SigV4 and yield it."""
+        from botocore.auth import SigV4Auth
+        from botocore.awsrequest import AWSRequest
+        from botocore.credentials import Credentials
+
+        credentials = Credentials(
+            self._access_key, self._secret_key, self._session_token
+        )
+
+        body_content = request.content.decode("utf-8") if request.content else None
+
+        headers_for_signing = {
+            key: value
+            for key, value in request.headers.items()
+            if key.lower() not in self._HEADERS_TO_EXCLUDE and value
+        }
+
+        aws_request = AWSRequest(
+            method=request.method,
+            url=str(request.url),
+            data=body_content,
+            headers=headers_for_signing,
+        )
+
+        class _SigV4Auth(Protocol):
+            def add_auth(self, request: AWSRequest) -> None: ...
+
+        auth = cast(_SigV4Auth, SigV4Auth(credentials, "bedrock", self._region))
+        auth.add_auth(aws_request)
+
+        if "authorization" in request.headers:
+            del request.headers["authorization"]
+
+        signed_headers = dict(aws_request.headers)
+        for header_name, header_value in signed_headers.items():
+            request.headers[header_name] = header_value
+
+        yield request
+
+
+def _resolve_aws_credentials(
+    session: _BotocoreSession | None,
+    aws_access_key_id: str | None,
+    aws_secret_access_key: str | None,
+    aws_session_token: str | None,
+) -> tuple[str, str, str | None]:
+    """Resolve AWS credentials from explicit args or botocore session.
+
+    Raises:
+        ValueError: If credentials cannot be resolved.
+    """
+    resolved_access_key: str | None = aws_access_key_id
+    resolved_secret_key: str | None = aws_secret_access_key
+    resolved_session_token: str | None = aws_session_token
+
+    if not resolved_access_key or not resolved_secret_key:
+        credentials = session.get_credentials() if session else None
+        if credentials is not None:
+            frozen = credentials.get_frozen_credentials()
+            resolved_access_key = frozen.access_key
+            resolved_secret_key = frozen.secret_key
+            resolved_session_token = frozen.token
+
+    if not resolved_access_key or not resolved_secret_key:
+        raise ValueError(
+            "Bedrock OpenAI-compatible API requires either an API key "
+            "or AWS credentials. Set the AWS_ACCESS_KEY_ID and "
+            "AWS_SECRET_ACCESS_KEY environment variables, configure a "
+            "shared credentials/profile, or pass aws_access_key_id and "
+            "aws_secret_access_key parameters."
+        )
+
+    return resolved_access_key, resolved_secret_key, resolved_session_token
+
+
+def _create_sigv4_clients(
+    base_url: str,
+    access_key: str,
+    secret_key: str,
+    region: str,
+    session_token: str | None,
+) -> tuple[OpenAI, AsyncOpenAI]:
+    """Create OpenAI clients with SigV4 authentication."""
+    sigv4_auth = BedrockSigV4Auth(
+        access_key=access_key,
+        secret_key=secret_key,
+        region=region,
+        session_token=session_token,
+    )
+
+    sync_http_client = httpx.Client(auth=sigv4_auth)
+    async_http_client = httpx.AsyncClient(auth=sigv4_auth)
+
+    client = OpenAI(
+        api_key="bedrock-sigv4",
+        base_url=base_url,
+        http_client=sync_http_client,
+    )
+    async_client = AsyncOpenAI(
+        api_key="bedrock-sigv4",
+        base_url=base_url,
+        http_client=async_http_client,
+    )
+
+    return client, async_client
+
+
+class BedrockOpenAIProvider(BaseOpenAICompletionsProvider):
+    """Provider for Amazon Bedrock's OpenAI-compatible API.
+
+    This provider uses the OpenAI SDK to communicate with Bedrock's OpenAI-compatible
+    endpoints. It supports two authentication methods:
+
+    1. API Key (Official): Use a Bedrock-issued API key via the api_key parameter
+       or AWS_BEARER_TOKEN_BEDROCK environment variable.
+    2. AWS SigV4 (Unofficial): Use IAM credentials for request signing. This is
+       widely adopted but not officially documented for the OpenAI SDK.
+
+    Note:
+        OpenAI-compatible endpoints are only available for a subset of Bedrock models
+        and regions. Check the AWS documentation for supported models and regions.
+    """
+
+    id: ClassVar[str] = "bedrock:openai"
+    default_scope: ClassVar[str | list[str]] = "bedrock/openai."
+    api_key_env_var: ClassVar[str] = "AWS_BEARER_TOKEN_BEDROCK"
+    api_key_required: ClassVar[bool] = False
+    provider_name: ClassVar[str | None] = "Amazon Bedrock (OpenAI-compatible)"
+    error_map = OPENAI_ERROR_MAP
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        aws_region: str | None = None,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+        aws_session_token: str | None = None,
+        aws_profile: str | None = None,
+    ) -> None:
+        """Initialize the Bedrock OpenAI-compatible provider.
+
+        Args:
+            api_key: Optional API key for authentication. If provided, this takes
+                priority over AWS credentials.
+            base_url: Optional base URL override. If not provided, the URL will be
+                constructed from the AWS region.
+            aws_region: AWS region for the Bedrock endpoint. Defaults to the
+                AWS_REGION or AWS_DEFAULT_REGION environment variable.
+            aws_access_key_id: AWS access key ID. Defaults to the
+                AWS_ACCESS_KEY_ID environment variable.
+            aws_secret_access_key: AWS secret access key. Defaults to the
+                AWS_SECRET_ACCESS_KEY environment variable.
+            aws_session_token: AWS session token for temporary credentials.
+                Defaults to the AWS_SESSION_TOKEN environment variable.
+            aws_profile: AWS profile name for credentials. Defaults to environment.
+
+        Raises:
+            ValueError: If neither API key nor AWS credentials are available.
+        """
+        resolved_api_key = api_key or os.environ.get(self.api_key_env_var)
+        resolved_region = bedrock_utils.resolve_region(
+            aws_region, aws_profile=aws_profile
+        )
+        session: _BotocoreSession | None = None
+        if not resolved_api_key:
+            from botocore.session import Session as BotocoreSession
+
+            session = cast(
+                _BotocoreSession,
+                BotocoreSession(profile=aws_profile)
+                if aws_profile
+                else BotocoreSession(),
+            )
+
+        resolved_base_url = base_url or _build_bedrock_openai_base_url(resolved_region)
+
+        if resolved_api_key:
+            self.client = OpenAI(
+                api_key=resolved_api_key,
+                base_url=resolved_base_url,
+            )
+            self.async_client = AsyncOpenAI(
+                api_key=resolved_api_key,
+                base_url=resolved_base_url,
+            )
+        else:
+            access_key, secret_key, session_token = _resolve_aws_credentials(
+                session,
+                aws_access_key_id,
+                aws_secret_access_key,
+                aws_session_token,
+            )
+            self.client, self.async_client = _create_sigv4_clients(
+                resolved_base_url,
+                access_key,
+                secret_key,
+                resolved_region,
+                session_token,
+            )
+
+    def get_error_status(self, e: Exception) -> int | None:
+        """Extract HTTP status code from OpenAI exception."""
+        return getattr(e, "status_code", None)
+
+    def _model_name(self, model_id: str) -> str:
+        if model_id.startswith("bedrock/"):
+            model_name = model_id.split("/", 1)[1]
+        else:  # pragma: no cover - defensive fallback for direct model names
+            model_name = model_id
+
+        return model_name
+
+
+class BedrockOpenAIRoutedProvider(BedrockOpenAIProvider):
+    """Bedrock OpenAI-compatible provider that reports provider_id as "bedrock"."""
+
+    id: ClassVar[str] = "bedrock"

--- a/python/tests/e2e/input/cassettes/test_bedrock_openai_async_call_and_stream/bedrock_openai_gpt_oss_20b_1_0.yaml
+++ b/python/tests/e2e/input/cassettes/test_bedrock_openai_async_call_and_stream/bedrock_openai_gpt_oss_20b_1_0.yaml
@@ -1,0 +1,279 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '94'
+      Content-Type:
+      - application/json
+      Host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "{\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"logprobs\":null,\"message\":{\"content\":\"<reasoning>The
+        user asks: \\\"What is 4200 + 42?\\\" We simply compute: 4200 + 42 = 4242.
+        Provide answer. Probably trivial. We'll respond.</reasoning>4200\u202F+\u202F42\u202F=\u202F**4242**\",\"refusal\":null,\"role\":\"assistant\"}}],\"created\":1769777294,\"id\":\"chatcmpl-87c8cdcf-2a16-46e5-95e8-030749383ebb\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":61,\"prompt_tokens\":74,\"total_tokens\":135}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '527'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Jan 2026 12:48:20 GMT
+      X-Request-ID:
+      - 675cf68e-b8d5-4ef1-a88c-88126f9aeee0
+      x-amzn-RequestId:
+      - 675cf68e-b8d5-4ef1-a88c-88126f9aeee0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '94'
+      Content-Type:
+      - application/json
+      Host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: '{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"<reasoning>The
+        user asks: \"What is 4200 + 42?\" Simple arithmetic: 4200 + 42 = 4242. So
+        answer that.</reasoning>4200 + 42 = **4242**.","refusal":null,"role":"assistant"}}],"created":1769777301,"id":"chatcmpl-3cc75e39-bece-49d5-a47b-962e8e9ef0a9","model":"openai.gpt-oss-20b-1:0","object":"chat.completion","service_tier":"default","usage":{"completion_tokens":53,"prompt_tokens":74,"total_tokens":127}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '487'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Jan 2026 12:48:21 GMT
+      X-Request-ID:
+      - a2e68af3-be91-4e11-8ca5-5a93e6b46f29
+      x-amzn-RequestId:
+      - a2e68af3-be91-4e11-8ca5-5a93e6b46f29
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0","stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null,"index":0,"obfuscation":"XvEcSplga8mFtnuLKBOyLEaUYBNWNVO2gSBq2YfpkOKNsVIAwFMs83"}],"created":1769777302,"id":"chatcmpl-e3555cd5-ec95-4750-8e22-521c53da589e","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[{"delta":{"content":"<reasoning>User: \"What is 4200 + 42?\"
+        They want sum. 4200+42=4242. Provide answer.</reasoning>"},"finish_reason":null,"index":0,"obfuscation":"wp13a141IC3TJl9AHCDJiuXyCJUk8gwDadEGLCR8sWate9tSwldArxAwEtmuNKlAryXKVg5LduxS4OTD3iZh8TXCM4"}],"created":1769777302,"id":"chatcmpl-e3555cd5-ec95-4750-8e22-521c53da589e","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[{"delta":{"content":"4200 + 42 = **4242**."},"finish_reason":null,"index":0,"obfuscation":"v9U8ycCYRc8z2rWxetScsdlJroZdwOiVI9eJTB2A8yqjWI6w3msAvkYfipTOr3YN4J60"}],"created":1769777302,"id":"chatcmpl-e3555cd5-ec95-4750-8e22-521c53da589e","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[{"delta":{},"finish_reason":"stop","index":0,"obfuscation":"mE41VVi8et7HnlZvILxVa3AUo6UokfHlnG7fYpDLxxgrTYxvY5BrVEaZ3sIRtEhb9m5gJdDAg7TNdl"}],"created":1769777302,"id":"chatcmpl-e3555cd5-ec95-4750-8e22-521c53da589e","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[],"created":1769777302,"id":"chatcmpl-e3555cd5-ec95-4750-8e22-521c53da589e","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default","usage":{"completion_tokens":49,"prompt_tokens":74,"total_tokens":123}}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 30 Jan 2026 12:48:22 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - a9e93e60-b09f-4756-8b1c-25f988bdadf7
+      x-amzn-RequestId:
+      - a9e93e60-b09f-4756-8b1c-25f988bdadf7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0","stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null,"index":0,"obfuscation":"0msTHTgWOeKHcOHBHGXdKFr1F7zPcERHebNR9qtoReZwKRyh8u9aVOtwe6Uu3mAACeXItPnOb7U"}],"created":1769777303,"id":"chatcmpl-58960f12-2485-4297-9191-e7acb3699d99","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[{"delta":{"content":"<reasoning>The user asks a simple arithmetic:
+        4200 + 42 = 4242. They might want an answer. Just answer: 4242</reasoning>"},"finish_reason":null,"index":0,"obfuscation":"3E0BtGyFkrFZfU5ZFxOd5KtsAo8MvE3R7annc8JXTDzGhEHbou95rEy4o4LlrDmMpSIPKTOk0DdvE7HSUrEe7CFK2WFdtI6XoYRY"}],"created":1769777303,"id":"chatcmpl-58960f12-2485-4297-9191-e7acb3699d99","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[{"delta":{"content":"<reasoning>.</reasoning>"},"finish_reason":null,"index":0,"obfuscation":"viCmFDtBv7Rmf2HNSbvBtwyk7wzBez5kwCyi53sHj45PNZYW2zCRO7S0mdSa44Gm"}],"created":1769777303,"id":"chatcmpl-58960f12-2485-4297-9191-e7acb3699d99","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[{"delta":{"content":"\\(4200 + 42 = 4242\\)."},"finish_reason":null,"index":0,"obfuscation":"X08nn45W64C6043Md6f5mU4SOIyUsU8kaa4xQZeC9UiYHQthGrSN1oeX7FoOGp3j3RksC9Wq8pHISpokmVBWYUp2CB5lpsdeWb21txla"}],"created":1769777303,"id":"chatcmpl-58960f12-2485-4297-9191-e7acb3699d99","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[{"delta":{},"finish_reason":"stop","index":0,"obfuscation":"v99kmdCwMa9hgTbIfR9dbnedgXI6pmH3NpmiWhppBD84Ewn41NZnx8iNUgtaVc3kSzaHbH6qO8jSlB4K69WgLAloa1z4R19G7mXtnJwwKt6ok7GknP6itxBji"}],"created":1769777303,"id":"chatcmpl-58960f12-2485-4297-9191-e7acb3699d99","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[],"created":1769777303,"id":"chatcmpl-58960f12-2485-4297-9191-e7acb3699d99","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default","usage":{"completion_tokens":53,"prompt_tokens":74,"total_tokens":127}}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 30 Jan 2026 12:48:23 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - 23cf3504-9ccf-4a47-89a0-fc072964ff9a
+      x-amzn-RequestId:
+      - 23cf3504-9ccf-4a47-89a0-fc072964ff9a
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_bedrock_openai_provider/bedrock_openai_gpt_oss_20b_1_0.yaml
+++ b/python/tests/e2e/input/cassettes/test_bedrock_openai_provider/bedrock_openai_gpt_oss_20b_1_0.yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '94'
+      Content-Type:
+      - application/json
+      Host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      User-Agent:
+      - OpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: '{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"<reasoning>The
+        user asks: \"What is 4200 + 42?\" They likely expect the sum 4242. That''s
+        straightforward. No special context. Provide answer. It''s 4242.</reasoning>4200
+        + 42 equals **4242**.","refusal":null,"role":"assistant"}}],"created":1769777277,"id":"chatcmpl-aeec1411-e519-4175-9ec9-517d3acef15b","model":"openai.gpt-oss-20b-1:0","object":"chat.completion","service_tier":"default","usage":{"completion_tokens":59,"prompt_tokens":74,"total_tokens":133}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '543'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Jan 2026 12:48:04 GMT
+      X-Request-ID:
+      - 2dcd9885-bce5-44aa-925b-b2d2ddb6d8e6
+      x-amzn-RequestId:
+      - 2dcd9885-bce5-44aa-925b-b2d2ddb6d8e6
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_bedrock_openai_sigv4_call/bedrock_openai_gpt_oss_20b_1_0.yaml
+++ b/python/tests/e2e/input/cassettes/test_bedrock_openai_sigv4_call/bedrock_openai_gpt_oss_20b_1_0.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Say hello in one word."}],"model":"openai.gpt-oss-20b-1:0"}'
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      User-Agent:
+      - OpenAI/Python 2.16.0
+      X-Amz-Date:
+      - 20260130T142607Z
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      accept:
+      - application/json
+      content-length:
+      - '98'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "{\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"logprobs\":null,\"message\":{\"content\":\"<reasoning>The
+        user: \\\"Say hello in one word.\\\" They want an answer: \\\"hello\\\" or
+        \\\"hola\\\" etc. The task is to produce a greeting consisting of a single
+        word. So maybe respond with \\\"hello\\\". Possibly includes mention that
+        it's greeting. They want a single word\u2014likely \\\"hello\\\". So respond
+        \\\"hello\\\". That satisfies.</reasoning>hello\",\"refusal\":null,\"role\":\"assistant\"}}],\"created\":1769783168,\"id\":\"chatcmpl-e1873a97-d89e-4694-9ae4-1bae3911e4af\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":80,\"prompt_tokens\":71,\"total_tokens\":151}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '689'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Jan 2026 14:26:08 GMT
+      X-Request-ID:
+      - 03b4afd9-cb04-44c8-b301-3a0577bfd7b0
+      x-amzn-RequestId:
+      - 03b4afd9-cb04-44c8-b301-3a0577bfd7b0
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_bedrock_openai_sync_call_and_stream/bedrock_openai_gpt_oss_20b_1_0.yaml
+++ b/python/tests/e2e/input/cassettes/test_bedrock_openai_sync_call_and_stream/bedrock_openai_gpt_oss_20b_1_0.yaml
@@ -1,0 +1,252 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '94'
+      Content-Type:
+      - application/json
+      Host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      User-Agent:
+      - OpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: '{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"<reasoning>The
+        user asks: \"What is 4200 + 42?\" That''s a simple addition: 4200 + 42 = 4242.
+        So answer 4242. That''s it.</reasoning>4220 + 22 is 4220 + 22 = 4242.\n\nTherefore,
+        4200 + 42 = **4242**.","refusal":null,"role":"assistant"}}],"created":1769777285,"id":"chatcmpl-497b74de-0fe5-412b-a803-8b60f04c3037","model":"openai.gpt-oss-20b-1:0","object":"chat.completion","service_tier":"default","usage":{"completion_tokens":80,"prompt_tokens":74,"total_tokens":154}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '550'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Jan 2026 12:48:08 GMT
+      X-Request-ID:
+      - 991c49d7-6122-45f0-8940-e23508b1c25a
+      x-amzn-RequestId:
+      - 991c49d7-6122-45f0-8940-e23508b1c25a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '94'
+      Content-Type:
+      - application/json
+      Host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      User-Agent:
+      - OpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: '{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"<reasoning>The
+        user is asking a simple arithmetic addition problem: 4200 + 42. The answer
+        is 4242. I should respond succinctly: 4242.</reasoning>\\(4200 + 42 = 4242\\)","refusal":null,"role":"assistant"}}],"created":1769777289,"id":"chatcmpl-bb7a8c79-62d1-42f5-8bb8-810536312706","model":"openai.gpt-oss-20b-1:0","object":"chat.completion","service_tier":"default","usage":{"completion_tokens":56,"prompt_tokens":74,"total_tokens":130}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '520'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Jan 2026 12:48:09 GMT
+      X-Request-ID:
+      - 7f9c811d-2891-4f69-b157-3fa4aee80ab3
+      x-amzn-RequestId:
+      - 7f9c811d-2891-4f69-b157-3fa4aee80ab3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0","stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      User-Agent:
+      - OpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"role\":\"assistant\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"Z30Orx1CqiVKx2OrgvTIscn0qRdkXm7yBw4OAJ4WR3WSNqYSMwXWjGScZlu9m7MhOg08bNvYmMhCltFgqvFLBCg8EogZlQPd1Pk1b4rOIKU92DGS2Lv2b9cRJx\"}],\"created\":1769777290,\"id\":\"chatcmpl-6b7ea2f5-5138-46db-bfe8-0577a85b25ba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"<reasoning>User asks simple math:
+        4200 + 42? That's 4242. Provide answer. I might mention it's 4242.</reasoning>\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"2HPCpg92DdglUZbQhlPDAd9KYrfqLJDoZx84TsbvyQZ85QvdvNTofIpaHgrwQ1jYoSWnJ9CtUV5qCwz68VplDvdzK9Um2fD2e0r1640ZVL1Oa5eEefQw\"}],\"created\":1769777290,\"id\":\"chatcmpl-6b7ea2f5-5138-46db-bfe8-0577a85b25ba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"4200\u202F+\u202F42\u202F=\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"DnmSmtb6kaIw0N1b13TIgxu7zcZ4AiuDPCaHUdLpaj1J4I9XFwrB73eJTeE\"}],\"created\":1769777290,\"id\":\"chatcmpl-6b7ea2f5-5138-46db-bfe8-0577a85b25ba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"\u202F**4242**.\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"eaU3txNvhy97J318h9uNeY8OSXgR3IOoqxnddYgO8GTCX06mTkRNzI8W6bzDMmq6w1AW5n7mUIxC0Z4gV2xlzyDp6Ts6fJwSfTuiCnk5l22rMmglLj9CKOdHdxpCqIf\"}],\"created\":1769777290,\"id\":\"chatcmpl-6b7ea2f5-5138-46db-bfe8-0577a85b25ba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0,\"obfuscation\":\"6YjV01dIGyRL3jU5Bb6N5kScIh287TSgPxlZgScCeLDSjY\"}],\"created\":1769777290,\"id\":\"chatcmpl-6b7ea2f5-5138-46db-bfe8-0577a85b25ba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[],\"created\":1769777290,\"id\":\"chatcmpl-6b7ea2f5-5138-46db-bfe8-0577a85b25ba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":52,\"prompt_tokens\":74,\"prompt_tokens_details\":{\"audio_tokens\":0,\"cached_tokens\":48},\"total_tokens\":126}}\n\ndata:
+        [DONE]\n\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 30 Jan 2026 12:48:10 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - 1577a217-9b58-465b-8b81-ea5bd17feec1
+      x-amzn-RequestId:
+      - 1577a217-9b58-465b-8b81-ea5bd17feec1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0","stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - <filtered>
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      User-Agent:
+      - OpenAI/Python 2.16.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.16.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"role\":\"assistant\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"iDM4t3D36zWvaMeTrJQYSKkLD7RE5PmajgUMa5Quq2EbLjSgA9flgatCUktq1FPZDlizUcocsiYM9gtwRGlo\"}],\"created\":1769777293,\"id\":\"chatcmpl-f1208a8c-0adc-4202-b5f3-135bbffeaa23\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"<reasoning>The user asks: \\\"What
+        is 4200 + 42?\\\" Simple addition: 4200 + 42 = 4242. So answer is 4242.</reasoning>\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"VoxoP0nbtjvYiBOWGclcfq4UNNDbqb6qr6DW\"}],\"created\":1769777293,\"id\":\"chatcmpl-f1208a8c-0adc-4202-b5f3-135bbffeaa23\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"The sum is\u202F**4242**.\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"ZnPwWV6wyyVYuDyKa4IUXb6Q7HGg7bRq0ETBHgMGeqH7c7OaUh9CvUAJtnMBYZVHHVyGvZN15uXBKncVFKmejxWdsc3ix2qn60Pwq43Q\"}],\"created\":1769777293,\"id\":\"chatcmpl-f1208a8c-0adc-4202-b5f3-135bbffeaa23\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0,\"obfuscation\":\"tT9hJRhDhmURJgBLobfKJqS1iysLlLIWijC0\"}],\"created\":1769777293,\"id\":\"chatcmpl-f1208a8c-0adc-4202-b5f3-135bbffeaa23\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[],\"created\":1769777293,\"id\":\"chatcmpl-f1208a8c-0adc-4202-b5f3-135bbffeaa23\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":54,\"prompt_tokens\":74,\"total_tokens\":128}}\n\ndata:
+        [DONE]\n\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 30 Jan 2026 12:48:13 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - 4423df38-a252-4c4b-8b84-3bbacc92e62d
+      x-amzn-RequestId:
+      - 4423df38-a252-4c4b-8b84-3bbacc92e62d
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/snapshots/test_azure_anthropic_provider/azure_azureml___registries_azureml_anthropic_models_claude_haiku_4_5_versions_20251001_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_azure_anthropic_provider/azure_azureml___registries_azureml_anthropic_models_claude_haiku_4_5_versions_20251001_snapshots.py
@@ -1,0 +1,3 @@
+from inline_snapshot import snapshot
+
+test_snapshot = snapshot()

--- a/python/tests/e2e/input/snapshots/test_bedrock_openai_async_call_and_stream/bedrock_openai_gpt_oss_20b_1_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_bedrock_openai_async_call_and_stream/bedrock_openai_gpt_oss_20b_1_0_snapshots.py
@@ -1,0 +1,146 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "async_call": {
+            "provider_id": "bedrock",
+            "model_id": "bedrock/openai.gpt-oss-20b-1:0",
+            "provider_model_name": "openai.gpt-oss-20b-1:0",
+            "params": {},
+            "finish_reason": None,
+            "usage": {
+                "input_tokens": 74,
+                "output_tokens": 61,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "raw": "CompletionUsage(completion_tokens=61, prompt_tokens=74, total_tokens=135, completion_tokens_details=None, prompt_tokens_details=None)",
+                "total_tokens": 135,
+            },
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='<reasoning>The user asks: "What is 4200 + 42?" We simply compute: 4200 + 42 = 4242. Provide answer. Probably trivial. We\'ll respond.</reasoning>4200\u202f+\u202f42\u202f=\u202f**4242**'
+                        )
+                    ],
+                    provider_id="bedrock",
+                    model_id="bedrock/openai.gpt-oss-20b-1:0",
+                    provider_model_name="openai.gpt-oss-20b-1:0",
+                    raw_message={
+                        "content": '<reasoning>The user asks: "What is 4200 + 42?" We simply compute: 4200 + 42 = 4242. Provide answer. Probably trivial. We\'ll respond.</reasoning>4200\u202f+\u202f42\u202f=\u202f**4242**',
+                        "role": "assistant",
+                    },
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        },
+        "async_context_call": {
+            "provider_id": "bedrock",
+            "model_id": "bedrock/openai.gpt-oss-20b-1:0",
+            "provider_model_name": "openai.gpt-oss-20b-1:0",
+            "params": {},
+            "finish_reason": None,
+            "usage": {
+                "input_tokens": 74,
+                "output_tokens": 53,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "raw": "CompletionUsage(completion_tokens=53, prompt_tokens=74, total_tokens=127, completion_tokens_details=None, prompt_tokens_details=None)",
+                "total_tokens": 127,
+            },
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='<reasoning>The user asks: "What is 4200 + 42?" Simple arithmetic: 4200 + 42 = 4242. So answer that.</reasoning>4200 + 42 = **4242**.'
+                        )
+                    ],
+                    provider_id="bedrock",
+                    model_id="bedrock/openai.gpt-oss-20b-1:0",
+                    provider_model_name="openai.gpt-oss-20b-1:0",
+                    raw_message={
+                        "content": '<reasoning>The user asks: "What is 4200 + 42?" Simple arithmetic: 4200 + 42 = 4242. So answer that.</reasoning>4200 + 42 = **4242**.',
+                        "role": "assistant",
+                    },
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        },
+        "async_stream": {
+            "provider_id": "bedrock",
+            "model_id": "bedrock/openai.gpt-oss-20b-1:0",
+            "provider_model_name": "openai.gpt-oss-20b-1:0",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='<reasoning>User: "What is 4200 + 42?" They want sum. 4200+42=4242. Provide answer.</reasoning>4200 + 42 = **4242**.'
+                        )
+                    ],
+                    provider_id="bedrock",
+                    model_id="bedrock/openai.gpt-oss-20b-1:0",
+                    provider_model_name="openai.gpt-oss-20b-1:0",
+                    raw_message=None,
+                ),
+            ],
+            "format": None,
+            "tools": [],
+            "usage": {
+                "input_tokens": 74,
+                "output_tokens": 49,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "raw": "None",
+                "total_tokens": 123,
+            },
+            "n_chunks": 4,
+        },
+        "async_context_stream": {
+            "provider_id": "bedrock",
+            "model_id": "bedrock/openai.gpt-oss-20b-1:0",
+            "provider_model_name": "openai.gpt-oss-20b-1:0",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="<reasoning>The user asks a simple arithmetic: 4200 + 42 = 4242. They might want an answer. Just answer: 4242</reasoning><reasoning>.</reasoning>\\(4200 + 42 = 4242\\)."
+                        )
+                    ],
+                    provider_id="bedrock",
+                    model_id="bedrock/openai.gpt-oss-20b-1:0",
+                    provider_model_name="openai.gpt-oss-20b-1:0",
+                    raw_message=None,
+                ),
+            ],
+            "format": None,
+            "tools": [],
+            "usage": {
+                "input_tokens": 74,
+                "output_tokens": 53,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "raw": "None",
+                "total_tokens": 127,
+            },
+            "n_chunks": 5,
+        },
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_bedrock_openai_provider/bedrock_openai_gpt_oss_20b_1_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_bedrock_openai_provider/bedrock_openai_gpt_oss_20b_1_0_snapshots.py
@@ -1,0 +1,47 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "bedrock",
+            "model_id": "bedrock/openai.gpt-oss-20b-1:0",
+            "provider_model_name": "openai.gpt-oss-20b-1:0",
+            "params": {},
+            "finish_reason": None,
+            "usage": {
+                "input_tokens": 74,
+                "output_tokens": 59,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "raw": "CompletionUsage(completion_tokens=59, prompt_tokens=74, total_tokens=133, completion_tokens_details=None, prompt_tokens_details=None)",
+                "total_tokens": 133,
+            },
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="<reasoning>The user asks: \"What is 4200 + 42?\" They likely expect the sum 4242. That's straightforward. No special context. Provide answer. It's 4242.</reasoning>4200 + 42 equals **4242**."
+                        )
+                    ],
+                    provider_id="bedrock",
+                    model_id="bedrock/openai.gpt-oss-20b-1:0",
+                    provider_model_name="openai.gpt-oss-20b-1:0",
+                    raw_message={
+                        "content": "<reasoning>The user asks: \"What is 4200 + 42?\" They likely expect the sum 4242. That's straightforward. No special context. Provide answer. It's 4242.</reasoning>4200 + 42 equals **4242**.",
+                        "role": "assistant",
+                    },
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_bedrock_openai_sync_call_and_stream/bedrock_openai_gpt_oss_20b_1_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_bedrock_openai_sync_call_and_stream/bedrock_openai_gpt_oss_20b_1_0_snapshots.py
@@ -1,0 +1,154 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "call": {
+            "provider_id": "bedrock",
+            "model_id": "bedrock/openai.gpt-oss-20b-1:0",
+            "provider_model_name": "openai.gpt-oss-20b-1:0",
+            "params": {},
+            "finish_reason": None,
+            "usage": {
+                "input_tokens": 74,
+                "output_tokens": 80,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "raw": "CompletionUsage(completion_tokens=80, prompt_tokens=74, total_tokens=154, completion_tokens_details=None, prompt_tokens_details=None)",
+                "total_tokens": 154,
+            },
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+<reasoning>The user asks: "What is 4200 + 42?" That's a simple addition: 4200 + 42 = 4242. So answer 4242. That's it.</reasoning>4220 + 22 is 4220 + 22 = 4242.
+
+Therefore, 4200 + 42 = **4242**.\
+"""
+                        )
+                    ],
+                    provider_id="bedrock",
+                    model_id="bedrock/openai.gpt-oss-20b-1:0",
+                    provider_model_name="openai.gpt-oss-20b-1:0",
+                    raw_message={
+                        "content": """\
+<reasoning>The user asks: "What is 4200 + 42?" That's a simple addition: 4200 + 42 = 4242. So answer 4242. That's it.</reasoning>4220 + 22 is 4220 + 22 = 4242.
+
+Therefore, 4200 + 42 = **4242**.\
+""",
+                        "role": "assistant",
+                    },
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        },
+        "context_call": {
+            "provider_id": "bedrock",
+            "model_id": "bedrock/openai.gpt-oss-20b-1:0",
+            "provider_model_name": "openai.gpt-oss-20b-1:0",
+            "params": {},
+            "finish_reason": None,
+            "usage": {
+                "input_tokens": 74,
+                "output_tokens": 56,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "raw": "CompletionUsage(completion_tokens=56, prompt_tokens=74, total_tokens=130, completion_tokens_details=None, prompt_tokens_details=None)",
+                "total_tokens": 130,
+            },
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="<reasoning>The user is asking a simple arithmetic addition problem: 4200 + 42. The answer is 4242. I should respond succinctly: 4242.</reasoning>\\(4200 + 42 = 4242\\)"
+                        )
+                    ],
+                    provider_id="bedrock",
+                    model_id="bedrock/openai.gpt-oss-20b-1:0",
+                    provider_model_name="openai.gpt-oss-20b-1:0",
+                    raw_message={
+                        "content": "<reasoning>The user is asking a simple arithmetic addition problem: 4200 + 42. The answer is 4242. I should respond succinctly: 4242.</reasoning>\\(4200 + 42 = 4242\\)",
+                        "role": "assistant",
+                    },
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        },
+        "stream": {
+            "provider_id": "bedrock",
+            "model_id": "bedrock/openai.gpt-oss-20b-1:0",
+            "provider_model_name": "openai.gpt-oss-20b-1:0",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="<reasoning>User asks simple math: 4200 + 42? That's 4242. Provide answer. I might mention it's 4242.</reasoning>4200\u202f+\u202f42\u202f=\u202f**4242**."
+                        )
+                    ],
+                    provider_id="bedrock",
+                    model_id="bedrock/openai.gpt-oss-20b-1:0",
+                    provider_model_name="openai.gpt-oss-20b-1:0",
+                    raw_message=None,
+                ),
+            ],
+            "format": None,
+            "tools": [],
+            "usage": {
+                "input_tokens": 74,
+                "output_tokens": 52,
+                "cache_read_tokens": 48,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "raw": "None",
+                "total_tokens": 126,
+            },
+            "n_chunks": 5,
+        },
+        "context_stream": {
+            "provider_id": "bedrock",
+            "model_id": "bedrock/openai.gpt-oss-20b-1:0",
+            "provider_model_name": "openai.gpt-oss-20b-1:0",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='<reasoning>The user asks: "What is 4200 + 42?" Simple addition: 4200 + 42 = 4242. So answer is 4242.</reasoning>The sum is\u202f**4242**.'
+                        )
+                    ],
+                    provider_id="bedrock",
+                    model_id="bedrock/openai.gpt-oss-20b-1:0",
+                    provider_model_name="openai.gpt-oss-20b-1:0",
+                    raw_message=None,
+                ),
+            ],
+            "format": None,
+            "tools": [],
+            "usage": {
+                "input_tokens": 74,
+                "output_tokens": 54,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "raw": "None",
+                "total_tokens": 128,
+            },
+            "n_chunks": 4,
+        },
+    }
+)

--- a/python/tests/e2e/input/test_bedrock_openai_sigv4.py
+++ b/python/tests/e2e/input/test_bedrock_openai_sigv4.py
@@ -1,0 +1,31 @@
+"""End-to-end test for Bedrock OpenAI SigV4 authentication."""
+
+import pytest
+
+from mirascope import llm
+from mirascope.llm.providers.bedrock.openai import BedrockOpenAIProvider
+
+BEDROCK_OPENAI_SIGV4_MODEL_IDS: list[llm.ModelId] = [
+    "bedrock/openai.gpt-oss-20b-1:0",
+]
+
+
+@pytest.mark.parametrize("model_id", BEDROCK_OPENAI_SIGV4_MODEL_IDS)
+@pytest.mark.vcr
+def test_bedrock_openai_sigv4_call(
+    model_id: llm.ModelId,
+    reset_provider_registry: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test Bedrock OpenAI call with SigV4 authentication."""
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    provider = BedrockOpenAIProvider(aws_region="us-east-1")
+    llm.register_provider(provider)
+
+    @llm.call(model_id)
+    def simple_call() -> str:
+        return "Say hello in one word."
+
+    response = simple_call()
+    assert response.content is not None
+    assert len(response.content) > 0

--- a/python/tests/e2e/input/test_call_with_audio.py
+++ b/python/tests/e2e/input/test_call_with_audio.py
@@ -15,10 +15,10 @@ HELLO_AUDIO_PATH = str(
     Path(__file__).parent.parent / "assets" / "audio" / "tagline.mp3"
 )
 
-E2E_MODEL_IDS = [*E2E_MODEL_IDS, "openai/gpt-audio"]
+_AUDIO_MODEL_IDS = [*E2E_MODEL_IDS, "openai/gpt-audio"]
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", _AUDIO_MODEL_IDS)
 @pytest.mark.vcr
 def test_call_with_audio(
     model_id: llm.ModelId,
@@ -34,6 +34,8 @@ def test_call_with_audio(
             llm.Audio.from_file(audio_path),
         ]
 
-    with snapshot_test(snapshot, caplog) as snap:
+    with snapshot_test(
+        snapshot, caplog, extra_exceptions=[llm.BadRequestError]
+    ) as snap:
         response = transcribe_audio(HELLO_AUDIO_PATH)
         snap.set_response(response)

--- a/python/tests/e2e/input/test_call_with_image.py
+++ b/python/tests/e2e/input/test_call_with_image.py
@@ -15,6 +15,7 @@ from tests.utils import (
 IMAGE_URL_MODEL_IDS = [
     model_id for model_id in E2E_MODEL_IDS if not model_id.startswith("bedrock/")
 ]
+IMAGE_CONTENT_MODEL_IDS = list(E2E_MODEL_IDS)
 
 WIKIPEDIA_ICON_URL = "https://en.wikipedia.org/static/images/icons/wikipedia.png"
 WIKIPEDIA_ICON_PATH = str(
@@ -22,7 +23,7 @@ WIKIPEDIA_ICON_PATH = str(
 )
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", IMAGE_CONTENT_MODEL_IDS)
 @pytest.mark.vcr
 def test_call_with_image_content(
     model_id: llm.ModelId,
@@ -38,7 +39,9 @@ def test_call_with_image_content(
             llm.Image.from_file(image_path),
         ]
 
-    with snapshot_test(snapshot, caplog) as snap:
+    with snapshot_test(
+        snapshot, caplog, extra_exceptions=[llm.BadRequestError]
+    ) as snap:
         response = analyze_image(WIKIPEDIA_ICON_PATH)
         snap.set_response(response)
 

--- a/python/tests/e2e/input/test_call_with_parse_error.py
+++ b/python/tests/e2e/input/test_call_with_parse_error.py
@@ -21,7 +21,14 @@ def extract_passphrase(response: llm.AnyResponse) -> str:
     return "the cake is a lie"
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+PARSE_ERROR_MODEL_IDS = [
+    model_id
+    for model_id in E2E_MODEL_IDS
+    if model_id != "bedrock/openai.gpt-oss-20b-1:0"
+]
+
+
+@pytest.mark.parametrize("model_id", PARSE_ERROR_MODEL_IDS)
 @pytest.mark.vcr
 def test_call_with_parse_error(
     model_id: llm.ModelId,

--- a/python/tests/e2e/input/test_model_not_found.py
+++ b/python/tests/e2e/input/test_model_not_found.py
@@ -18,16 +18,20 @@ def get_nonexistent_model_id(model_id: llm.ModelId) -> llm.ModelId:
         else:
             model_scope = parts[0]
             model_part = parts[1]
+        provider_model = model_part.split(":", 1)[0]
+        bedrock_prefix = (
+            "openai.nonexistent-model-12345"
+            if provider_model.startswith("openai.")
+            else "us.anthropic.nonexistent-model-12345-v1"
+        )
         # Check if there's a suffix after the model name (like :completions or :responses)
         if ":" in model_part:
             _, suffix = model_part.rsplit(":", 1)
-            # Bedrock needs anthropic prefix for routing to work
             if model_scope == "bedrock":
-                return f"{model_scope}/us.anthropic.nonexistent-model-12345-v1:{suffix}"
+                return f"{model_scope}/{bedrock_prefix}:{suffix}"
             return f"{model_scope}/this-model-does-not-exist-12345:{suffix}"
-        # Bedrock needs anthropic prefix for routing to work
         if model_scope == "bedrock":
-            return f"{model_scope}/us.anthropic.nonexistent-model-12345-v1:0"
+            return f"{model_scope}/{bedrock_prefix}:0"
         return f"{model_scope}/this-model-does-not-exist-12345"
     return "nonexistent-model-12345"
 

--- a/python/tests/e2e/input/test_openai_compatibility_providers.py
+++ b/python/tests/e2e/input/test_openai_compatibility_providers.py
@@ -391,3 +391,124 @@ async def test_bedrock_anthropic_async_call_and_stream(
         assert "4242" in stream_ctx.pretty(), (
             f"Expected '4242' in response: {stream_ctx.pretty()}"
         )
+
+
+# =============================================================================
+# Bedrock OpenAI Provider Tests
+# =============================================================================
+
+BEDROCK_OPENAI_MODEL_IDS = ["bedrock/openai.gpt-oss-20b-1:0"]
+
+
+@pytest.mark.parametrize("model_id", BEDROCK_OPENAI_MODEL_IDS)
+@pytest.mark.vcr
+def test_bedrock_openai_provider(model_id: llm.ModelId, snapshot: Snapshot) -> None:
+    """Test that Bedrock OpenAI provider works correctly."""
+
+    @llm.call(model_id)
+    def add_numbers(a: int, b: int) -> str:
+        return f"What is {a} + {b}?"
+
+    _register_bedrock_provider()
+
+    with snapshot_test(snapshot) as snap:
+        response = add_numbers(4200, 42)
+        assert response.provider_id == "bedrock"
+        assert response.provider_model_name == "openai.gpt-oss-20b-1:0"
+        snap.set_response(response)
+        assert "4242" in response.pretty(), (
+            f"Expected '4242' in response: {response.pretty()}"
+        )
+
+
+@pytest.mark.parametrize("model_id", BEDROCK_OPENAI_MODEL_IDS)
+@pytest.mark.vcr
+def test_bedrock_openai_sync_call_and_stream(
+    model_id: llm.ModelId, snapshot: Snapshot
+) -> None:
+    """Test sync call + stream paths for Bedrock OpenAI (with and without context)."""
+
+    @llm.call(model_id)
+    def add_numbers(a: int, b: int) -> str:
+        return f"What is {a} + {b}?"
+
+    @llm.call(model_id)
+    def add_numbers_ctx(ctx: llm.Context[int], b: int) -> str:
+        return f"What is {ctx.deps} + {b}?"
+
+    _register_bedrock_provider()
+
+    with snapshot_test(snapshot) as snap:
+        response = add_numbers(4200, 42)
+        snap["call"] = response_snapshot_dict(response)
+        assert "4242" in response.pretty(), (
+            f"Expected '4242' in response: {response.pretty()}"
+        )
+
+        ctx = llm.Context(deps=4200)
+        response_ctx = add_numbers_ctx(ctx, 42)
+        snap["context_call"] = response_snapshot_dict(response_ctx)
+        assert "4242" in response_ctx.pretty(), (
+            f"Expected '4242' in response: {response_ctx.pretty()}"
+        )
+
+        stream = add_numbers.stream(4200, 42)
+        stream.finish()
+        snap["stream"] = stream_response_snapshot_dict(stream)
+        assert "4242" in stream.pretty(), (
+            f"Expected '4242' in response: {stream.pretty()}"
+        )
+
+        stream_ctx = add_numbers_ctx.stream(ctx, 42)
+        stream_ctx.finish()
+        snap["context_stream"] = stream_response_snapshot_dict(stream_ctx)
+        assert "4242" in stream_ctx.pretty(), (
+            f"Expected '4242' in response: {stream_ctx.pretty()}"
+        )
+
+
+@pytest.mark.parametrize("model_id", BEDROCK_OPENAI_MODEL_IDS)
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_bedrock_openai_async_call_and_stream(
+    model_id: llm.ModelId, snapshot: Snapshot
+) -> None:
+    """Test async call + stream paths for Bedrock OpenAI (with and without context)."""
+
+    @llm.call(model_id)
+    async def add_numbers(a: int, b: int) -> str:
+        return f"What is {a} + {b}?"
+
+    @llm.call(model_id)
+    async def add_numbers_ctx(ctx: llm.Context[int], b: int) -> str:
+        return f"What is {ctx.deps} + {b}?"
+
+    _register_bedrock_provider()
+
+    with snapshot_test(snapshot) as snap:
+        response = await add_numbers(4200, 42)
+        snap["async_call"] = response_snapshot_dict(response)
+        assert "4242" in response.pretty(), (
+            f"Expected '4242' in response: {response.pretty()}"
+        )
+
+        ctx = llm.Context(deps=4200)
+        response_ctx = await add_numbers_ctx(ctx, 42)
+        snap["async_context_call"] = response_snapshot_dict(response_ctx)
+        assert "4242" in response_ctx.pretty(), (
+            f"Expected '4242' in response: {response_ctx.pretty()}"
+        )
+
+        stream = await add_numbers.stream(4200, 42)
+        await stream.finish()
+        snap["async_stream"] = stream_response_snapshot_dict(stream)
+        assert "4242" in stream.pretty(), (
+            f"Expected '4242' in response: {stream.pretty()}"
+        )
+
+        stream_ctx = await add_numbers_ctx.stream(ctx, 42)
+        await stream_ctx.finish()
+        snap["async_context_stream"] = stream_response_snapshot_dict(stream_ctx)
+        assert "4242" in stream_ctx.pretty(), (
+            f"Expected '4242' in response: {stream_ctx.pretty()}"
+        )

--- a/python/tests/e2e/input/test_structured_output_with_formatting_instructions.py
+++ b/python/tests/e2e/input/test_structured_output_with_formatting_instructions.py
@@ -27,7 +27,14 @@ class Book(BaseModel):
         """)
 
 
-@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
+FORMAT_INSTRUCTIONS_MODEL_IDS = [
+    model_id
+    for model_id in STRUCTURED_OUTPUT_MODEL_IDS
+    if model_id != "bedrock/openai.gpt-oss-20b-1:0"
+]
+
+
+@pytest.mark.parametrize("model_id", FORMAT_INSTRUCTIONS_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_with_formatting_instructions(

--- a/python/tests/e2e/output/cassettes/test_call/bedrock_openai_gpt_oss_20b_1_0/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_call/bedrock_openai_gpt_oss_20b_1_0/async.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '94'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - AsyncOpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "{\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"logprobs\":null,\"message\":{\"content\":\"<reasoning>The
+        user asks: \\\"What is 4200 + 42?\\\" It's a simple math: 4200 + 42 = 4242.
+        Let's ensure no ambiguity. So answer is 4242. Let's respond.</reasoning>4200\u202F+\u202F42\_=\_4242.\",\"refusal\":null,\"role\":\"assistant\"}}],\"created\":1769185805,\"id\":\"chatcmpl-363a7ca1-ee2e-4275-98c9-533cbdba3008\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":67,\"prompt_tokens\":78,\"total_tokens\":145}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '535'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Jan 2026 16:30:05 GMT
+      X-Request-ID:
+      - 494561e7-dc46-4d1f-a026-29772fc651e8
+      x-amzn-RequestId:
+      - 494561e7-dc46-4d1f-a026-29772fc651e8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_call/bedrock_openai_gpt_oss_20b_1_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call/bedrock_openai_gpt_oss_20b_1_0/async_stream.yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0","stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '148'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - AsyncOpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"role\":\"assistant\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"kq6RYb4IT0fR5jjlTA4A2g2f5t2PV9c9MM0Trwc7lh68Np856l1FSoLOf41WFvFyRrkXq0rUKbyJoGXJqB0IfxM0ejrIHUL9sG49W1vXMmsN9bbW\"}],\"created\":1769185807,\"id\":\"chatcmpl-fb2b1f61-caed-48cc-8fc8-16313c28cef1\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"<reasoning>User asks a simple math:
+        4200 + 42 = 4242. Need to respond.</reasoning>\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"p6wKmMAba6B90lZg16fgQkqd5NdjA8HjgIsUSe\"}],\"created\":1769185807,\"id\":\"chatcmpl-fb2b1f61-caed-48cc-8fc8-16313c28cef1\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"4200\u202F+\u202F42\u202F=\u202F**4242**.\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"by6rQTZcd3l3zUS4UDiz5IubhrpyKS2AaHkaCPjsbkH97x3IwHUBmxgxMp57gtg2mwWQ4JhWczCpONdZoG4mKmOxc\"}],\"created\":1769185807,\"id\":\"chatcmpl-fb2b1f61-caed-48cc-8fc8-16313c28cef1\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0,\"obfuscation\":\"1mA1vUP03EnNLPQq4X85pYDWH1rNyGhk7mAXBwt6aatz2sIUL3gq6Ey7WkZFOuuqxbFi0cijWp7U5HCJpQPFvfLLuGmRHewYApBsgdE0\"}],\"created\":1769185807,\"id\":\"chatcmpl-fb2b1f61-caed-48cc-8fc8-16313c28cef1\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[],\"created\":1769185807,\"id\":\"chatcmpl-fb2b1f61-caed-48cc-8fc8-16313c28cef1\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":45,\"prompt_tokens\":78,\"prompt_tokens_details\":{\"audio_tokens\":0,\"cached_tokens\":48},\"total_tokens\":123}}\n\ndata:
+        [DONE]\n\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 23 Jan 2026 16:30:07 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - 4cee2ae7-f542-4ec2-8e65-49be84abefc7
+      x-amzn-RequestId:
+      - 4cee2ae7-f542-4ec2-8e65-49be84abefc7
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_call/bedrock_openai_gpt_oss_20b_1_0/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call/bedrock_openai_gpt_oss_20b_1_0/stream.yaml
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0","stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '148'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - OpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"role\":\"assistant\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"QEfsOV4bzHZRPNrOc6vSOkcbBHGf0olZJRSnOSMTozuRQuNyfTKZNrp6akVh2WDr0aoWO82kca5lmeplsZxzmcaoYfvF7vvqVs1gjhOw0JjsZp\"}],\"created\":1769185806,\"id\":\"chatcmpl-6c60a842-d37a-47a9-9bbe-3c981a790bba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"<reasoning>The user asks \\\"What
+        is 4200 + 42?\\\" We just need to give the sum: 4242. It's trivial. In addition,
+        check if any mention of policies like privacy or no.</reasoning>\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"3XjD9GOSd5aYC6qMaZTyCsP31FLWtRhz7lC6u8ni00xmozuAiAOeAY\"}],\"created\":1769185806,\"id\":\"chatcmpl-6c60a842-d37a-47a9-9bbe-3c981a790bba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"<reasoning> It's straightforward.
+        Provide the answer and maybe a bit of explanation.</reasoning>\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"HGL7Xz6AGkA1eRValv6cJVXCUBuF2Wjy9oyl6eZRsT2BlDXk5n6B92GOe0exbZCExb1IrEGUgXTs8R3IywmwLFhWi3ipGbALEMc6a3wX15JAv4PsO5Ecw03rjftYL3\"}],\"created\":1769185806,\"id\":\"chatcmpl-6c60a842-d37a-47a9-9bbe-3c981a790bba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"4200\u202F+\u202F42\u202F=\u202F**4242**.\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"0F0DGUTDwcpwxAtr3sS5D8lA23dyK06UAK9n57DqL2So6utDwCqIxXTfOyZA6vOY\"}],\"created\":1769185806,\"id\":\"chatcmpl-6c60a842-d37a-47a9-9bbe-3c981a790bba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0,\"obfuscation\":\"rn1eenHjxLnUMXPcqvVPT6muKSIDoVodZXUrwpWi0pax4yhCka0Tv0JG9jGcJ3UWMpUz8TB4e\"}],\"created\":1769185806,\"id\":\"chatcmpl-6c60a842-d37a-47a9-9bbe-3c981a790bba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[],\"created\":1769185806,\"id\":\"chatcmpl-6c60a842-d37a-47a9-9bbe-3c981a790bba\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":79,\"prompt_tokens\":78,\"total_tokens\":157}}\n\ndata:
+        [DONE]\n\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 23 Jan 2026 16:30:06 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - f3682e3f-132b-43c3-9348-3f5e2f7b26d1
+      x-amzn-RequestId:
+      - f3682e3f-132b-43c3-9348-3f5e2f7b26d1
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_call/bedrock_openai_gpt_oss_20b_1_0/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_call/bedrock_openai_gpt_oss_20b_1_0/sync.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"openai.gpt-oss-20b-1:0"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '94'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - OpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "{\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"logprobs\":null,\"message\":{\"content\":\"<reasoning>We
+        need to answer sum. 4200+42=4242. Probably just answer.</reasoning>4200\u202F+\u202F42\u202F=\u202F4242.\",\"refusal\":null,\"role\":\"assistant\"}}],\"created\":1769185778,\"id\":\"chatcmpl-b4cd8721-b80b-4a8c-a2da-da6858f12a0d\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":41,\"prompt_tokens\":78,\"total_tokens\":119}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '459'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Jan 2026 16:29:38 GMT
+      X-Request-ID:
+      - 0e5804a4-97e8-4c71-83cc-e0cc24b95b4e
+      x-amzn-RequestId:
+      - 0e5804a4-97e8-4c71-83cc-e0cc24b95b4e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_max_tokens/bedrock_openai_gpt_oss_20b_1_0/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/bedrock_openai_gpt_oss_20b_1_0/async.yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"List all U.S. states."}],"model":"openai.gpt-oss-20b-1:0","max_completion_tokens":50}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '124'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - AsyncOpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: '{"choices":[{"finish_reason":"length","index":0,"logprobs":null,"message":{"content":"<reasoning>User:
+        \"List all U.S. states.\" There''s no special instruction, so just give list
+        of 50 U.S. states.\n\nWe should comply and provide a list of all 50 states
+        alphabetically or similar. Provide as final</reasoning>","refusal":null,"role":"assistant"}}],"created":1769185906,"id":"chatcmpl-7746109b-341d-457b-ae8c-2a374af31094","model":"openai.gpt-oss-20b-1:0","object":"chat.completion","service_tier":"default","usage":{"completion_tokens":50,"prompt_tokens":76,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":48},"total_tokens":126}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '640'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Jan 2026 16:31:47 GMT
+      X-Request-ID:
+      - a4000c75-2ba2-4bbc-852c-ebcec1ba9088
+      x-amzn-RequestId:
+      - a4000c75-2ba2-4bbc-852c-ebcec1ba9088
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_max_tokens/bedrock_openai_gpt_oss_20b_1_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/bedrock_openai_gpt_oss_20b_1_0/async_stream.yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"List all U.S. states."}],"model":"openai.gpt-oss-20b-1:0","max_completion_tokens":50,"stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '178'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - AsyncOpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"role\":\"assistant\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"TkmDHvD0awQHyLGlSQNdhq9hx5mLUzER4T4YZypn2JgAfy0zrYqOVeaxCgSlvuydx3hNHK01N84F0SckybJpB0ve8mBsUJdK\"}],\"created\":1769185909,\"id\":\"chatcmpl-849234cf-9bb2-4a7d-b9a9-bdc3a997a026\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"<reasoning>The user wants a list of
+        all U.S. states. Provide full list: 50 states. They probably want them alphabetically.
+        Provide with numbers. That is straightforward.</reasoning>\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"A14ocTjt5GJOZ8uQkizY8vA6eH121PDwDmfpXfNsTtfVfPc6uAWrUKmRWJSTMt84rmcfJ0o\"}],\"created\":1769185909,\"id\":\"chatcmpl-849234cf-9bb2-4a7d-b9a9-bdc3a997a026\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"**The 50 United\u202F\"},\"finish_reason\":\"length\",\"index\":0,\"obfuscation\":\"OsnU0r75R4yyCfRctm7x41zCJp4e4P4aWe0IThoJKd8r7PI5QTgMZx6lSol7zQcDxcOoMydl\"}],\"created\":1769185909,\"id\":\"chatcmpl-849234cf-9bb2-4a7d-b9a9-bdc3a997a026\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[],\"created\":1769185909,\"id\":\"chatcmpl-849234cf-9bb2-4a7d-b9a9-bdc3a997a026\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":50,\"prompt_tokens\":76,\"prompt_tokens_details\":{\"audio_tokens\":0,\"cached_tokens\":48},\"total_tokens\":126}}\n\ndata:
+        [DONE]\n\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 23 Jan 2026 16:31:49 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - a2053510-2be9-445c-bf4a-7545c7602ad5
+      x-amzn-RequestId:
+      - a2053510-2be9-445c-bf4a-7545c7602ad5
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_max_tokens/bedrock_openai_gpt_oss_20b_1_0/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/bedrock_openai_gpt_oss_20b_1_0/stream.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"List all U.S. states."}],"model":"openai.gpt-oss-20b-1:0","max_completion_tokens":50,"stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '178'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - OpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null,"index":0,"obfuscation":"hpEgxCGBt4PjMXSe7xQXxeQgobq9Wv76OLfFI3Do5iVLTkhPBp6fZBOM7mMSbnaAYGtdsf"}],"created":1769185908,"id":"chatcmpl-a09d8603-8bff-48fa-af7b-fa4aaa8d8059","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[{"delta":{"content":"<reasoning>We need to list all US states.
+        The user asked for a list of all states. We''ll provide a list. Probably alphabetically.
+        Include the 50 states. We should ensure we include all. Also mention that
+        DC is not a</reasoning>"},"finish_reason":"length","index":0,"obfuscation":"c7JUbMDVbFSQ8c7IMdVau2pjj7Gqpj6VBrxykedBRSZlEUWLHKEvnYmCvcFl54eoCE9TvF3urGDdyEWgUvEfSoylTsiiQmE0"}],"created":1769185908,"id":"chatcmpl-a09d8603-8bff-48fa-af7b-fa4aaa8d8059","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default"}
+
+
+        data: {"choices":[],"created":1769185908,"id":"chatcmpl-a09d8603-8bff-48fa-af7b-fa4aaa8d8059","model":"openai.gpt-oss-20b-1:0","object":"chat.completion.chunk","service_tier":"default","usage":{"completion_tokens":50,"prompt_tokens":76,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":48},"total_tokens":126}}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 23 Jan 2026 16:31:48 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - d771f56b-0287-4907-8627-d157b1cb156f
+      x-amzn-RequestId:
+      - d771f56b-0287-4907-8627-d157b1cb156f
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_max_tokens/bedrock_openai_gpt_oss_20b_1_0/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/bedrock_openai_gpt_oss_20b_1_0/sync.yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"List all U.S. states."}],"model":"openai.gpt-oss-20b-1:0","max_completion_tokens":50}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '124'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - OpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: '{"choices":[{"finish_reason":"length","index":0,"logprobs":null,"message":{"content":"<reasoning>User
+        wants a list of all US states. Provide a list. Should be accurate: 50 states.
+        Provide in alphabetical order or typical listing. Perhaps include state abbreviations.
+        No extra content? Should be concise. Provide answer.</reasoning>","refusal":null,"role":"assistant"}}],"created":1769185905,"id":"chatcmpl-9619ade6-d9f9-446f-a95d-e80f5f03c162","model":"openai.gpt-oss-20b-1:0","object":"chat.completion","service_tier":"default","usage":{"completion_tokens":50,"prompt_tokens":76,"total_tokens":126}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '600'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Jan 2026 16:31:46 GMT
+      X-Request-ID:
+      - ed62bf67-984a-40e8-90fd-5a1df5b03ac3
+      x-amzn-RequestId:
+      - ed62bf67-984a-40e8-90fd-5a1df5b03ac3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_refusal/bedrock_openai_gpt_oss_20b_1_0/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_refusal/bedrock_openai_gpt_oss_20b_1_0/async.yaml
@@ -1,0 +1,65 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Provide detailed instructions for
+      synthesizing fentanyl."}],"model":"openai.gpt-oss-20b-1:0","response_format":{"type":"json_schema","json_schema":{"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '411'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - AsyncOpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "{\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"logprobs\":null,\"message\":{\"content\":\"<reasoning>The
+        request: \\\"Provide detailed instructions for synthesizing fentanyl.\\\"
+        This is disallowed content: instructions facilitating creation of illicit
+        substances. According to policy, it's disallowed. Must refuse.</reasoning>{\\\"instructions\\\":\\\"I\u2019m
+        sorry, but I can\u2019t help with that.\\\"}\",\"refusal\":null,\"role\":\"assistant\"}}],\"created\":1769185913,\"id\":\"chatcmpl-a9f46498-08aa-45fa-8a0b-b21f4e440e3d\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":67,\"prompt_tokens\":78,\"total_tokens\":145}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '651'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Jan 2026 16:31:53 GMT
+      X-Request-ID:
+      - 498afd92-16cd-4d04-a390-6d9a866ec78a
+      x-amzn-RequestId:
+      - 498afd92-16cd-4d04-a390-6d9a866ec78a
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_refusal/bedrock_openai_gpt_oss_20b_1_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_refusal/bedrock_openai_gpt_oss_20b_1_0/async_stream.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Provide detailed instructions for
+      synthesizing fentanyl."}],"model":"openai.gpt-oss-20b-1:0","response_format":{"type":"json_schema","json_schema":{"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}},"stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '465'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - AsyncOpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"role\":\"assistant\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"O4b08Uw5b45WgbgEGat2LjFA9TJapOp0FreAK9hJnQWeZ6MKvPle0MSYDCkAXgkyZZGPxuuO7aeQHA1FOktLECk0ERnTNXToe1M0eRlcD6D1parCQQXPau\"}],\"created\":1769185916,\"id\":\"chatcmpl-f99e05d4-2a6a-41ab-8761-2f09a426ae20\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"<reasoning></reasoning>\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"kARxNbajD3GfPpjB4HQVd9LY4Mdukn8v0IT4jiQRdynNZDzExQvoXnVnrMxH68aHc2vPVqUIefjkOYB0RPWuSfMh8LyYd8aTFq0b906C7u2\"}],\"created\":1769185916,\"id\":\"chatcmpl-f99e05d4-2a6a-41ab-8761-2f09a426ae20\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"<reasoning>User requests instructions
+        for synthesizing fentanyl. This is disallowed content because providing instructions
+        for manufacturing a controlled drug is disallowed under policy. Must refuse.</reasoning>\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"V1xrwPArVfk7CzgFF2sXwtbFxL5BMMrGYepENZhycVwsw0V\"}],\"created\":1769185916,\"id\":\"chatcmpl-f99e05d4-2a6a-41ab-8761-2f09a426ae20\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"I\u2019m sorry,{\\\"instructions\\\":\\\"I'm
+        sorry, but I can\u2019t help with that.\\\"}\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"6EYUNYMSEEDzeR7CnFet4iQQxn9WJJqwgCW51uCDOuEPNXfB\"}],\"created\":1769185916,\"id\":\"chatcmpl-f99e05d4-2a6a-41ab-8761-2f09a426ae20\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0,\"obfuscation\":\"1f8bCTATJoHoGjLupgArMpqXOUwbciJ9LKduLsU7Jj\"}],\"created\":1769185916,\"id\":\"chatcmpl-f99e05d4-2a6a-41ab-8761-2f09a426ae20\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[],\"created\":1769185916,\"id\":\"chatcmpl-f99e05d4-2a6a-41ab-8761-2f09a426ae20\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":63,\"prompt_tokens\":78,\"total_tokens\":141}}\n\ndata:
+        [DONE]\n\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 23 Jan 2026 16:31:57 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - 17207329-8698-4f7e-a9b8-649dffdf0db9
+      x-amzn-RequestId:
+      - 17207329-8698-4f7e-a9b8-649dffdf0db9
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_refusal/bedrock_openai_gpt_oss_20b_1_0/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_refusal/bedrock_openai_gpt_oss_20b_1_0/stream.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Provide detailed instructions for
+      synthesizing fentanyl."}],"model":"openai.gpt-oss-20b-1:0","response_format":{"type":"json_schema","json_schema":{"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}},"stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '465'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - OpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "data: {\"choices\":[{\"delta\":{\"content\":\"\",\"role\":\"assistant\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"EnBuX8FH7TnxHyFdos4mpBsdmNriOBpNlUW8fPaG6CaITBR68kJrcDzjIpz2Dagg2LT\"}],\"created\":1769185914,\"id\":\"chatcmpl-24d0e77a-d2ba-43ad-a48e-98768c623d7e\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"<reasoning>The user requests instructions
+        for synthesizing fentanyl: that's instructions facilitating creation of a
+        controlled substance. This is disallowed content under the policy: instructions
+        to produce illegal drugs. Must refuse.</reasoning>\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"b2V1p49xHFhS7z03uj0nl65wVJBSWUm5DXeo2ACKJzyrwrc5B4RdMPc2AlNBPlYyImeyXzb4nSQJQTBef4wbcKptepKNDQ9stMwI56GA1cj7OKCWy1cYbd\"}],\"created\":1769185914,\"id\":\"chatcmpl-24d0e77a-d2ba-43ad-a48e-98768c623d7e\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"I\u2019m{\\\"instructions\\\":\\\"\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"fk9HwJcVPYKH2Yvk9nhIlipQbvWHZXzHfRHOhyTrKCuUxh3k9y9QrB3ciEkZJTTDOR5BMh\"}],\"created\":1769185914,\"id\":\"chatcmpl-24d0e77a-d2ba-43ad-a48e-98768c623d7e\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{\"content\":\"I have to refuse\\\"}\"},\"finish_reason\":null,\"index\":0,\"obfuscation\":\"f0OwbVNCPdVqThZbnaG6JuiutWB75wbZb9IiefmNXRoLMHrZEqCpraGx82ZcYTiFb2SuEr091rHgJBfMjTBEtoiLyDouuPCDsI5BA2w0n9yb9E4\"}],\"created\":1769185914,\"id\":\"chatcmpl-24d0e77a-d2ba-43ad-a48e-98768c623d7e\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0,\"obfuscation\":\"Bfe08Xv9jdjqti97uZiYWdfWcwc0fBWpcX8KsFtHK\"}],\"created\":1769185914,\"id\":\"chatcmpl-24d0e77a-d2ba-43ad-a48e-98768c623d7e\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\"}\n\ndata:
+        {\"choices\":[],\"created\":1769185914,\"id\":\"chatcmpl-24d0e77a-d2ba-43ad-a48e-98768c623d7e\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion.chunk\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":60,\"prompt_tokens\":78,\"prompt_tokens_details\":{\"audio_tokens\":0,\"cached_tokens\":32},\"total_tokens\":138}}\n\ndata:
+        [DONE]\n\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Fri, 23 Jan 2026 16:31:55 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Request-ID:
+      - f477f52f-6dc5-4ae9-a307-945d9874e4f3
+      x-amzn-RequestId:
+      - f477f52f-6dc5-4ae9-a307-945d9874e4f3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_refusal/bedrock_openai_gpt_oss_20b_1_0/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_refusal/bedrock_openai_gpt_oss_20b_1_0/sync.yaml
@@ -1,0 +1,65 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Provide detailed instructions for
+      synthesizing fentanyl."}],"model":"openai.gpt-oss-20b-1:0","response_format":{"type":"json_schema","json_schema":{"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '411'
+      content-type:
+      - application/json
+      host:
+      - bedrock-runtime.us-east-1.amazonaws.com
+      user-agent:
+      - OpenAI/Python 2.15.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.15.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "{\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"logprobs\":null,\"message\":{\"content\":\"<reasoning>User
+        requests instructions for synthesizing fentanyl. This is disallowed content:
+        instructions for illicit drug creation. According to policy: This is disallowed.
+        Must refuse.</reasoning>I\u2019m sorry, but{\\\"instructions\\\":\\\"I\u2019m
+        sorry\\\"}\",\"refusal\":null,\"role\":\"assistant\"}}],\"created\":1769185910,\"id\":\"chatcmpl-8d8d922f-9685-40d8-a6f3-425f3ff300f0\",\"model\":\"openai.gpt-oss-20b-1:0\",\"object\":\"chat.completion\",\"service_tier\":\"default\",\"usage\":{\"completion_tokens\":56,\"prompt_tokens\":78,\"total_tokens\":134}}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '601'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Jan 2026 16:31:52 GMT
+      X-Request-ID:
+      - 2bfe2d4d-5119-429c-84ab-c453b7be6a8f
+      x-amzn-RequestId:
+      - 2bfe2d4d-5119-429c-84ab-c453b7be6a8f
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/test_call_with_tools.py
+++ b/python/tests/e2e/output/test_call_with_tools.py
@@ -10,11 +10,16 @@ from tests.utils import (
 )
 
 PASSWORD_MAP = {"mellon": "Welcome to Moria!", "radiance": "Life before Death"}
+TOOL_MODEL_IDS = [
+    model_id
+    for model_id in E2E_MODEL_IDS
+    if model_id != "bedrock/openai.gpt-oss-20b-1:0"
+]
 
 # ============= SYNC TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", TOOL_MODEL_IDS)
 @pytest.mark.vcr
 def test_call_with_tools_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test synchronous tool call without context."""
@@ -53,7 +58,7 @@ def test_call_with_tools_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None
         )
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", TOOL_MODEL_IDS)
 @pytest.mark.vcr
 def test_call_with_tools_sync_context(
     model_id: llm.ModelId, snapshot: Snapshot
@@ -102,7 +107,7 @@ def test_call_with_tools_sync_context(
 # ============= ASYNC TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", TOOL_MODEL_IDS)
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_call_with_tools_async(model_id: llm.ModelId, snapshot: Snapshot) -> None:
@@ -142,7 +147,7 @@ async def test_call_with_tools_async(model_id: llm.ModelId, snapshot: Snapshot) 
         )
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", TOOL_MODEL_IDS)
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_call_with_tools_async_context(
@@ -192,7 +197,7 @@ async def test_call_with_tools_async_context(
 # ============= STREAM TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", TOOL_MODEL_IDS)
 @pytest.mark.vcr
 def test_call_with_tools_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test streaming tool call without context."""
@@ -234,7 +239,7 @@ def test_call_with_tools_stream(model_id: llm.ModelId, snapshot: Snapshot) -> No
         )
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", TOOL_MODEL_IDS)
 @pytest.mark.vcr
 def test_call_with_tools_stream_context(
     model_id: llm.ModelId, snapshot: Snapshot
@@ -284,7 +289,7 @@ def test_call_with_tools_stream_context(
 # ============= ASYNC STREAM TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", TOOL_MODEL_IDS)
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_call_with_tools_async_stream(
@@ -329,7 +334,7 @@ async def test_call_with_tools_async_stream(
         )
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", TOOL_MODEL_IDS)
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_call_with_tools_async_stream_context(

--- a/python/tests/e2e/output/test_structured_output.py
+++ b/python/tests/e2e/output/test_structured_output.py
@@ -26,6 +26,13 @@ class Book(BaseModel):
     rating: int = Field(description="For testing purposes, the rating should be 7")
 
 
+STREAM_STRUCTURED_OUTPUT_MODEL_IDS = [
+    model_id
+    for model_id in STRUCTURED_OUTPUT_MODEL_IDS
+    if model_id != "bedrock/openai.gpt-oss-20b-1:0"
+]
+
+
 # ============= SYNC TESTS =============
 
 
@@ -167,7 +174,7 @@ async def test_structured_output_async_context(
 # ============= STREAM TESTS =============
 
 
-@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STREAM_STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_stream(
@@ -201,7 +208,7 @@ def test_structured_output_stream(
         assert book.rating == 7
 
 
-@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STREAM_STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_stream_context(
@@ -239,7 +246,7 @@ def test_structured_output_stream_context(
 # ============= ASYNC STREAM TESTS =============
 
 
-@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STREAM_STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio
@@ -274,7 +281,7 @@ async def test_structured_output_async_stream(
         assert book.rating == 7
 
 
-@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STREAM_STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio

--- a/python/tests/llm/providers/bedrock/test_bedrock_openai_provider.py
+++ b/python/tests/llm/providers/bedrock/test_bedrock_openai_provider.py
@@ -1,0 +1,79 @@
+"""Tests for BedrockOpenAIProvider."""
+
+from pathlib import Path
+
+import pytest
+
+from mirascope.llm.providers.bedrock._utils import BEDROCK_OPENAI_MODEL_PREFIXES
+from mirascope.llm.providers.bedrock.openai import BedrockOpenAIProvider
+from mirascope.llm.providers.bedrock.openai.provider import (
+    BedrockOpenAIRoutedProvider,
+    _build_bedrock_openai_base_url,  # pyright: ignore[reportPrivateUsage]
+)
+
+
+def test_build_bedrock_openai_base_url() -> None:
+    """Test _build_bedrock_openai_base_url constructs correct URL."""
+    url = _build_bedrock_openai_base_url("us-east-1")
+    assert url == "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1"
+
+
+def test_build_bedrock_openai_base_url_other_region() -> None:
+    """Test _build_bedrock_openai_base_url with different region."""
+    url = _build_bedrock_openai_base_url("eu-west-1")
+    assert url == "https://bedrock-runtime.eu-west-1.amazonaws.com/openai/v1"
+
+
+def test_bedrock_openai_model_prefixes() -> None:
+    """Test BEDROCK_OPENAI_MODEL_PREFIXES contains OpenAI prefix."""
+    assert "bedrock/openai." in BEDROCK_OPENAI_MODEL_PREFIXES
+
+
+def test_bedrock_openai_provider_requires_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test BedrockOpenAIProvider raises error without credentials."""
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
+    credentials_file = tmp_path / "credentials"
+    config_file = tmp_path / "config"
+    credentials_file.write_text("")
+    config_file.write_text("")
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(credentials_file))
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+    with pytest.raises(
+        ValueError, match="requires either an API key or AWS credentials"
+    ):
+        BedrockOpenAIProvider(aws_region="us-east-1")
+
+
+def test_bedrock_openai_provider_default_scope() -> None:
+    """Test BedrockOpenAIProvider has correct default scope."""
+    assert BedrockOpenAIProvider.default_scope == "bedrock/openai."
+
+
+def test_bedrock_openai_provider_id() -> None:
+    """Test BedrockOpenAIProvider has correct provider id."""
+    assert BedrockOpenAIProvider.id == "bedrock:openai"
+
+
+def test_bedrock_openai_routed_provider_id() -> None:
+    """Test BedrockOpenAIRoutedProvider reports provider_id as bedrock."""
+    assert BedrockOpenAIRoutedProvider.id == "bedrock"
+
+
+def test_bedrock_openai_provider_get_error_status() -> None:
+    """Test BedrockOpenAIProvider.get_error_status extracts status code."""
+    provider = BedrockOpenAIProvider(
+        api_key="test-api-key",
+        base_url="https://example.com/openai/v1",
+    )
+
+    class MockError(Exception):
+        status_code = 429
+
+    assert provider.get_error_status(MockError()) == 429
+    assert provider.get_error_status(Exception()) is None

--- a/python/tests/llm/providers/bedrock/test_bedrock_provider.py
+++ b/python/tests/llm/providers/bedrock/test_bedrock_provider.py
@@ -293,6 +293,26 @@ def test_bedrock_provider_longest_prefix_match() -> None:
     assert route == "anthropic"
 
 
+def test_bedrock_provider_route_openai_model() -> None:
+    """Test BedrockProvider routes OpenAI-compatible model IDs."""
+    provider = BedrockProvider()
+    route = provider._route_provider(  # pyright: ignore[reportPrivateUsage]
+        "bedrock/openai.gpt-4"
+    )
+    assert route == "openai"
+
+
+def test_bedrock_provider_default_routing_scopes_has_openai() -> None:
+    """Test default routing scopes include OpenAI prefixes."""
+    from mirascope.llm.providers.bedrock.provider import (
+        _default_routing_scopes,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    scopes = _default_routing_scopes()
+    assert "openai" in scopes
+    assert len(scopes["openai"]) > 0
+
+
 def test_bedrock_provider_initialization_with_anthropic_api_key() -> None:
     """Test BedrockProvider creates API key client for Anthropic subprovider."""
     from mirascope.llm.providers.bedrock.anthropic.provider import (
@@ -305,6 +325,16 @@ def test_bedrock_provider_initialization_with_anthropic_api_key() -> None:
     )
     subprovider = provider._get_anthropic_provider()  # pyright: ignore[reportPrivateUsage]
     assert isinstance(subprovider.client, BedrockAnthropicApiKeyClient)
+
+
+def test_bedrock_provider_initialization_with_openai_api_key() -> None:
+    """Test BedrockProvider creates API key client for OpenAI subprovider."""
+    provider = BedrockProvider(
+        openai_api_key="test-api-key",
+        aws_region="us-east-1",
+    )
+    subprovider = provider._get_openai_provider()  # pyright: ignore[reportPrivateUsage]
+    assert subprovider.client.api_key == "test-api-key"
 
 
 def test_resolve_region_with_aws_profile_botocore_available(


### PR DESCRIPTION
### TL;DR

Added support for Amazon Bedrock's OpenAI-compatible API endpoints.

### What changed?

- Added `BedrockOpenAIProvider` and `BedrockOpenAIRoutedProvider` classes to support Amazon Bedrock's OpenAI-compatible API endpoints
- Implemented AWS SigV4 authentication for Bedrock OpenAI endpoints
- Updated the unified `BedrockProvider` to auto-route OpenAI-compatible model IDs (with `bedrock/openai.` prefix)
- Added comprehensive test coverage including VCR-based end-to-end tests

### How to test?

1. Install the package with AWS dependencies:
   ```
   pip install "mirascope[aws]"
   ```

2. Configure AWS credentials (either via environment variables or AWS config)

3. Use the provider with OpenAI-compatible models:
   ```python
   from mirascope import llm
   from mirascope.llm.messages import user

   # Direct usage
   provider = llm.get_provider("bedrock:openai")
   response = provider.call(
       model_id="bedrock/openai.gpt-oss-20b-1:0",
       messages=[user("Hello from Bedrock OpenAI")]
   )
   
   # Or via unified Bedrock provider
   provider = llm.get_provider("bedrock")
   response = provider.call(
       model_id="bedrock/openai.gpt-oss-20b-1:0",
       messages=[user("Hello from Bedrock OpenAI")]
   )
   ```

### Why make this change?

Amazon Bedrock recently added OpenAI-compatible API endpoints, allowing users to interact with Bedrock models using the OpenAI SDK. This change adds support for these endpoints, enabling users to leverage Bedrock's OpenAI-compatible models with the same familiar interface while maintaining the benefits of AWS infrastructure and security features like IAM-based authentication.