### PR TITLE
refactor(python-sdk): Standardize on toolkits at Provider interface

### DIFF
--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -27,7 +27,16 @@ from ..responses import (
     Response,
     StreamResponse,
 )
-from ..tools import AsyncContextTools, AsyncTools, ContextTools, Tools
+from ..tools import (
+    AsyncContextTools,
+    AsyncTools,
+    ContextTools,
+    Tools,
+    normalize_async_context_tools,
+    normalize_async_tools,
+    normalize_context_tools,
+    normalize_tools,
+)
 from .params import Params
 
 MODEL_CONTEXT: ContextVar[Model | None] = ContextVar("MODEL_CONTEXT", default=None)
@@ -204,7 +213,7 @@ class Model:
         return self.provider.call(
             model_id=self.model_id,
             messages=messages,
-            tools=tools,
+            toolkit=normalize_tools(tools),
             format=format,
             **self.params,
         )
@@ -271,9 +280,9 @@ class Model:
         return await self.provider.call_async(
             model_id=self.model_id,
             messages=messages,
-            tools=tools,
-            **self.params,
+            toolkit=normalize_async_tools(tools),
             format=format,
+            **self.params,
         )
 
     @overload
@@ -338,7 +347,7 @@ class Model:
         return self.provider.stream(
             model_id=self.model_id,
             messages=messages,
-            tools=tools,
+            toolkit=normalize_tools(tools),
             format=format,
             **self.params,
         )
@@ -405,7 +414,7 @@ class Model:
         return await self.provider.stream_async(
             model_id=self.model_id,
             messages=messages,
-            tools=tools,
+            toolkit=normalize_async_tools(tools),
             format=format,
             **self.params,
         )
@@ -478,7 +487,7 @@ class Model:
             ctx=ctx,
             model_id=self.model_id,
             messages=messages,
-            tools=tools,
+            toolkit=normalize_context_tools(tools),
             format=format,
             **self.params,
         )
@@ -551,7 +560,7 @@ class Model:
             ctx=ctx,
             model_id=self.model_id,
             messages=messages,
-            tools=tools,
+            toolkit=normalize_async_context_tools(tools),
             format=format,
             **self.params,
         )
@@ -628,7 +637,7 @@ class Model:
             ctx=ctx,
             model_id=self.model_id,
             messages=messages,
-            tools=tools,
+            toolkit=normalize_context_tools(tools),
             format=format,
             **self.params,
         )
@@ -707,7 +716,7 @@ class Model:
             ctx=ctx,
             model_id=self.model_id,
             messages=messages,
-            tools=tools,
+            toolkit=normalize_async_context_tools(tools),
             format=format,
             **self.params,
         )

--- a/python/mirascope/llm/providers/anthropic/beta_provider.py
+++ b/python/mirascope/llm/providers/anthropic/beta_provider.py
@@ -22,10 +22,10 @@ from ...responses import (
     StreamResponse,
 )
 from ...tools import (
-    AsyncContextTools,
-    AsyncTools,
-    ContextTools,
-    Tools,
+    AsyncContextToolkit,
+    AsyncToolkit,
+    ContextToolkit,
+    Toolkit,
 )
 from ..base import BaseProvider
 from . import _utils
@@ -59,7 +59,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -70,7 +70,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = beta_encode.beta_encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -85,7 +85,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -99,7 +99,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -110,7 +110,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = beta_encode.beta_encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -125,7 +125,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -138,7 +138,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -149,7 +149,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = beta_encode.beta_encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -164,7 +164,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -178,7 +178,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -189,7 +189,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = beta_encode.beta_encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -204,7 +204,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -217,7 +217,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -228,7 +228,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = beta_encode.beta_encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -242,7 +242,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=resolved_format,
@@ -254,7 +254,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -265,7 +265,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = beta_encode.beta_encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -279,7 +279,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=resolved_format,
@@ -290,7 +290,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -301,7 +301,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = beta_encode.beta_encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -315,7 +315,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=resolved_format,
@@ -327,7 +327,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -341,7 +341,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = beta_encode.beta_encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -355,7 +355,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=resolved_format,

--- a/python/mirascope/llm/providers/anthropic/provider.py
+++ b/python/mirascope/llm/providers/anthropic/provider.py
@@ -23,11 +23,11 @@ from ...responses import (
 )
 from ...tools import (
     AnyToolSchema,
-    AsyncContextTools,
-    AsyncTools,
+    AsyncContextToolkit,
+    AsyncToolkit,
     BaseToolkit,
-    ContextTools,
-    Tools,
+    ContextToolkit,
+    Toolkit,
 )
 from ..base import BaseProvider, _utils as _base_utils
 from . import _utils
@@ -45,7 +45,7 @@ def _should_use_beta(
     | Format[FormattableT]
     | OutputParser[FormattableT]
     | None,
-    tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
+    tools: BaseToolkit[AnyToolSchema],
 ) -> bool:
     """Determine whether to use the beta API based on format mode or strict tools.
 
@@ -61,7 +61,7 @@ def _should_use_beta(
     if resolved is not None and resolved.mode == "strict":
         return True
 
-    return _base_utils.has_strict_tools(tools)
+    return _base_utils.has_strict_tools(tools.tools)
 
 
 class AnthropicProvider(BaseProvider[Anthropic]):
@@ -89,7 +89,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -97,11 +97,11 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the Anthropic Messages API."""
-        if _should_use_beta(model_id, format, tools):
+        if _should_use_beta(model_id, format, toolkit):
             return self._beta_provider.call(
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -109,7 +109,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -124,7 +124,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -138,7 +138,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -146,12 +146,12 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling the Anthropic Messages API."""
-        if _should_use_beta(model_id, format, tools):
+        if _should_use_beta(model_id, format, toolkit):
             return self._beta_provider.context_call(
                 ctx=ctx,
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -159,7 +159,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -174,7 +174,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -187,7 +187,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -195,11 +195,11 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the Anthropic Messages API."""
-        if _should_use_beta(model_id, format, tools):
+        if _should_use_beta(model_id, format, toolkit):
             return await self._beta_provider.call_async(
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -207,7 +207,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -222,7 +222,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -236,7 +236,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -244,12 +244,12 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling the Anthropic Messages API."""
-        if _should_use_beta(model_id, format, tools):
+        if _should_use_beta(model_id, format, toolkit):
             return await self._beta_provider.context_call_async(
                 ctx=ctx,
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -257,7 +257,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -272,7 +272,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -285,7 +285,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -293,11 +293,11 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from the Anthropic Messages API."""
-        if _should_use_beta(model_id, format, tools):
+        if _should_use_beta(model_id, format, toolkit):
             return self._beta_provider.stream(
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -305,7 +305,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -319,7 +319,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=resolved_format,
@@ -331,7 +331,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -339,12 +339,12 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from the Anthropic Messages API."""
-        if _should_use_beta(model_id, format, tools):
+        if _should_use_beta(model_id, format, toolkit):
             return self._beta_provider.context_stream(
                 ctx=ctx,
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -352,7 +352,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -366,7 +366,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=resolved_format,
@@ -377,7 +377,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -385,18 +385,18 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from the Anthropic Messages API."""
-        if _should_use_beta(model_id, format, tools):
+        if _should_use_beta(model_id, format, toolkit):
             return await self._beta_provider.stream_async(
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
         input_messages, resolved_format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -410,7 +410,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=resolved_format,
@@ -422,7 +422,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -433,12 +433,12 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         | AsyncContextStreamResponse[DepsT, FormattableT]
     ):
         """Generate an `llm.AsyncContextStreamResponse` by asynchronously streaming from the Anthropic Messages API."""
-        if _should_use_beta(model_id, format, tools):
+        if _should_use_beta(model_id, format, toolkit):
             return await self._beta_provider.context_stream_async(
                 ctx=ctx,
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -446,7 +446,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         input_messages, resolved_format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -460,7 +460,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=resolved_format,

--- a/python/mirascope/llm/providers/base/_utils.py
+++ b/python/mirascope/llm/providers/base/_utils.py
@@ -10,7 +10,7 @@ from ...messages import AssistantMessage, Message, SystemMessage, UserMessage
 from ...models.params import (
     Params,  # Import directly from params.py to avoid circular dependency
 )
-from ...tools import AnyToolSchema, BaseToolkit
+from ...tools import AnyToolSchema
 from ..provider_id import ProviderId
 
 if TYPE_CHECKING:
@@ -28,21 +28,16 @@ def get_include_thoughts(params: Params) -> bool:
     return (thinking_config or {}).get("include_thoughts", False)
 
 
-def has_strict_tools(
-    tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-) -> bool:
+def has_strict_tools(tools: Sequence[AnyToolSchema]) -> bool:
     """Check if any tools have strict=True explicitly set.
 
     Args:
-        tools: The tools to check, either a sequence or a toolkit
+        tools: The tools to check
 
     Returns:
         True if any tool has strict=True, False otherwise
     """
-    if tools is None:
-        return False
-    tools_list = tools.tools if isinstance(tools, BaseToolkit) else tools
-    return any(tool.strict is True for tool in tools_list)
+    return any(tool.strict is True for tool in tools)
 
 
 def ensure_additional_properties_false(obj: object) -> None:

--- a/python/mirascope/llm/providers/base/base_provider.py
+++ b/python/mirascope/llm/providers/base/base_provider.py
@@ -25,10 +25,10 @@ from ...responses import (
     StreamResponse,
 )
 from ...tools import (
-    AsyncContextTools,
-    AsyncTools,
-    ContextTools,
-    Tools,
+    AsyncContextToolkit,
+    AsyncToolkit,
+    ContextToolkit,
+    Toolkit,
 )
 
 if TYPE_CHECKING:
@@ -146,7 +146,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: None = None,
         **params: Unpack[Params],
     ) -> Response:
@@ -159,7 +159,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> Response[FormattableT]:
@@ -172,7 +172,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -187,7 +187,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -210,7 +210,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
             return self._call(
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -221,7 +221,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -238,7 +238,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None]:
@@ -252,7 +252,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, FormattableT]:
@@ -266,7 +266,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -282,7 +282,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -307,7 +307,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
                 ctx=ctx,
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -319,7 +319,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -335,7 +335,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse:
@@ -348,7 +348,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncResponse[FormattableT]:
@@ -361,7 +361,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -376,7 +376,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -399,7 +399,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
             return await self._call_async(
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -410,7 +410,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -427,7 +427,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None]:
@@ -441,7 +441,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, FormattableT]:
@@ -455,7 +455,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -471,7 +471,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -496,7 +496,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
                 ctx=ctx,
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -508,7 +508,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -524,7 +524,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: None = None,
         **params: Unpack[Params],
     ) -> StreamResponse:
@@ -537,7 +537,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> StreamResponse[FormattableT]:
@@ -550,7 +550,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -565,7 +565,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -588,7 +588,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
             stream_response = self._stream(
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -603,7 +603,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -620,7 +620,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT, None]:
@@ -634,7 +634,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT, FormattableT]:
@@ -648,7 +648,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -666,7 +666,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -693,7 +693,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
                 ctx=ctx,
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -709,7 +709,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -727,7 +727,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse:
@@ -740,7 +740,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncStreamResponse[FormattableT]:
@@ -753,7 +753,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -768,7 +768,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -791,7 +791,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
             stream_response = await self._stream_async(
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -806,7 +806,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -823,7 +823,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT, None]:
@@ -837,7 +837,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
@@ -851,7 +851,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -870,7 +870,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -898,7 +898,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
                 ctx=ctx,
                 model_id=model_id,
                 messages=messages,
-                tools=tools,
+                toolkit=toolkit,
                 format=format,
                 **params,
             )
@@ -914,7 +914,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -991,7 +991,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         return self.call(
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit,
+            toolkit=response.toolkit,
             format=response.format,
             **params,
         )
@@ -1060,7 +1060,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         return await self.call_async(
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit,
+            toolkit=response.toolkit,
             format=response.format,
             **params,
         )
@@ -1135,7 +1135,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit,
+            toolkit=response.toolkit,
             format=response.format,
             **params,
         )
@@ -1212,7 +1212,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit,
+            toolkit=response.toolkit,
             format=response.format,
             **params,
         )
@@ -1281,7 +1281,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         return self.stream(
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit,
+            toolkit=response.toolkit,
             format=response.format,
             **params,
         )
@@ -1350,7 +1350,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         return await self.stream_async(
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit,
+            toolkit=response.toolkit,
             format=response.format,
             **params,
         )
@@ -1431,7 +1431,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit,
+            toolkit=response.toolkit,
             format=response.format,
             **params,
         )
@@ -1514,7 +1514,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit,
+            toolkit=response.toolkit,
             format=response.format,
             **params,
         )

--- a/python/mirascope/llm/providers/google/provider.py
+++ b/python/mirascope/llm/providers/google/provider.py
@@ -23,10 +23,10 @@ from ...responses import (
     StreamResponse,
 )
 from ...tools import (
-    AsyncContextTools,
-    AsyncTools,
-    ContextTools,
-    Tools,
+    AsyncContextToolkit,
+    AsyncToolkit,
+    ContextToolkit,
+    Toolkit,
 )
 from ..base import BaseProvider
 from . import _utils
@@ -65,7 +65,7 @@ class GoogleProvider(BaseProvider[Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -87,7 +87,7 @@ class GoogleProvider(BaseProvider[Client]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -104,7 +104,7 @@ class GoogleProvider(BaseProvider[Client]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -118,7 +118,7 @@ class GoogleProvider(BaseProvider[Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -141,7 +141,7 @@ class GoogleProvider(BaseProvider[Client]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -158,7 +158,7 @@ class GoogleProvider(BaseProvider[Client]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -171,7 +171,7 @@ class GoogleProvider(BaseProvider[Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -193,7 +193,7 @@ class GoogleProvider(BaseProvider[Client]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -210,7 +210,7 @@ class GoogleProvider(BaseProvider[Client]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -224,7 +224,7 @@ class GoogleProvider(BaseProvider[Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -247,7 +247,7 @@ class GoogleProvider(BaseProvider[Client]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -264,7 +264,7 @@ class GoogleProvider(BaseProvider[Client]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -277,7 +277,7 @@ class GoogleProvider(BaseProvider[Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -299,7 +299,7 @@ class GoogleProvider(BaseProvider[Client]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -316,7 +316,7 @@ class GoogleProvider(BaseProvider[Client]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -328,7 +328,7 @@ class GoogleProvider(BaseProvider[Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -351,7 +351,7 @@ class GoogleProvider(BaseProvider[Client]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -368,7 +368,7 @@ class GoogleProvider(BaseProvider[Client]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -379,7 +379,7 @@ class GoogleProvider(BaseProvider[Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -401,7 +401,7 @@ class GoogleProvider(BaseProvider[Client]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -418,7 +418,7 @@ class GoogleProvider(BaseProvider[Client]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -430,7 +430,7 @@ class GoogleProvider(BaseProvider[Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -456,7 +456,7 @@ class GoogleProvider(BaseProvider[Client]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -473,7 +473,7 @@ class GoogleProvider(BaseProvider[Client]):
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,

--- a/python/mirascope/llm/providers/mirascope/provider.py
+++ b/python/mirascope/llm/providers/mirascope/provider.py
@@ -21,10 +21,10 @@ from ...responses import (
     StreamResponse,
 )
 from ...tools import (
-    AsyncContextTools,
-    AsyncTools,
-    ContextTools,
-    Tools,
+    AsyncContextToolkit,
+    AsyncToolkit,
+    ContextToolkit,
+    Toolkit,
 )
 from ..base import BaseProvider, Provider
 from . import _utils
@@ -152,7 +152,7 @@ class MirascopeProvider(BaseProvider[None]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -164,7 +164,7 @@ class MirascopeProvider(BaseProvider[None]):
         return provider.call(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -175,7 +175,7 @@ class MirascopeProvider(BaseProvider[None]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -188,7 +188,7 @@ class MirascopeProvider(BaseProvider[None]):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -198,7 +198,7 @@ class MirascopeProvider(BaseProvider[None]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -210,7 +210,7 @@ class MirascopeProvider(BaseProvider[None]):
         return await provider.call_async(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -221,7 +221,7 @@ class MirascopeProvider(BaseProvider[None]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -234,7 +234,7 @@ class MirascopeProvider(BaseProvider[None]):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -244,7 +244,7 @@ class MirascopeProvider(BaseProvider[None]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -256,7 +256,7 @@ class MirascopeProvider(BaseProvider[None]):
         return provider.stream(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -267,7 +267,7 @@ class MirascopeProvider(BaseProvider[None]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -282,7 +282,7 @@ class MirascopeProvider(BaseProvider[None]):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -292,7 +292,7 @@ class MirascopeProvider(BaseProvider[None]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -304,7 +304,7 @@ class MirascopeProvider(BaseProvider[None]):
         return await provider.stream_async(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -315,7 +315,7 @@ class MirascopeProvider(BaseProvider[None]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -331,7 +331,7 @@ class MirascopeProvider(BaseProvider[None]):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )

--- a/python/mirascope/llm/providers/mlx/encoding/base.py
+++ b/python/mirascope/llm/providers/mlx/encoding/base.py
@@ -21,7 +21,7 @@ class BaseEncoder(abc.ABC):
     def encode_request(
         self,
         messages: Sequence[Message],
-        tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
+        tools: BaseToolkit[AnyToolSchema],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]

--- a/python/mirascope/llm/providers/mlx/encoding/transformers.py
+++ b/python/mirascope/llm/providers/mlx/encoding/transformers.py
@@ -80,15 +80,14 @@ class TransformersEncoder(BaseEncoder):
     def encode_request(
         self,
         messages: Sequence[Message],
-        tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
+        tools: BaseToolkit[AnyToolSchema],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
         | None,
     ) -> tuple[Sequence[Message], Format[FormattableT] | None, TokenIds]:
         """Encode a request into a format suitable for the model."""
-        tool_schemas = tools.tools if isinstance(tools, BaseToolkit) else tools or []
-        if len(tool_schemas) > 0:
+        if tools.tools:
             raise NotImplementedError("Tool usage is not supported.")
         if format is not None:
             raise NotImplementedError("Formatting is not supported.")

--- a/python/mirascope/llm/providers/mlx/mlx.py
+++ b/python/mirascope/llm/providers/mlx/mlx.py
@@ -137,7 +137,7 @@ class MLX:
     def stream(
         self,
         messages: Sequence[Message],
-        tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
+        tools: BaseToolkit[AnyToolSchema],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -163,7 +163,7 @@ class MLX:
     async def stream_async(
         self,
         messages: Sequence[Message],
-        tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
+        tools: BaseToolkit[AnyToolSchema],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -190,7 +190,7 @@ class MLX:
     def generate(
         self,
         messages: Sequence[Message],
-        tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
+        tools: BaseToolkit[AnyToolSchema],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -229,7 +229,7 @@ class MLX:
     async def generate_async(
         self,
         messages: Sequence[Message],
-        tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
+        tools: BaseToolkit[AnyToolSchema],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]

--- a/python/mirascope/llm/providers/mlx/provider.py
+++ b/python/mirascope/llm/providers/mlx/provider.py
@@ -23,10 +23,10 @@ from ...responses import (
     StreamResponse,
 )
 from ...tools import (
-    AsyncContextTools,
-    AsyncTools,
-    ContextTools,
-    Tools,
+    AsyncContextToolkit,
+    AsyncToolkit,
+    ContextToolkit,
+    Toolkit,
 )
 from ..base import BaseProvider
 from . import _utils
@@ -85,7 +85,7 @@ class MLXProvider(BaseProvider[None]):
         *,
         model_id: MLXModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -107,7 +107,7 @@ class MLXProvider(BaseProvider[None]):
         mlx = _get_mlx(model_id)
 
         input_messages, format, assistant_message, response = mlx.generate(
-            messages, tools, format, params
+            messages, toolkit, format, params
         )
 
         return Response(
@@ -116,7 +116,7 @@ class MLXProvider(BaseProvider[None]):
             model_id=model_id,
             provider_model_name=model_id,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=_utils.extract_finish_reason(response),
@@ -130,7 +130,7 @@ class MLXProvider(BaseProvider[None]):
         ctx: Context[DepsT],
         model_id: MLXModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -153,7 +153,7 @@ class MLXProvider(BaseProvider[None]):
         mlx = _get_mlx(model_id)
 
         input_messages, format, assistant_message, response = mlx.generate(
-            messages, tools, format, params
+            messages, toolkit, format, params
         )
 
         return ContextResponse(
@@ -162,7 +162,7 @@ class MLXProvider(BaseProvider[None]):
             model_id=model_id,
             provider_model_name=model_id,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=_utils.extract_finish_reason(response),
@@ -175,7 +175,7 @@ class MLXProvider(BaseProvider[None]):
         *,
         model_id: MLXModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -202,7 +202,7 @@ class MLXProvider(BaseProvider[None]):
             format,
             assistant_message,
             response,
-        ) = await mlx.generate_async(messages, tools, format, params)
+        ) = await mlx.generate_async(messages, toolkit, format, params)
 
         return AsyncResponse(
             raw=response,
@@ -210,7 +210,7 @@ class MLXProvider(BaseProvider[None]):
             model_id=model_id,
             provider_model_name=model_id,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=_utils.extract_finish_reason(response),
@@ -224,7 +224,7 @@ class MLXProvider(BaseProvider[None]):
         ctx: Context[DepsT],
         model_id: MLXModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -252,7 +252,7 @@ class MLXProvider(BaseProvider[None]):
             format,
             assistant_message,
             response,
-        ) = await mlx.generate_async(messages, tools, format, params)
+        ) = await mlx.generate_async(messages, toolkit, format, params)
 
         return AsyncContextResponse(
             raw=response,
@@ -260,7 +260,7 @@ class MLXProvider(BaseProvider[None]):
             model_id=model_id,
             provider_model_name=model_id,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=_utils.extract_finish_reason(response),
@@ -273,7 +273,7 @@ class MLXProvider(BaseProvider[None]):
         *,
         model_id: MLXModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -295,7 +295,7 @@ class MLXProvider(BaseProvider[None]):
         mlx = _get_mlx(model_id)
 
         input_messages, format, chunk_iterator = mlx.stream(
-            messages, tools, format, params
+            messages, toolkit, format, params
         )
 
         return StreamResponse(
@@ -303,7 +303,7 @@ class MLXProvider(BaseProvider[None]):
             model_id=model_id,
             provider_model_name=model_id,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -315,7 +315,7 @@ class MLXProvider(BaseProvider[None]):
         ctx: Context[DepsT],
         model_id: MLXModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -338,7 +338,7 @@ class MLXProvider(BaseProvider[None]):
         mlx = _get_mlx(model_id)
 
         input_messages, format, chunk_iterator = mlx.stream(
-            messages, tools, format, params
+            messages, toolkit, format, params
         )
 
         return ContextStreamResponse(
@@ -346,7 +346,7 @@ class MLXProvider(BaseProvider[None]):
             model_id=model_id,
             provider_model_name=model_id,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -357,7 +357,7 @@ class MLXProvider(BaseProvider[None]):
         *,
         model_id: MLXModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -379,7 +379,7 @@ class MLXProvider(BaseProvider[None]):
         mlx = _get_mlx(model_id)
 
         input_messages, format, chunk_iterator = await mlx.stream_async(
-            messages, tools, format, params
+            messages, toolkit, format, params
         )
 
         return AsyncStreamResponse(
@@ -387,7 +387,7 @@ class MLXProvider(BaseProvider[None]):
             model_id=model_id,
             provider_model_name=model_id,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -399,7 +399,7 @@ class MLXProvider(BaseProvider[None]):
         ctx: Context[DepsT],
         model_id: MLXModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -425,7 +425,7 @@ class MLXProvider(BaseProvider[None]):
         mlx = _get_mlx(model_id)
 
         input_messages, format, chunk_iterator = await mlx.stream_async(
-            messages, tools, format, params
+            messages, toolkit, format, params
         )
 
         return AsyncContextStreamResponse(
@@ -433,7 +433,7 @@ class MLXProvider(BaseProvider[None]):
             model_id=model_id,
             provider_model_name=model_id,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,

--- a/python/mirascope/llm/providers/openai/completions/_utils/encode.py
+++ b/python/mirascope/llm/providers/openai/completions/_utils/encode.py
@@ -280,7 +280,7 @@ def encode_request(
     *,
     model_id: OpenAIModelId,
     messages: Sequence[Message],
-    tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
+    tools: BaseToolkit[AnyToolSchema],
     format: type[FormattableT]
     | Format[FormattableT]
     | OutputParser[FormattableT]
@@ -325,9 +325,7 @@ def encode_request(
             if thinking.get("encode_thoughts_as_text"):
                 encode_thoughts_as_text = True
 
-    tools = tools.tools if isinstance(tools, BaseToolkit) else tools or []
-
-    openai_tools = [_convert_tool_to_tool_param(tool) for tool in tools]
+    openai_tools = [_convert_tool_to_tool_param(tool) for tool in tools.tools]
 
     model_supports_strict = base_model_name not in MODELS_WITHOUT_JSON_SCHEMA_SUPPORT
     default_mode = "strict" if model_supports_strict else "tool"
@@ -342,7 +340,7 @@ def encode_request(
                 )
             kwargs["response_format"] = _create_strict_response_format(format)
         elif format.mode == "tool":
-            if tools:
+            if tools.tools:
                 kwargs["tool_choice"] = "required"
             else:
                 kwargs["tool_choice"] = {

--- a/python/mirascope/llm/providers/openai/completions/base_provider.py
+++ b/python/mirascope/llm/providers/openai/completions/base_provider.py
@@ -22,7 +22,7 @@ from ....responses import (
     Response,
     StreamResponse,
 )
-from ....tools import AsyncContextTools, AsyncTools, ContextTools, Tools
+from ....tools import AsyncContextToolkit, AsyncToolkit, ContextToolkit, Toolkit
 from ...base import BaseProvider
 from .. import _utils as _shared_utils
 from ..model_id import model_name as openai_model_name
@@ -92,7 +92,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -114,7 +114,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -134,7 +134,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=self._provider_model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -148,7 +148,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -171,7 +171,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -191,7 +191,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=self._provider_model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -204,7 +204,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -227,7 +227,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             params=params,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
         )
         kwargs["model"] = self._model_name(model_id)
@@ -246,7 +246,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=self._provider_model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -260,7 +260,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -284,7 +284,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             params=params,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
         )
         kwargs["model"] = self._model_name(model_id)
@@ -303,7 +303,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=self._provider_model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -316,7 +316,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -338,7 +338,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -356,7 +356,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=self._provider_model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -368,7 +368,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -391,7 +391,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -410,7 +410,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=self._provider_model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -421,7 +421,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         *,
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -443,7 +443,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -461,7 +461,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=self._provider_model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -473,7 +473,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: str,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -499,7 +499,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         input_messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -518,7 +518,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=self._provider_model_name(model_id),
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
             format=format,

--- a/python/mirascope/llm/providers/openai/provider.py
+++ b/python/mirascope/llm/providers/openai/provider.py
@@ -23,10 +23,10 @@ from ...responses import (
     StreamResponse,
 )
 from ...tools import (
-    AsyncContextTools,
-    AsyncTools,
-    ContextTools,
-    Tools,
+    AsyncContextToolkit,
+    AsyncToolkit,
+    ContextToolkit,
+    Toolkit,
 )
 from ..base import BaseProvider
 from . import _utils
@@ -158,7 +158,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -181,7 +181,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         return client.call(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -192,7 +192,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -217,7 +217,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -227,7 +227,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -249,7 +249,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         return await self._choose_subprovider(model_id, messages).call_async(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -260,7 +260,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -284,7 +284,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -294,7 +294,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -317,7 +317,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         return client.stream(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -328,7 +328,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -353,7 +353,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -363,7 +363,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -385,7 +385,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         return await self._choose_subprovider(model_id, messages).stream_async(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )
@@ -396,7 +396,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -423,7 +423,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            toolkit=toolkit,
             format=format,
             **params,
         )

--- a/python/mirascope/llm/providers/openai/responses/_utils/encode.py
+++ b/python/mirascope/llm/providers/openai/responses/_utils/encode.py
@@ -281,7 +281,7 @@ def encode_request(
     *,
     model_id: OpenAIModelId,
     messages: Sequence[Message],
-    tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
+    tools: BaseToolkit[AnyToolSchema],
     format: type[FormattableT]
     | Format[FormattableT]
     | OutputParser[FormattableT]
@@ -334,8 +334,7 @@ def encode_request(
             if thinking_config.get("encode_thoughts_as_text"):
                 encode_thoughts = True
 
-    tools = tools.tools if isinstance(tools, BaseToolkit) else tools or []
-    openai_tools = [_convert_tool_to_function_tool_param(tool) for tool in tools]
+    openai_tools = [_convert_tool_to_function_tool_param(tool) for tool in tools.tools]
 
     model_supports_strict = model_id not in MODELS_WITHOUT_JSON_SCHEMA_SUPPORT
     default_mode = "strict" if model_supports_strict else "tool"
@@ -349,7 +348,7 @@ def encode_request(
             openai_tools.append(
                 _convert_tool_to_function_tool_param(format_tool_schema)
             )
-            if tools:
+            if tools.tools:
                 kwargs["tool_choice"] = ToolChoiceAllowedParam(
                     type="allowed_tools",
                     mode="required",

--- a/python/mirascope/llm/providers/openai/responses/provider.py
+++ b/python/mirascope/llm/providers/openai/responses/provider.py
@@ -22,7 +22,7 @@ from ....responses import (
     Response,
     StreamResponse,
 )
-from ....tools import AsyncContextTools, AsyncTools, ContextTools, Tools
+from ....tools import AsyncContextToolkit, AsyncToolkit, ContextToolkit, Toolkit
 from ...base import BaseProvider
 from .. import _utils as _shared_utils
 from ..model_id import OpenAIModelId, model_name
@@ -63,7 +63,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -85,7 +85,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -103,7 +103,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -116,7 +116,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -138,7 +138,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -156,7 +156,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -169,7 +169,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Tools | None = None,
+        toolkit: Toolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -191,7 +191,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -211,7 +211,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -222,7 +222,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: AsyncTools | None = None,
+        toolkit: AsyncToolkit,
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -244,7 +244,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -264,7 +264,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -276,7 +276,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -299,7 +299,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -317,7 +317,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -331,7 +331,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -354,7 +354,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -372,7 +372,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=messages,
             assistant_message=assistant_message,
             finish_reason=finish_reason,
@@ -386,7 +386,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: ContextTools[DepsT] | None = None,
+        toolkit: ContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -409,7 +409,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -430,7 +430,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=messages,
             chunk_iterator=chunk_iterator,
             format=format,
@@ -442,7 +442,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: AsyncContextTools[DepsT] | None = None,
+        toolkit: AsyncContextToolkit[DepsT],
         format: type[FormattableT]
         | Format[FormattableT]
         | OutputParser[FormattableT]
@@ -468,7 +468,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         messages, format, kwargs = _utils.encode_request(
             model_id=model_id,
             messages=messages,
-            tools=tools,
+            tools=toolkit,
             format=format,
             params=params,
         )
@@ -489,7 +489,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
-            tools=tools,
+            tools=toolkit,
             input_messages=messages,
             chunk_iterator=chunk_iterator,
             format=format,

--- a/python/mirascope/llm/tools/__init__.py
+++ b/python/mirascope/llm/tools/__init__.py
@@ -19,7 +19,17 @@ from .toolkit import (
     ToolkitT,
 )
 from .tools import AsyncContextTool, AsyncTool, ContextTool, Tool, ToolT
-from .types import AnyTools, AsyncContextTools, AsyncTools, ContextTools, Tools
+from .types import (
+    AnyTools,
+    AsyncContextTools,
+    AsyncTools,
+    ContextTools,
+    Tools,
+    normalize_async_context_tools,
+    normalize_async_tools,
+    normalize_context_tools,
+    normalize_tools,
+)
 
 __all__ = [
     "FORMAT_TOOL_NAME",
@@ -49,5 +59,9 @@ __all__ = [
     "Toolkit",
     "ToolkitT",
     "Tools",
+    "normalize_async_context_tools",
+    "normalize_async_tools",
+    "normalize_context_tools",
+    "normalize_tools",
     "tool",
 ]

--- a/python/mirascope/llm/tools/types.py
+++ b/python/mirascope/llm/tools/types.py
@@ -36,3 +36,71 @@ AsyncContextTools = TypeAliasType(
     type_params=(DepsT,),
 )
 """Type alias for async context tool parameters: a sequence of AsyncTools/AsyncContextTools or an AsyncContextToolkit."""
+
+
+def normalize_tools(tools: Tools | None) -> Toolkit:
+    """Normalize tools input to a Toolkit.
+
+    Args:
+        tools: A sequence of Tools, a Toolkit, or None.
+
+    Returns:
+        A Toolkit containing the tools (or an empty Toolkit if None).
+    """
+    if tools is None:
+        return Toolkit(None)
+    if isinstance(tools, Toolkit):
+        return tools
+    return Toolkit(tools)
+
+
+def normalize_async_tools(tools: AsyncTools | None) -> AsyncToolkit:
+    """Normalize async tools input to an AsyncToolkit.
+
+    Args:
+        tools: A sequence of AsyncTools, an AsyncToolkit, or None.
+
+    Returns:
+        An AsyncToolkit containing the tools (or an empty AsyncToolkit if None).
+    """
+    if tools is None:
+        return AsyncToolkit(None)
+    if isinstance(tools, AsyncToolkit):
+        return tools
+    return AsyncToolkit(tools)
+
+
+def normalize_context_tools(
+    tools: ContextTools[DepsT] | None,
+) -> ContextToolkit[DepsT]:
+    """Normalize context tools input to a ContextToolkit.
+
+    Args:
+        tools: A sequence of Tools/ContextTools, a ContextToolkit, or None.
+
+    Returns:
+        A ContextToolkit containing the tools (or an empty ContextToolkit if None).
+    """
+    if tools is None:
+        return ContextToolkit(None)
+    if isinstance(tools, ContextToolkit):
+        return tools
+    return ContextToolkit(tools)
+
+
+def normalize_async_context_tools(
+    tools: AsyncContextTools[DepsT] | None,
+) -> AsyncContextToolkit[DepsT]:
+    """Normalize async context tools input to an AsyncContextToolkit.
+
+    Args:
+        tools: A sequence of AsyncTools/AsyncContextTools, an AsyncContextToolkit, or None.
+
+    Returns:
+        An AsyncContextToolkit containing the tools (or an empty AsyncContextToolkit if None).
+    """
+    if tools is None:
+        return AsyncContextToolkit(None)
+    if isinstance(tools, AsyncContextToolkit):
+        return tools
+    return AsyncContextToolkit(tools)

--- a/python/tests/llm/providers/base/test_utils.py
+++ b/python/tests/llm/providers/base/test_utils.py
@@ -270,6 +270,6 @@ def test_ensure_all_properties_required_no_properties_key() -> None:
     assert "required" not in schema
 
 
-def test_has_strict_tools_with_none() -> None:
-    """Test that has_strict_tools returns False when tools is None."""
-    assert _utils.has_strict_tools(None) is False
+def test_has_strict_tools_with_empty_list() -> None:
+    """Test that has_strict_tools returns False when tools is an empty list."""
+    assert _utils.has_strict_tools([]) is False

--- a/python/tests/llm/providers/openai/test_completions_encoding.py
+++ b/python/tests/llm/providers/openai/test_completions_encoding.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from mirascope import llm
 from mirascope.llm.providers.openai.completions._utils import encode_request
+from mirascope.llm.tools import Toolkit
 
 
 def test_prepare_message_multiple_user_text_parts() -> None:
@@ -18,7 +19,11 @@ def test_prepare_message_multiple_user_text_parts() -> None:
         llm.messages.user(["Hello there", "fellow humans"]),
     ]
     assert encode_request(
-        model_id="openai/gpt-4o", messages=messages, format=None, tools=None, params={}
+        model_id="openai/gpt-4o",
+        messages=messages,
+        format=None,
+        tools=Toolkit(None),
+        params={},
     ) == snapshot(
         (
             [
@@ -61,7 +66,11 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
         ),
     ]
     assert encode_request(
-        model_id="openai/gpt-4o", messages=messages, format=None, tools=None, params={}
+        model_id="openai/gpt-4o",
+        messages=messages,
+        format=None,
+        tools=Toolkit(None),
+        params={},
     ) == snapshot(
         (
             [
@@ -110,6 +119,6 @@ def test_strict_unsupported_legacy_model() -> None:
             model_id="openai/gpt-4",
             messages=messages,
             format=format,
-            tools=None,
+            tools=Toolkit(None),
             params={},
         )

--- a/python/tests/llm/providers/openai/test_responses_encoding.py
+++ b/python/tests/llm/providers/openai/test_responses_encoding.py
@@ -4,6 +4,7 @@ from inline_snapshot import snapshot
 
 from mirascope import llm
 from mirascope.llm.providers.openai.responses._utils import encode_request
+from mirascope.llm.tools import Toolkit
 
 
 def test_prepare_message_multiple_assistant_text_parts() -> None:
@@ -24,7 +25,7 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
         model_id="openai/gpt-4o",
         messages=messages,
         format=None,
-        tools=None,
+        tools=Toolkit(None),
         params={},
     )
     assert kwargs == snapshot(
@@ -51,7 +52,7 @@ def test_prepare_message_multiple_system_messages() -> None:
         model_id="openai/gpt-4o",
         messages=messages,
         format=None,
-        tools=None,
+        tools=Toolkit(None),
         params={},
     )
     assert kwargs == snapshot(

--- a/python/tests/llm/providers/test_mirascope_provider.py
+++ b/python/tests/llm/providers/test_mirascope_provider.py
@@ -7,6 +7,12 @@ import pytest
 
 from mirascope.llm.providers.mirascope import _utils
 from mirascope.llm.providers.mirascope.provider import MirascopeProvider
+from mirascope.llm.tools import (
+    AsyncContextToolkit,
+    AsyncToolkit,
+    ContextToolkit,
+    Toolkit,
+)
 
 
 class TestMirascopeUtils:
@@ -205,7 +211,7 @@ class TestMirascopeProvider:
         mock_create_provider.return_value = mock_underlying
 
         provider = MirascopeProvider(api_key="test-key")
-        provider._call(model_id="openai/gpt-4", messages=[])  # pyright: ignore[reportPrivateUsage]
+        provider._call(model_id="openai/gpt-4", messages=[], toolkit=Toolkit(None))  # pyright: ignore[reportPrivateUsage]
 
         mock_underlying.call.assert_called_once()
 
@@ -222,7 +228,9 @@ class TestMirascopeProvider:
 
         provider = MirascopeProvider(api_key="test-key")
         ctx = Context(deps={})
-        provider._context_call(ctx=ctx, model_id="openai/gpt-4", messages=[])  # pyright: ignore[reportPrivateUsage]
+        provider._context_call(  # pyright: ignore[reportPrivateUsage]
+            ctx=ctx, model_id="openai/gpt-4", messages=[], toolkit=ContextToolkit(None)
+        )
 
         mock_underlying.context_call.assert_called_once()
 
@@ -237,7 +245,9 @@ class TestMirascopeProvider:
         mock_create_provider.return_value = mock_underlying
 
         provider = MirascopeProvider(api_key="test-key")
-        await provider._call_async(model_id="openai/gpt-4", messages=[])  # pyright: ignore[reportPrivateUsage]
+        await provider._call_async(  # pyright: ignore[reportPrivateUsage]
+            model_id="openai/gpt-4", messages=[], toolkit=AsyncToolkit(None)
+        )
 
         mock_underlying.call_async.assert_called_once()
 
@@ -256,7 +266,10 @@ class TestMirascopeProvider:
         provider = MirascopeProvider(api_key="test-key")
         ctx = Context(deps={})
         await provider._context_call_async(  # pyright: ignore[reportPrivateUsage]
-            ctx=ctx, model_id="openai/gpt-4", messages=[]
+            ctx=ctx,
+            model_id="openai/gpt-4",
+            messages=[],
+            toolkit=AsyncContextToolkit(None),
         )
 
         mock_underlying.context_call_async.assert_called_once()
@@ -271,7 +284,7 @@ class TestMirascopeProvider:
         mock_create_provider.return_value = mock_underlying
 
         provider = MirascopeProvider(api_key="test-key")
-        provider._stream(model_id="openai/gpt-4", messages=[])  # pyright: ignore[reportPrivateUsage]
+        provider._stream(model_id="openai/gpt-4", messages=[], toolkit=Toolkit(None))  # pyright: ignore[reportPrivateUsage]
 
         mock_underlying.stream.assert_called_once()
 
@@ -288,7 +301,9 @@ class TestMirascopeProvider:
 
         provider = MirascopeProvider(api_key="test-key")
         ctx = Context(deps={})
-        provider._context_stream(ctx=ctx, model_id="openai/gpt-4", messages=[])  # pyright: ignore[reportPrivateUsage]
+        provider._context_stream(  # pyright: ignore[reportPrivateUsage]
+            ctx=ctx, model_id="openai/gpt-4", messages=[], toolkit=ContextToolkit(None)
+        )
 
         mock_underlying.context_stream.assert_called_once()
 
@@ -303,7 +318,9 @@ class TestMirascopeProvider:
         mock_create_provider.return_value = mock_underlying
 
         provider = MirascopeProvider(api_key="test-key")
-        await provider._stream_async(model_id="openai/gpt-4", messages=[])  # pyright: ignore[reportPrivateUsage]
+        await provider._stream_async(  # pyright: ignore[reportPrivateUsage]
+            model_id="openai/gpt-4", messages=[], toolkit=AsyncToolkit(None)
+        )
 
         mock_underlying.stream_async.assert_called_once()
 
@@ -322,7 +339,10 @@ class TestMirascopeProvider:
         provider = MirascopeProvider(api_key="test-key")
         ctx = Context(deps={})
         await provider._context_stream_async(  # pyright: ignore[reportPrivateUsage]
-            ctx=ctx, model_id="openai/gpt-4", messages=[]
+            ctx=ctx,
+            model_id="openai/gpt-4",
+            messages=[],
+            toolkit=AsyncContextToolkit(None),
         )
 
         mock_underlying.context_stream_async.assert_called_once()
@@ -361,7 +381,7 @@ class TestMirascopeProviderErrorHandling:
 
         # Should propagate the RateLimitError from underlying provider
         with pytest.raises(RateLimitError) as exc_info:
-            provider.call(model_id="openai/gpt-4", messages=[])
+            provider.call(model_id="openai/gpt-4", messages=[], toolkit=Toolkit(None))
 
         assert "Rate limit exceeded" in str(exc_info.value)
 
@@ -384,7 +404,9 @@ class TestMirascopeProviderErrorHandling:
 
         # Should propagate the AuthenticationError from underlying provider
         with pytest.raises(AuthenticationError) as exc_info:
-            await provider.call_async(model_id="anthropic/claude-3", messages=[])
+            await provider.call_async(
+                model_id="anthropic/claude-3", messages=[], toolkit=AsyncToolkit(None)
+            )
 
         assert "Invalid API key" in str(exc_info.value)
 
@@ -406,6 +428,8 @@ class TestMirascopeProviderErrorHandling:
 
         # Should propagate the ServerError from underlying provider
         with pytest.raises(ServerError) as exc_info:
-            provider.stream(model_id="google/gemini-pro", messages=[])
+            provider.stream(
+                model_id="google/gemini-pro", messages=[], toolkit=Toolkit(None)
+            )
 
         assert "Internal server error" in str(exc_info.value)


### PR DESCRIPTION
Model has flexibility: Can pass tools, or toolkit, or None
This refactor makes it so that underneath Model we go for consistency:
Always pass a toolkit. This is a prefactor so provider-native tools can
be implemented more cleanly.