### PR TITLE
refactor(python-sdk): cleaner retries interface

### DIFF
--- a/python/mirascope/llm/retries/retry_decorator.py
+++ b/python/mirascope/llm/retries/retry_decorator.py
@@ -241,13 +241,13 @@ def retry(
 
     1. Direct wrapping:
         ```python
-        retry_model = llm.retry(model, max_attempts=3)
-        retry_call = llm.retry(my_call, max_attempts=3)
+        retry_model = llm.retry(model, max_retries=2)
+        retry_call = llm.retry(my_call, max_retries=2)
         ```
 
     2. As a decorator:
         ```python
-        @llm.retry(max_attempts=3)
+        @llm.retry(max_retries=2)
         @llm.call("openai/gpt-4")
         def my_call() -> str:
             return "Hello"

--- a/python/mirascope/llm/retries/retry_responses.py
+++ b/python/mirascope/llm/retries/retry_responses.py
@@ -51,7 +51,7 @@ class RetryResponse(Response[FormattableT]):
     def validate(self) -> FormattableT | None:
         """Parse and validate the response, automatically retrying on ParseError.
 
-        When `max_parse_attempts` is set in the retry config, this method will
+        When `max_parse_retries` is set in the retry config, this method will
         automatically retry on ParseError by calling `resume(error.retry_message())`
         to ask the LLM to fix its output.
 
@@ -67,17 +67,16 @@ class RetryResponse(Response[FormattableT]):
         if self.format is None:
             return None
 
-        max_parse_attempts = self.retry_config.max_parse_attempts
+        max_parse_retries = self.retry_config.max_parse_retries
 
-        # +1 because max_parse_attempts is the number of retries, not total attempts
-        for attempt in range(max_parse_attempts + 1):
+        for retry in range(max_parse_retries + 1):
             try:
                 return self.parse()
             except ParseError as e:
-                if attempt == max_parse_attempts:
-                    raise  # Exhausted all attempts
+                if retry == max_parse_retries:
+                    raise  # Exhausted all retries
 
-                self.retry_state.parse_attempts += 1
+                self.retry_state.parse_retries += 1
                 self.retry_state.parse_exceptions.append(e)
 
                 # Get new response via resume with the retry message
@@ -160,7 +159,7 @@ class AsyncRetryResponse(AsyncResponse[FormattableT]):
     async def validate(self) -> FormattableT | None:
         """Parse and validate the response, automatically retrying on ParseError.
 
-        When `max_parse_attempts` is set in the retry config, this method will
+        When `max_parse_retries` is set in the retry config, this method will
         automatically retry on ParseError by calling `resume(error.retry_message())`
         to ask the LLM to fix its output.
 
@@ -179,17 +178,16 @@ class AsyncRetryResponse(AsyncResponse[FormattableT]):
         if self.format is None:
             return None
 
-        max_parse_attempts = self.retry_config.max_parse_attempts
+        max_parse_retries = self.retry_config.max_parse_retries
 
-        # +1 because max_parse_attempts is the number of retries, not total attempts
-        for attempt in range(max_parse_attempts + 1):
+        for retry in range(max_parse_retries + 1):
             try:
                 return self.parse()
             except ParseError as e:
-                if attempt == max_parse_attempts:
-                    raise  # Exhausted all attempts
+                if retry == max_parse_retries:
+                    raise  # Exhausted all retries
 
-                self.retry_state.parse_attempts += 1
+                self.retry_state.parse_retries += 1
                 self.retry_state.parse_exceptions.append(e)
 
                 # Get new response via resume with the retry message

--- a/python/tests/llm/retries/test_retry_calls.py
+++ b/python/tests/llm/retries/test_retry_calls.py
@@ -26,17 +26,17 @@ class TestRetryCallModelOverride:
 
     def test_retry_call_wraps_default_model_in_retry_model(self) -> None:
         """Test that RetryCall.model wraps the default model in RetryModel."""
-        retry_call = _create_retry_call(llm.RetryConfig(max_attempts=3))
+        retry_call = _create_retry_call(llm.RetryConfig(max_retries=3))
 
         model = retry_call.model
 
         assert isinstance(model, llm.RetryModel)
         assert model.model_id == "openai/gpt-4o"
-        assert model.retry_config.max_attempts == 3
+        assert model.retry_config.max_retries == 3
 
     def test_retry_call_wraps_context_model_in_retry_model(self) -> None:
         """Test that RetryCall.model wraps context override in RetryModel."""
-        retry_call = _create_retry_call(llm.RetryConfig(max_attempts=3))
+        retry_call = _create_retry_call(llm.RetryConfig(max_retries=3))
 
         with llm.model("anthropic/claude-sonnet-4-0"):
             model = retry_call.model
@@ -44,15 +44,15 @@ class TestRetryCallModelOverride:
             assert isinstance(model, llm.RetryModel)
             assert model.model_id == "anthropic/claude-sonnet-4-0"
             # Uses the prompt's retry config when wrapping
-            assert model.retry_config.max_attempts == 3
+            assert model.retry_config.max_retries == 3
 
     def test_retry_call_uses_override_retry_model_directly(self) -> None:
         """Test that if context override is a RetryModel, it's used as-is."""
-        retry_call = _create_retry_call(llm.RetryConfig(max_attempts=3))
+        retry_call = _create_retry_call(llm.RetryConfig(max_retries=3))
 
         override_retry_model = llm.RetryModel(
             "anthropic/claude-sonnet-4-0",
-            llm.RetryConfig(max_attempts=5),
+            llm.RetryConfig(max_retries=5),
         )
 
         with override_retry_model:
@@ -61,15 +61,15 @@ class TestRetryCallModelOverride:
             assert isinstance(model, llm.RetryModel)
             assert model.model_id == "anthropic/claude-sonnet-4-0"
             # The override's retry config should win, not the prompt's
-            assert model.retry_config.max_attempts == 5
+            assert model.retry_config.max_retries == 5
 
     def test_retry_call_override_retry_model_is_same_instance(self) -> None:
         """Test that the override RetryModel is returned directly, not re-wrapped."""
-        retry_call = _create_retry_call(llm.RetryConfig(max_attempts=3))
+        retry_call = _create_retry_call(llm.RetryConfig(max_retries=3))
 
         override_retry_model = llm.RetryModel(
             "anthropic/claude-sonnet-4-0",
-            llm.RetryConfig(max_attempts=5),
+            llm.RetryConfig(max_retries=5),
         )
 
         with override_retry_model:
@@ -79,8 +79,8 @@ class TestRetryCallModelOverride:
 
     def test_retry_config_property_returns_prompt_config(self) -> None:
         """Test that retry_config property returns the prompt's retry config."""
-        config = llm.RetryConfig(max_attempts=7)
+        config = llm.RetryConfig(max_retries=7)
         retry_call = _create_retry_call(config)
 
         assert retry_call.retry_config is config
-        assert retry_call.retry_config.max_attempts == 7
+        assert retry_call.retry_config.max_retries == 7


### PR DESCRIPTION
Change max_attempts to max_retries
I think reasoning about # of retries is more intuitive.