### PR TITLE
refactor(python-sdk): add a FormatSpec

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -75,6 +75,7 @@ from .exceptions import (
 )
 from .formatting import (
     Format,
+    FormatSpec,
     FormattableT,
     FormattingMode,
     OutputParser,
@@ -219,6 +220,7 @@ __all__ = [
     "FeatureNotSupportedError",
     "FinishReason",
     "Format",
+    "FormatSpec",
     "FormattableT",
     "FormattingMode",
     "Image",

--- a/python/mirascope/llm/calls/decorator.py
+++ b/python/mirascope/llm/calls/decorator.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Generic, cast, overload
 from typing_extensions import Unpack
 
 from ..context import DepsT
-from ..formatting import Format, FormattableT, OutputParser
+from ..formatting import FormatSpec, FormattableT
 from ..models import Model
 from ..prompts import (
     AsyncContextMessageTemplate,
@@ -62,9 +62,7 @@ class CallDecorator(Generic[ToolT, FormattableT]):
     tools: Sequence[ToolT | ProviderTool] | None
     """The tools that are included in the prompt, if any."""
 
-    format: (
-        type[FormattableT] | Format[FormattableT] | OutputParser[FormattableT] | None
-    )
+    format: FormatSpec[FormattableT] | None
     """The structured output format off the prompt, if any."""
 
     @overload
@@ -163,10 +161,7 @@ def call(
     model: ModelId,
     *,
     tools: Sequence[ToolT | ProviderTool] | None = None,
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None = None,
+    format: FormatSpec[FormattableT] | None = None,
     **params: Unpack[Params],
 ) -> CallDecorator[ToolT, FormattableT]:
     """Decorator for converting prompt functions into LLM calls.
@@ -181,10 +176,7 @@ def call(
     model: Model,
     *,
     tools: Sequence[ToolT | ProviderTool] | None = None,
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> CallDecorator[ToolT, FormattableT]:
     """Decorator for converting prompt functions into LLM calls.
 
@@ -197,10 +189,7 @@ def call(
     model: ModelId | Model,
     *,
     tools: Sequence[ToolT | ProviderTool] | None = None,
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None = None,
+    format: FormatSpec[FormattableT] | None = None,
     **params: Unpack[Params],
 ) -> CallDecorator[ToolT, FormattableT]:
     """Decorates a `MessageTemplate` to create a `Call` that can be invoked directly.

--- a/python/mirascope/llm/formatting/__init__.py
+++ b/python/mirascope/llm/formatting/__init__.py
@@ -18,11 +18,11 @@ from .primitives import (
     create_wrapper_model,
     is_primitive_type,
 )
-from .types import FormattableT, FormattingMode
+from .types import FormatSpec, FormattableT, FormattingMode
 
 __all__ = [
     "Format",
-    "FormattableT",
+    "FormatSpec",
     "FormattableT",
     "FormattingMode",
     "FromCallArgs",

--- a/python/mirascope/llm/formatting/format.py
+++ b/python/mirascope/llm/formatting/format.py
@@ -11,7 +11,7 @@ from ..tools import FORMAT_TOOL_NAME, ToolFn, ToolParameterSchema, ToolSchema
 from ..types import NoneType
 from .output_parser import OutputParser, is_output_parser
 from .primitives import create_wrapper_model, is_primitive_type
-from .types import FormattableT, FormattingMode, HasFormattingInstructions
+from .types import FormatSpec, FormattableT, FormattingMode, HasFormattingInstructions
 
 TOOL_MODE_INSTRUCTIONS = f"""Always respond to the user's query using the {FORMAT_TOOL_NAME} tool for structured output."""
 
@@ -267,9 +267,7 @@ def format(
 
 
 def resolve_format(
-    formattable: (
-        type[FormattableT] | Format[FormattableT] | OutputParser[FormattableT] | None
-    ),
+    formattable: FormatSpec[FormattableT] | None,
     default_mode: FormattingMode,
 ) -> Format[FormattableT] | None:
     """Resolve a `Format` (or None) from a possible `Format`, Formattable, or `OutputParser`.

--- a/python/mirascope/llm/formatting/types.py
+++ b/python/mirascope/llm/formatting/types.py
@@ -1,15 +1,32 @@
 """Type for the formatting module."""
 
-from typing import Literal, Protocol, runtime_checkable
-from typing_extensions import TypeVar
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+from typing_extensions import TypeAliasType, TypeVar
 
 from pydantic import BaseModel
 
 from .primitives import PrimitiveType
 
+if TYPE_CHECKING:
+    from .format import Format
+    from .output_parser import OutputParser
+
 FormattableT = TypeVar(
     "FormattableT", bound=BaseModel | PrimitiveType | None, default=None
 )
+
+FormatSpec = TypeAliasType(
+    "FormatSpec",
+    "type[FormattableT] | Format[FormattableT] | OutputParser[FormattableT]",
+    type_params=(FormattableT,),
+)
+"""Type alias for format parameter types.
+
+A FormatSpec can be:
+- A type (class) that represents the format schema (e.g., a Pydantic BaseModel)
+- A Format wrapper that includes mode and other metadata
+- An OutputParser for custom parsing logic
+"""
 """Type variable for structured response format types.
 
 This TypeVar represents the type of structured output format that LLM responses

--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -9,7 +9,7 @@ from typing import overload
 from typing_extensions import Unpack
 
 from ..context import Context, DepsT
-from ..formatting import Format, FormattableT, OutputParser
+from ..formatting import Format, FormatSpec, FormattableT
 from ..messages import Message, UserContent, promote_to_messages
 from ..providers import (
     ModelId,
@@ -179,10 +179,7 @@ class Model:
         content: UserContent | Sequence[Message],
         *,
         tools: Tools | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` with an optional response format."""
         ...
@@ -192,10 +189,7 @@ class Model:
         content: UserContent | Sequence[Message],
         *,
         tools: Tools | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling this model's LLM provider.
 
@@ -246,10 +240,7 @@ class Model:
         content: UserContent | Sequence[Message],
         *,
         tools: AsyncTools | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` with an optional response format."""
         ...
@@ -259,10 +250,7 @@ class Model:
         content: UserContent | Sequence[Message],
         *,
         tools: AsyncTools | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling this model's LLM provider.
 
@@ -313,10 +301,7 @@ class Model:
         content: UserContent | Sequence[Message],
         *,
         tools: Tools | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Stream an `llm.StreamResponse` with an optional response format."""
         ...
@@ -326,10 +311,7 @@ class Model:
         content: UserContent | Sequence[Message],
         *,
         tools: Tools | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from this model's LLM provider.
 
@@ -380,10 +362,7 @@ class Model:
         content: UserContent | Sequence[Message],
         *,
         tools: AsyncTools | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Stream an `llm.AsyncStreamResponse` with an optional response format."""
         ...
@@ -393,10 +372,7 @@ class Model:
         content: UserContent | Sequence[Message],
         *,
         tools: AsyncTools | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from this model's LLM provider.
 
@@ -450,10 +426,7 @@ class Model:
         *,
         ctx: Context[DepsT],
         tools: ContextTools[DepsT] | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` with an optional response format."""
         ...
@@ -464,10 +437,7 @@ class Model:
         *,
         ctx: Context[DepsT],
         tools: ContextTools[DepsT] | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling this model's LLM provider.
 
@@ -523,10 +493,7 @@ class Model:
         *,
         ctx: Context[DepsT],
         tools: AsyncContextTools[DepsT] | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` with an optional response format."""
         ...
@@ -537,10 +504,7 @@ class Model:
         *,
         ctx: Context[DepsT],
         tools: AsyncContextTools[DepsT] | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling this model's LLM provider.
 
@@ -596,10 +560,7 @@ class Model:
         *,
         ctx: Context[DepsT],
         tools: ContextTools[DepsT] | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
     ):
@@ -612,10 +573,7 @@ class Model:
         *,
         ctx: Context[DepsT],
         tools: ContextTools[DepsT] | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
     ):
@@ -673,10 +631,7 @@ class Model:
         *,
         ctx: Context[DepsT],
         tools: AsyncContextTools[DepsT] | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> (
         AsyncContextStreamResponse[DepsT, None]
         | AsyncContextStreamResponse[DepsT, FormattableT]
@@ -690,10 +645,7 @@ class Model:
         *,
         ctx: Context[DepsT],
         tools: AsyncContextTools[DepsT] | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
     ) -> (
         AsyncContextStreamResponse[DepsT, None]
         | AsyncContextStreamResponse[DepsT, FormattableT]

--- a/python/mirascope/llm/prompts/decorator.py
+++ b/python/mirascope/llm/prompts/decorator.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Generic, cast, overload
 
 from ..context import DepsT
-from ..formatting import Format, FormattableT, OutputParser
+from ..formatting import FormatSpec, FormattableT
 from ..tools import (
     AsyncContextTool,
     AsyncContextToolkit,
@@ -46,18 +46,13 @@ class PromptDecorator(Generic[ToolT, FormattableT]):
     tools: Sequence[ToolT] | None
     """The tools that are included in the prompt, if any."""
 
-    format: (
-        type[FormattableT] | Format[FormattableT] | OutputParser[FormattableT] | None
-    )
+    format: FormatSpec[FormattableT] | None
     """The structured output format off the prompt, if any."""
 
     def __init__(
         self,
         tools: Sequence[ToolT] | None = None,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
     ) -> None:
         """Initialize the decorator with optional tools and format."""
         self.tools = tools
@@ -173,10 +168,7 @@ def prompt(
 def prompt(
     *,
     tools: Sequence[ToolT] | None = None,
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> PromptDecorator[ToolT, FormattableT]:
     """Create a decorator for Prompt functions with tools and format"""
 
@@ -189,10 +181,7 @@ def prompt(
     | None = None,
     *,
     tools: Sequence[ToolT] | None = None,
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> (
     AsyncContextPrompt[P, DepsT, FormattableT]
     | ContextPrompt[P, DepsT, FormattableT]

--- a/python/mirascope/llm/prompts/prompts.py
+++ b/python/mirascope/llm/prompts/prompts.py
@@ -6,7 +6,7 @@ from typing import Any, Generic, TypeVar, overload
 
 from ..._utils import copy_function_metadata
 from ..context import Context, DepsT
-from ..formatting import Format, FormattableT, OutputParser
+from ..formatting import FormatSpec, FormattableT
 from ..messages import Message, promote_to_messages
 from ..models import Model
 from ..providers import ModelId
@@ -61,9 +61,7 @@ class Prompt(BasePrompt[MessageTemplate[P]], Generic[P, FormattableT]):
     toolkit: Toolkit
     """The toolkit containing this prompt's tools."""
 
-    format: (
-        type[FormattableT] | Format[FormattableT] | OutputParser[FormattableT] | None
-    )
+    format: FormatSpec[FormattableT] | None
     """The response format for the generated response."""
 
     def messages(self, *args: P.args, **kwargs: P.kwargs) -> Sequence[Message]:
@@ -157,9 +155,7 @@ class AsyncPrompt(BasePrompt[AsyncMessageTemplate[P]], Generic[P, FormattableT])
     toolkit: AsyncToolkit
     """The toolkit containing this prompt's async tools."""
 
-    format: (
-        type[FormattableT] | Format[FormattableT] | OutputParser[FormattableT] | None
-    )
+    format: FormatSpec[FormattableT] | None
     """The response format for the generated response."""
 
     async def messages(self, *args: P.args, **kwargs: P.kwargs) -> Sequence[Message]:
@@ -258,9 +254,7 @@ class ContextPrompt(
     toolkit: ContextToolkit[DepsT]
     """The toolkit containing this prompt's context-aware tools."""
 
-    format: (
-        type[FormattableT] | Format[FormattableT] | OutputParser[FormattableT] | None
-    )
+    format: FormatSpec[FormattableT] | None
     """The response format for the generated response."""
 
     def messages(
@@ -383,9 +377,7 @@ class AsyncContextPrompt(
     toolkit: AsyncContextToolkit[DepsT]
     """The toolkit containing this prompt's async context-aware tools."""
 
-    format: (
-        type[FormattableT] | Format[FormattableT] | OutputParser[FormattableT] | None
-    )
+    format: FormatSpec[FormattableT] | None
     """The response format for the generated response."""
 
     async def messages(

--- a/python/mirascope/llm/providers/anthropic/_utils/beta_encode.py
+++ b/python/mirascope/llm/providers/anthropic/_utils/beta_encode.py
@@ -20,8 +20,8 @@ from ....content import ContentPart
 from ....exceptions import FeatureNotSupportedError
 from ....formatting import (
     Format,
+    FormatSpec,
     FormattableT,
-    OutputParser,
     resolve_format,
 )
 from ....messages import AssistantMessage, Message, UserMessage
@@ -168,10 +168,7 @@ def beta_encode_request(
     model_id: str,
     messages: Sequence[Message],
     tools: BaseToolkit[AnyToolSchema],
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None,
+    format: FormatSpec[FormattableT] | None,
     params: "Params",
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, BetaParseKwargs]:
     """Prepares a request for the Anthropic beta.messages.parse method."""

--- a/python/mirascope/llm/providers/anthropic/_utils/encode.py
+++ b/python/mirascope/llm/providers/anthropic/_utils/encode.py
@@ -14,8 +14,8 @@ from ....content import ContentPart, ImageMimeType
 from ....exceptions import FeatureNotSupportedError
 from ....formatting import (
     Format,
+    FormatSpec,
     FormattableT,
-    OutputParser,
     resolve_format,
 )
 from ....messages import AssistantMessage, Message, UserMessage
@@ -345,10 +345,7 @@ def encode_request(
     model_id: AnthropicModelId,
     messages: Sequence[Message],
     tools: BaseToolkit[AnyToolSchema],
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None,
+    format: FormatSpec[FormattableT] | None,
     params: Params,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, MessageCreateKwargs]:
     """Prepares a request for the Anthropic messages.create method."""

--- a/python/mirascope/llm/providers/anthropic/beta_provider.py
+++ b/python/mirascope/llm/providers/anthropic/beta_provider.py
@@ -9,7 +9,7 @@ from typing_extensions import Unpack
 from anthropic import Anthropic, AsyncAnthropic
 
 from ...context import Context, DepsT
-from ...formatting import Format, FormattableT, OutputParser
+from ...formatting import FormatSpec, FormattableT
 from ...messages import Message
 from ...responses import (
     AsyncContextResponse,
@@ -60,10 +60,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` using the beta Anthropic API."""
@@ -100,10 +97,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` using the beta Anthropic API."""
@@ -139,10 +133,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` using the beta Anthropic API."""
@@ -179,10 +170,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` using the beta Anthropic API."""
@@ -218,10 +206,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` using the beta Anthropic API."""
@@ -255,10 +240,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` using the beta Anthropic API."""
@@ -291,10 +273,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` using the beta Anthropic API."""
@@ -328,10 +307,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/anthropic/provider.py
+++ b/python/mirascope/llm/providers/anthropic/provider.py
@@ -9,7 +9,7 @@ from typing_extensions import Unpack
 from anthropic import Anthropic, AsyncAnthropic
 
 from ...context import Context, DepsT
-from ...formatting import Format, FormattableT, OutputParser, resolve_format
+from ...formatting import FormatSpec, FormattableT, resolve_format
 from ...messages import Message
 from ...responses import (
     AsyncContextResponse,
@@ -41,10 +41,7 @@ if TYPE_CHECKING:
 
 def _should_use_beta(
     model_id: AnthropicModelId,
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None,
+    format: FormatSpec[FormattableT] | None,
     tools: BaseToolkit[AnyToolSchema],
 ) -> bool:
     """Determine whether to use the beta API based on format mode or strict tools.
@@ -90,10 +87,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         model_id: AnthropicModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the Anthropic Messages API."""
@@ -139,10 +133,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         model_id: AnthropicModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling the Anthropic Messages API."""
@@ -188,10 +179,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         model_id: AnthropicModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the Anthropic Messages API."""
@@ -237,10 +225,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         model_id: AnthropicModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling the Anthropic Messages API."""
@@ -286,10 +271,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         model_id: AnthropicModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from the Anthropic Messages API."""
@@ -332,10 +314,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         model_id: AnthropicModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from the Anthropic Messages API."""
@@ -378,10 +357,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         model_id: AnthropicModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from the Anthropic Messages API."""
@@ -423,10 +399,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         model_id: AnthropicModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/base/base_provider.py
+++ b/python/mirascope/llm/providers/base/base_provider.py
@@ -10,7 +10,7 @@ from typing_extensions import TypeVar, Unpack
 
 from ...context import Context, DepsT
 from ...exceptions import APIError, ProviderError
-from ...formatting import Format, FormattableT, OutputParser
+from ...formatting import FormatSpec, FormattableT
 from ...messages import Message, UserContent, user
 from ...responses import (
     AsyncChunkIterator,
@@ -160,7 +160,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT] | Format[FormattableT],
+        format: FormatSpec[FormattableT],
         **params: Unpack[Params],
     ) -> Response[FormattableT]:
         """Generate an `llm.Response` with a response format."""
@@ -173,10 +173,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` with an optional response format."""
@@ -188,10 +185,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling this client's LLM provider.
@@ -222,10 +216,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Implementation for call(). Subclasses override this method."""
@@ -253,7 +244,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT] | Format[FormattableT],
+        format: FormatSpec[FormattableT],
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` with a response format."""
@@ -267,10 +258,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` with an optional response format."""
@@ -283,10 +271,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling this client's LLM provider.
@@ -320,10 +305,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Implementation for context_call(). Subclasses override this method."""
@@ -349,7 +331,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT] | Format[FormattableT],
+        format: FormatSpec[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` with a response format."""
@@ -362,10 +344,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` with an optional response format."""
@@ -377,10 +356,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling this client's LLM provider.
@@ -411,10 +387,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Implementation for call_async(). Subclasses override this method."""
@@ -442,7 +415,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT] | Format[FormattableT],
+        format: FormatSpec[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` with a response format."""
@@ -456,10 +429,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` with an optional response format."""
@@ -472,10 +442,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling this client's LLM provider.
@@ -509,10 +476,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Implementation for context_call_async(). Subclasses override this method."""
@@ -538,7 +502,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT] | Format[FormattableT],
+        format: FormatSpec[FormattableT],
         **params: Unpack[Params],
     ) -> StreamResponse[FormattableT]:
         """Stream an `llm.StreamResponse` with a response format."""
@@ -551,10 +515,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Stream an `llm.StreamResponse` with an optional response format."""
@@ -566,10 +527,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from this client's LLM provider.
@@ -604,10 +562,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Implementation for stream(). Subclasses override this method."""
@@ -635,7 +590,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT] | Format[FormattableT],
+        format: FormatSpec[FormattableT],
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT, FormattableT]:
         """Stream an `llm.ContextStreamResponse` with a response format."""
@@ -649,10 +604,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -667,10 +619,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -710,10 +659,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -741,7 +687,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT] | Format[FormattableT],
+        format: FormatSpec[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncStreamResponse[FormattableT]:
         """Stream an `llm.AsyncStreamResponse` with a response format."""
@@ -754,10 +700,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Stream an `llm.AsyncStreamResponse` with an optional response format."""
@@ -769,10 +712,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from this client's LLM provider.
@@ -807,10 +747,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Implementation for stream_async(). Subclasses override this method."""
@@ -838,7 +775,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT] | Format[FormattableT],
+        format: FormatSpec[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
         """Stream an `llm.AsyncContextStreamResponse` with a response format."""
@@ -852,10 +789,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT, None]
@@ -871,10 +805,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT, None]
@@ -915,10 +846,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT, None]

--- a/python/mirascope/llm/providers/google/_utils/encode.py
+++ b/python/mirascope/llm/providers/google/_utils/encode.py
@@ -15,8 +15,8 @@ from ....content import ContentPart
 from ....exceptions import FeatureNotSupportedError
 from ....formatting import (
     Format,
+    FormatSpec,
     FormattableT,
-    OutputParser,
     resolve_format,
 )
 from ....messages import AssistantMessage, Message, UserMessage
@@ -275,10 +275,7 @@ def encode_request(
     model_id: GoogleModelId,
     messages: Sequence[Message],
     tools: BaseToolkit[AnyToolSchema],
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None,
+    format: FormatSpec[FormattableT] | None,
     params: Params,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, GoogleKwargs]:
     """Prepares a request for the genai `Client.models.generate_content` method."""

--- a/python/mirascope/llm/providers/google/provider.py
+++ b/python/mirascope/llm/providers/google/provider.py
@@ -10,7 +10,7 @@ from google.genai import Client
 from google.genai.types import HttpOptions
 
 from ...context import Context, DepsT
-from ...formatting import Format, FormattableT, OutputParser
+from ...formatting import FormatSpec, FormattableT
 from ...messages import Message
 from ...responses import (
     AsyncContextResponse,
@@ -66,10 +66,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the Google GenAI API.
@@ -119,10 +116,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling the Google GenAI API.
@@ -172,10 +166,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the Google GenAI API.
@@ -225,10 +216,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling the Google GenAI API.
@@ -278,10 +266,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from the Google GenAI API.
@@ -329,10 +314,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from the Google GenAI API.
@@ -380,10 +362,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from the Google GenAI API.
@@ -431,10 +410,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/mirascope/provider.py
+++ b/python/mirascope/llm/providers/mirascope/provider.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from typing_extensions import Unpack
 
 from ...context import Context, DepsT
-from ...formatting import Format, FormattableT, OutputParser
+from ...formatting import FormatSpec, FormattableT
 from ...messages import Message
 from ...responses import (
     AsyncContextResponse,
@@ -153,10 +153,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by calling through the Mirascope Router."""
@@ -176,10 +173,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by calling through the Mirascope Router."""
@@ -199,10 +193,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by calling through the Mirascope Router."""
@@ -222,10 +213,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by calling through the Mirascope Router."""
@@ -245,10 +233,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Stream an `llm.StreamResponse` by calling through the Mirascope Router."""
@@ -268,10 +253,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -293,10 +275,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Stream an `llm.AsyncStreamResponse` by calling through the Mirascope Router."""
@@ -316,10 +295,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT, None]

--- a/python/mirascope/llm/providers/mlx/encoding/base.py
+++ b/python/mirascope/llm/providers/mlx/encoding/base.py
@@ -6,7 +6,7 @@ from typing import TypeAlias
 
 from mlx_lm.generate import GenerationResponse
 
-from ....formatting import Format, FormattableT, OutputParser
+from ....formatting import Format, FormatSpec, FormattableT
 from ....messages import AssistantContent, Message
 from ....responses import ChunkIterator
 from ....tools import AnyToolSchema, BaseToolkit
@@ -22,10 +22,7 @@ class BaseEncoder(abc.ABC):
         self,
         messages: Sequence[Message],
         tools: BaseToolkit[AnyToolSchema],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> tuple[Sequence[Message], Format[FormattableT] | None, TokenIds]:
         """Encode the request messages into a format suitable for the model.
 

--- a/python/mirascope/llm/providers/mlx/encoding/transformers.py
+++ b/python/mirascope/llm/providers/mlx/encoding/transformers.py
@@ -8,7 +8,7 @@ from mlx_lm.generate import GenerationResponse
 from transformers import PreTrainedTokenizer
 
 from ....content import ContentPart, TextChunk, TextEndChunk, TextStartChunk
-from ....formatting import Format, FormattableT, OutputParser
+from ....formatting import Format, FormatSpec, FormattableT
 from ....messages import AssistantContent, Message
 from ....responses import (
     ChunkIterator,
@@ -81,10 +81,7 @@ class TransformersEncoder(BaseEncoder):
         self,
         messages: Sequence[Message],
         tools: BaseToolkit[AnyToolSchema],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
     ) -> tuple[Sequence[Message], Format[FormattableT] | None, TokenIds]:
         """Encode a request into a format suitable for the model."""
         if tools.tools:

--- a/python/mirascope/llm/providers/mlx/mlx.py
+++ b/python/mirascope/llm/providers/mlx/mlx.py
@@ -13,7 +13,7 @@ from mlx_lm import stream_generate  # type: ignore[reportPrivateImportUsage]
 from mlx_lm.generate import GenerationResponse
 from transformers import PreTrainedTokenizer
 
-from ...formatting import Format, FormattableT, OutputParser
+from ...formatting import Format, FormatSpec, FormattableT
 from ...messages import AssistantMessage, Message, assistant
 from ...responses import AsyncChunkIterator, ChunkIterator, StreamResponseChunk
 from ...tools import AnyToolSchema, BaseToolkit
@@ -138,10 +138,7 @@ class MLX:
         self,
         messages: Sequence[Message],
         tools: BaseToolkit[AnyToolSchema],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         params: Params,
     ) -> tuple[Sequence[Message], Format[FormattableT] | None, ChunkIterator]:
         """Stream response chunks synchronously.
@@ -164,10 +161,7 @@ class MLX:
         self,
         messages: Sequence[Message],
         tools: BaseToolkit[AnyToolSchema],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         params: Params,
     ) -> tuple[Sequence[Message], Format[FormattableT] | None, AsyncChunkIterator]:
         """Stream response chunks asynchronously.
@@ -191,10 +185,7 @@ class MLX:
         self,
         messages: Sequence[Message],
         tools: BaseToolkit[AnyToolSchema],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         params: Params,
     ) -> tuple[
         Sequence[Message],
@@ -230,10 +221,7 @@ class MLX:
         self,
         messages: Sequence[Message],
         tools: BaseToolkit[AnyToolSchema],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None,
+        format: FormatSpec[FormattableT] | None,
         params: Params,
     ) -> tuple[
         Sequence[Message],

--- a/python/mirascope/llm/providers/mlx/provider.py
+++ b/python/mirascope/llm/providers/mlx/provider.py
@@ -10,7 +10,7 @@ from mlx_lm import load as mlx_load
 from transformers import PreTrainedTokenizer
 
 from ...context import Context, DepsT
-from ...formatting import Format, FormattableT, OutputParser
+from ...formatting import FormatSpec, FormattableT
 from ...messages import Message
 from ...responses import (
     AsyncContextResponse,
@@ -86,10 +86,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` using MLX model.
@@ -131,10 +128,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` using MLX model.
@@ -176,10 +170,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` using MLX model by asynchronously calloing
@@ -225,10 +216,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncResponse` using MLX model by asynchronously calloing
@@ -274,10 +262,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from MLX model output.
@@ -316,10 +301,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from MLX model output.
@@ -358,10 +340,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from MLX model output.
@@ -400,10 +379,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/openai/completions/_utils/encode.py
+++ b/python/mirascope/llm/providers/openai/completions/_utils/encode.py
@@ -11,7 +11,7 @@ from openai.types import chat as openai_types, shared_params as shared_openai_ty
 from openai.types.shared_params.response_format_json_schema import JSONSchema
 
 from .....exceptions import FeatureNotSupportedError
-from .....formatting import Format, FormattableT, OutputParser, resolve_format
+from .....formatting import Format, FormatSpec, FormattableT, resolve_format
 from .....messages import AssistantMessage, Message, UserMessage
 from .....tools import FORMAT_TOOL_NAME, AnyToolSchema, BaseToolkit, ProviderTool
 from ....base import _utils as _base_utils
@@ -285,10 +285,7 @@ def encode_request(
     model_id: OpenAIModelId,
     messages: Sequence[Message],
     tools: BaseToolkit[AnyToolSchema],
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None,
+    format: FormatSpec[FormattableT] | None,
     params: Params,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, ChatCompletionCreateKwargs]:
     """Prepares a request for the `OpenAI.chat.completions.create` method."""

--- a/python/mirascope/llm/providers/openai/completions/base_provider.py
+++ b/python/mirascope/llm/providers/openai/completions/base_provider.py
@@ -10,7 +10,7 @@ from typing_extensions import Unpack
 from openai import AsyncOpenAI, OpenAI
 
 from ....context import Context, DepsT
-from ....formatting import Format, FormattableT, OutputParser
+from ....formatting import FormatSpec, FormattableT
 from ....messages import Message
 from ....responses import (
     AsyncContextResponse,
@@ -93,10 +93,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the API.
@@ -149,10 +146,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling the API.
@@ -205,10 +199,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the API.
@@ -261,10 +252,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling the API.
@@ -317,10 +305,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from the API.
@@ -369,10 +354,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from the API.
@@ -422,10 +404,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from the API.
@@ -474,10 +453,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/openai/provider.py
+++ b/python/mirascope/llm/providers/openai/provider.py
@@ -10,7 +10,7 @@ from openai import BadRequestError as OpenAIBadRequestError, OpenAI
 
 from ...context import Context, DepsT
 from ...exceptions import BadRequestError, NotFoundError
-from ...formatting import Format, FormattableT, OutputParser
+from ...formatting import FormatSpec, FormattableT
 from ...messages import Message
 from ...responses import (
     AsyncContextResponse,
@@ -159,10 +159,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the OpenAI API.
@@ -193,10 +190,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling the OpenAI API.
@@ -228,10 +222,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the OpenAI API.
@@ -261,10 +252,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling the OpenAI API.
@@ -295,10 +283,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from the OpenAI API.
@@ -329,10 +314,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from the OpenAI API.
@@ -364,10 +346,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from the OpenAI API.
@@ -397,10 +376,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/openai/responses/_utils/encode.py
+++ b/python/mirascope/llm/providers/openai/responses/_utils/encode.py
@@ -34,8 +34,8 @@ from openai.types.shared_params.responses_model import ResponsesModel
 from .....exceptions import FeatureNotSupportedError
 from .....formatting import (
     Format,
+    FormatSpec,
     FormattableT,
-    OutputParser,
     resolve_format,
 )
 from .....messages import AssistantMessage, Message, UserMessage
@@ -288,10 +288,7 @@ def encode_request(
     model_id: OpenAIModelId,
     messages: Sequence[Message],
     tools: BaseToolkit[AnyToolSchema],
-    format: type[FormattableT]
-    | Format[FormattableT]
-    | OutputParser[FormattableT]
-    | None,
+    format: FormatSpec[FormattableT] | None,
     params: Params,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, ResponseCreateKwargs]:
     """Prepares a request for the `OpenAI.responses.create` method."""

--- a/python/mirascope/llm/providers/openai/responses/provider.py
+++ b/python/mirascope/llm/providers/openai/responses/provider.py
@@ -10,7 +10,7 @@ from openai import AsyncOpenAI, BadRequestError as OpenAIBadRequestError, OpenAI
 
 from ....context import Context, DepsT
 from ....exceptions import BadRequestError, NotFoundError
-from ....formatting import Format, FormattableT, OutputParser
+from ....formatting import FormatSpec, FormattableT
 from ....messages import Message
 from ....responses import (
     AsyncContextResponse,
@@ -64,10 +64,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the OpenAI Responses API.
@@ -117,10 +114,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the OpenAI Responses API.
@@ -170,10 +164,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: Toolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate a `llm.StreamResponse` by synchronously streaming from the OpenAI Responses API.
@@ -223,10 +214,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: AsyncToolkit,
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate a `llm.AsyncStreamResponse` by asynchronously streaming from the OpenAI Responses API.
@@ -277,10 +265,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT] | ContextResponse[DepsT, FormattableT]:
         """Generate a `llm.ContextResponse` by synchronously calling the OpenAI Responses API with context.
@@ -332,10 +317,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate a `llm.AsyncContextResponse` by asynchronously calling the OpenAI Responses API with context.
@@ -387,10 +369,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: ContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate a `llm.ContextStreamResponse` by synchronously streaming from the OpenAI Responses API with context.
@@ -443,10 +422,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         toolkit: AsyncContextToolkit[DepsT],
-        format: type[FormattableT]
-        | Format[FormattableT]
-        | OutputParser[FormattableT]
-        | None = None,
+        format: FormatSpec[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/ops/_internal/instrumentation/llm/common.py
+++ b/python/mirascope/ops/_internal/instrumentation/llm/common.py
@@ -21,6 +21,7 @@ from .....llm import (
     AnyToolSchema,
     BaseToolkit,
     Format,
+    FormatSpec,
     FormattableT,
     Jsonable,
     Message,
@@ -65,7 +66,7 @@ else:
     Tracer = None
 
 
-FormatParam: TypeAlias = Format[FormattableT] | None
+FormatParam: TypeAlias = FormatSpec[FormattableT] | None
 ParamsDict: TypeAlias = Mapping[str, str | int | float | bool | Sequence[str] | None]
 SpanAttributes: TypeAlias = Mapping[str, AttributeValue]
 AttributeSetter: TypeAlias = Callable[[str, AttributeValue], None]

--- a/python/mirascope/ops/_internal/instrumentation/llm/model.py
+++ b/python/mirascope/ops/_internal/instrumentation/llm/model.py
@@ -28,10 +28,10 @@ from .....llm import (
     ContextStreamResponse,
     ContextTools,
     DepsT,
+    FormatSpec,
     FormattableT,
     Message,
     Model,
-    OutputParser,
     Response,
     RootResponse,
     StreamResponse,
@@ -114,7 +114,7 @@ def _instrumented_model_call(
     content: UserContent | Sequence[Message],
     *,
     tools: Tools | None = None,
-    format: type[FormattableT] | FormatParam,
+    format: FormatSpec[FormattableT],
 ) -> Response[FormattableT]: ...
 
 
@@ -124,7 +124,7 @@ def _instrumented_model_call(
     content: UserContent | Sequence[Message],
     *,
     tools: Tools | None = None,
-    format: type[FormattableT] | FormatParam | OutputParser[FormattableT] | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> Response | Response[FormattableT]: ...
 
 
@@ -199,7 +199,7 @@ async def _instrumented_model_call_async(
     content: UserContent | Sequence[Message],
     *,
     tools: AsyncTools | None = None,
-    format: type[FormattableT] | FormatParam,
+    format: FormatSpec[FormattableT],
 ) -> AsyncResponse[FormattableT]: ...
 
 
@@ -209,7 +209,7 @@ async def _instrumented_model_call_async(
     content: UserContent | Sequence[Message],
     *,
     tools: AsyncTools | None = None,
-    format: type[FormattableT] | FormatParam | OutputParser[FormattableT] | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> AsyncResponse | AsyncResponse[FormattableT]: ...
 
 
@@ -287,7 +287,7 @@ def _instrumented_model_context_call(
     *,
     ctx: Context[DepsT],
     tools: ContextTools[DepsT] | None = None,
-    format: type[FormattableT] | FormatParam,
+    format: FormatSpec[FormattableT],
 ) -> ContextResponse[DepsT, FormattableT]: ...
 
 
@@ -298,7 +298,7 @@ def _instrumented_model_context_call(
     *,
     ctx: Context[DepsT],
     tools: ContextTools[DepsT] | None = None,
-    format: type[FormattableT] | FormatParam | OutputParser[FormattableT] | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]: ...
 
 
@@ -378,7 +378,7 @@ async def _instrumented_model_context_call_async(
     *,
     ctx: Context[DepsT],
     tools: AsyncContextTools[DepsT] | None = None,
-    format: type[FormattableT] | FormatParam,
+    format: FormatSpec[FormattableT],
 ) -> AsyncContextResponse[DepsT, FormattableT]: ...
 
 
@@ -389,7 +389,7 @@ async def _instrumented_model_context_call_async(
     *,
     ctx: Context[DepsT],
     tools: AsyncContextTools[DepsT] | None = None,
-    format: type[FormattableT] | FormatParam | OutputParser[FormattableT] | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]: ...
 
 
@@ -565,7 +565,7 @@ def _instrumented_model_stream(
     content: UserContent | Sequence[Message],
     *,
     tools: Tools | None = None,
-    format: type[FormattableT] | FormatParam,
+    format: FormatSpec[FormattableT],
 ) -> StreamResponse[FormattableT]: ...
 
 
@@ -575,7 +575,7 @@ def _instrumented_model_stream(
     content: UserContent | Sequence[Message],
     *,
     tools: Tools | None = None,
-    format: type[FormattableT] | FormatParam | OutputParser[FormattableT] | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> StreamResponse | StreamResponse[FormattableT]: ...
 
 
@@ -674,7 +674,7 @@ async def _instrumented_model_stream_async(
     content: UserContent | Sequence[Message],
     *,
     tools: AsyncTools | None = None,
-    format: type[FormattableT] | FormatParam,
+    format: FormatSpec[FormattableT],
 ) -> AsyncStreamResponse[FormattableT]: ...
 
 
@@ -684,7 +684,7 @@ async def _instrumented_model_stream_async(
     content: UserContent | Sequence[Message],
     *,
     tools: AsyncTools | None = None,
-    format: type[FormattableT] | FormatParam | OutputParser[FormattableT] | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]: ...
 
 
@@ -787,7 +787,7 @@ def _instrumented_model_context_stream(
     *,
     ctx: Context[DepsT],
     tools: ContextTools[DepsT] | None = None,
-    format: type[FormattableT] | FormatParam,
+    format: FormatSpec[FormattableT],
 ) -> ContextStreamResponse[DepsT, FormattableT]: ...
 
 
@@ -798,7 +798,7 @@ def _instrumented_model_context_stream(
     *,
     ctx: Context[DepsT],
     tools: ContextTools[DepsT] | None = None,
-    format: type[FormattableT] | FormatParam | OutputParser[FormattableT] | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> (
     ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
 ): ...
@@ -904,7 +904,7 @@ async def _instrumented_model_context_stream_async(
     *,
     ctx: Context[DepsT],
     tools: AsyncContextTools[DepsT] | None = None,
-    format: type[FormattableT] | FormatParam,
+    format: FormatSpec[FormattableT],
 ) -> AsyncContextStreamResponse[DepsT, FormattableT]: ...
 
 
@@ -915,7 +915,7 @@ async def _instrumented_model_context_stream_async(
     *,
     ctx: Context[DepsT],
     tools: AsyncContextTools[DepsT] | None = None,
-    format: type[FormattableT] | FormatParam | OutputParser[FormattableT] | None = None,
+    format: FormatSpec[FormattableT] | None = None,
 ) -> (
     AsyncContextStreamResponse[DepsT, None]
     | AsyncContextStreamResponse[DepsT, FormattableT]


### PR DESCRIPTION
DRYs some repetitive code from signatures tracking the different ways to
represent a format specification. Also addresses some code drift where
some call sites had not been updated correctly to include OutputParser