### PR TITLE
fix(cloud): use latitude to calculate sunset duration

### DIFF
--- a/cloud/app/hooks/sunset-time.ts
+++ b/cloud/app/hooks/sunset-time.ts
@@ -194,7 +194,10 @@ function isAroundSunsetTime(): boolean {
 
   // Calculate civil twilight end (when it's actually dark) + small buffer
   const BUFFER_MINUTES = 10;
-  const civilTwilightEndHour = estimateCivilTwilightEndHour(latitude, dayOfYear);
+  const civilTwilightEndHour = estimateCivilTwilightEndHour(
+    latitude,
+    dayOfYear,
+  );
 
   // Window: starts 30 min before sunset, ends when civil twilight ends + buffer
   // Convert everything to minutes since midnight for easier comparison
@@ -213,7 +216,11 @@ function isAroundSunsetTime(): boolean {
 
   const formattedWindowStart = `${windowStartHour}:${windowStartMinute.toString().padStart(2, "0")}`;
   const formattedWindowEnd = `${windowEndHour}:${windowEndMinute.toString().padStart(2, "0")}`;
-  const formattedTwilightEnd = `${Math.floor(civilTwilightEndHour)}:${Math.round((civilTwilightEndHour % 1) * 60).toString().padStart(2, "0")}`;
+  const formattedTwilightEnd = `${Math.floor(civilTwilightEndHour)}:${Math.round(
+    (civilTwilightEndHour % 1) * 60,
+  )
+    .toString()
+    .padStart(2, "0")}`;
 
   // Determine if it's sunset time
   const isSunsetTime =


### PR DESCRIPTION
Estimating the civil (as opposed to nautical) twilight based on latitude now. Sunset time will now span until 10min after civil twilight. Ideally this will result in a handoff to the system's appearance toggling (if enabled).

```
- Location: US (source: browser-locale, latitude: 38°)
      - Current time: 17:32
      - Estimated sunset: 17:04
      - Civil twilight ends: 17:36
      - Sunset window: 16:34 - 17:46
      - Day of year: 33/365
```