### PR TITLE
fix(cloud): run http basic auth even for assets via worker

### DIFF
--- a/cloud/wrangler.jsonc
+++ b/cloud/wrangler.jsonc
@@ -85,7 +85,7 @@
       "assets": {
         "directory": "./dist/client",
         "binding": "ASSETS",
-        "run_worker_first": true
+        "run_worker_first": true,
       },
       "ratelimits": [
         {


### PR DESCRIPTION
This settings trades off a minutiae overhead in staging to always hit the worker and not directly the CDN for assets. It allows the HTTP basic auth to run.

The alternative is to configure `CF Access` which is overkill for `staging`.