### PR TITLE
fix(cloud): always check if assets need serving in staging

### DIFF
--- a/cloud/server-entry.ts
+++ b/cloud/server-entry.ts
@@ -369,6 +369,16 @@ const fetch: ExportedHandlerFetchHandler<WorkerEnv> = async (
     // Fall through to normal handler if no .md file exists
   }
 
+  // Try serving from static assets first (only needed when run_worker_first is enabled)
+  // In staging, all requests go through the worker including assets
+  if (url.hostname === "staging.mirascope.com") {
+    const assetResponse = await environment.ASSETS.fetch(request);
+    if (assetResponse.ok) {
+      return assetResponse;
+    }
+  }
+
+  // Fall back to SSR handler for routes
   return fetchHandler(request);
 };
 


### PR DESCRIPTION
This is necessary to make assets subject to the http basic auth served out of the worker.