### PR TITLE
feat(python-sdk): support fallback models for RetryModel

### DIFF
--- a/python/mirascope/llm/retries/__init__.py
+++ b/python/mirascope/llm/retries/__init__.py
@@ -14,6 +14,7 @@ from .retry_models import RetryModel
 from .retry_prompts import AsyncRetryPrompt, BaseRetryPrompt, RetryPrompt
 from .retry_responses import AsyncRetryResponse, RetryResponse
 from .retry_stream_responses import AsyncRetryStreamResponse, RetryStreamResponse
+from .utils import RetryFailure
 
 __all__ = [
     "AsyncRetryCall",
@@ -25,6 +26,7 @@ __all__ = [
     "RetryArgs",
     "RetryCall",
     "RetryConfig",
+    "RetryFailure",
     "RetryModel",
     "RetryPrompt",
     "RetryResponse",


### PR DESCRIPTION
Significant refactor to RetryModel, now under the hood it tracks a
sequence of fallback models it can use, and sets the correct RetryModel
on the response for whichever one succeeded.