### PR TITLE
fix(ops): export sequence attrs as OTLP arrayValue

### DIFF
--- a/python/mirascope/ops/_internal/traced_functions.py
+++ b/python/mirascope/ops/_internal/traced_functions.py
@@ -200,7 +200,7 @@ class _BaseTracedFunction(_BaseFunction[P, R, FunctionT]):
                 "mirascope.trace.arg_values": json_dumps(arg_values),
             }
             if self.tags:
-                attributes["mirascope.trace.tags"] = self.tags
+                attributes["mirascope.trace.tags"] = list(self.tags)
             if self.metadata:
                 attributes["mirascope.trace.metadata"] = json_dumps(self.metadata)
             span.set(**attributes)
@@ -314,7 +314,7 @@ class _BaseTracedContextFunction(
                 "mirascope.trace.arg_values": json_dumps(arg_values),
             }
             if self.tags:
-                attributes["mirascope.trace.tags"] = self.tags
+                attributes["mirascope.trace.tags"] = list(self.tags)
             if self.metadata:
                 attributes["mirascope.trace.metadata"] = json_dumps(self.metadata)
             span.set(**attributes)

--- a/python/mirascope/ops/_internal/versioned_functions.py
+++ b/python/mirascope/ops/_internal/versioned_functions.py
@@ -196,7 +196,7 @@ class _BaseVersionedFunction(_BaseTracedFunction[P, R, Any]):
             if self.name:
                 span.set(**{"mirascope.version.name": self.name})
             if self.tags:
-                span.set(**{"mirascope.version.tags": self.tags})
+                span.set(**{"mirascope.version.tags": list(self.tags)})
             if self.metadata:
                 for key, value in self.metadata.items():
                     span.set(**{f"mirascope.version.meta.{key}": value})


### PR DESCRIPTION
### TL;DR

Improved attribute handling in OpenTelemetry exporters to properly support array values.

### What changed?

- Refactored attribute value conversion logic into utility functions (`to_fern_attribute_value` and `to_otlp_any_value`) to ensure consistent handling across different contexts
- Added proper support for array/sequence values in trace attributes, which are now exported as structured array values instead of string representations
- Fixed tag handling in traced and versioned functions by explicitly converting tag sets to lists
- Added comprehensive tests for the new array value handling functionality

### How to test?

1. Create spans with sequence attributes like:
   ```python
   span.set_attribute("mirascope.trace.tags", ["ml", "production"])
   ```

2. Verify that these are properly exported as array values in the OTLP format:
   ```python
   # Check that array values are properly structured
   assert trace_tags_value.array_value.values == [
       {"stringValue": "ml"},
       {"stringValue": "production"},
   ]
   ```

3. Run the new test cases that verify array value handling:
   - `test_span_sequence_attribute_exported_as_array_value`
   - `test_to_otlp_any_value_non_iterable_fallback`

### Why make this change?

The previous implementation converted sequence attributes to string representations, which lost their structured nature and made them harder to query and analyze in observability systems. This change ensures that array values maintain their structure throughout the export process, improving data fidelity and enabling better analysis of trace data.