### PR TITLE
chore(cloud): make sure coding agents use oxlint now

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ When making changes to the codebase:
 - **TypeScript/JS Package Manager**: `bun`
 - **Python Testing**: `pytest`
 - **TypeScript Testing**: `vitest`
-- **Linting**: `ruff` (Python), `eslint` (TypeScript)
+- **Linting**: `ruff` (Python), `oxlint` (TypeScript)
 - **Type Checking**: `pyright` (Python), `tsc` (TypeScript)
 
 ## Git Workflow with Graphite
@@ -73,7 +73,7 @@ gt submit                            # Push all PRs in the stack
 Before submitting changes, ensure:
 
 1. `bun run typecheck` passes
-2. `bun run lint:eslint` passes  
+2. `bun run lint:oxlint` passes  
 3. `bun run test:coverage` shows 100% coverage
 4. OpenAPI spec regenerated if API changed
 

--- a/cloud/AGENTS.md
+++ b/cloud/AGENTS.md
@@ -344,7 +344,7 @@ it.effect("returns DatabaseError when query fails", () =>
 
 ```bash
 bun run typecheck      # TypeScript type checking
-bun run lint:eslint    # ESLint
+bun run lint:oxlint    # oxlint
 bun run test           # Run all tests (NOT `bun test`)
 bun run test:coverage  # Run tests with coverage report
 bun run test <file>    # Run specific test file

--- a/content/docs/contributing.mdx
+++ b/content/docs/contributing.mdx
@@ -187,7 +187,7 @@ bun run test:coverage           # With coverage (required: 100%)
 
 ```bash
 bun run typecheck      # TypeScript type checking
-bun run lint:eslint    # ESLint
+bun run lint:oxlint    # oxlint
 ```
 
 ### Key Technologies
@@ -227,7 +227,7 @@ describe("MyService", () => {
 - [ ] Tests pass: `bun run test`
 - [ ] 100% coverage for new code
 - [ ] Type check passes: `bun run typecheck`
-- [ ] Linting passes: `bun run lint:eslint`
+- [ ] Linting passes: `bun run lint:oxlint`
 - [ ] Conventional commit messages
 
 ---


### PR DESCRIPTION
This avoids agents trying eslint just to fail before using oxlint.