### PR TITLE
refactor(python-sdk): add `llm.retry_model`

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -155,10 +155,12 @@ from .retries import (
     RetryCall,
     RetryConfig,
     RetryModel,
+    RetryModelParams,
     RetryPrompt,
     RetryResponse,
     RetryStreamResponse,
     retry,
+    retry_model,
 )
 from .tools import (
     AnyToolFn,
@@ -273,6 +275,7 @@ __all__ = [
     "RetryCall",
     "RetryConfig",
     "RetryModel",
+    "RetryModelParams",
     "RetryPrompt",
     "RetryResponse",
     "RetryStreamResponse",
@@ -339,6 +342,7 @@ __all__ = [
     "responses",
     "retries",
     "retry",
+    "retry_model",
     "tool",
     "tools",
     "types",

--- a/python/mirascope/llm/retries/__init__.py
+++ b/python/mirascope/llm/retries/__init__.py
@@ -10,7 +10,7 @@ This module provides retry capabilities for LLM calls, including:
 from .retry_calls import AsyncRetryCall, BaseRetryCall, RetryCall
 from .retry_config import RetryArgs, RetryConfig
 from .retry_decorator import retry
-from .retry_models import RetryModel
+from .retry_models import RetryModel, RetryModelParams, retry_model
 from .retry_prompts import AsyncRetryPrompt, BaseRetryPrompt, RetryPrompt
 from .retry_responses import AsyncRetryResponse, RetryResponse
 from .retry_stream_responses import AsyncRetryStreamResponse, RetryStreamResponse
@@ -28,8 +28,10 @@ __all__ = [
     "RetryConfig",
     "RetryFailure",
     "RetryModel",
+    "RetryModelParams",
     "RetryPrompt",
     "RetryResponse",
     "RetryStreamResponse",
     "retry",
+    "retry_model",
 ]

--- a/python/mirascope/llm/retries/retry_config.py
+++ b/python/mirascope/llm/retries/retry_config.py
@@ -2,8 +2,8 @@
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-from typing_extensions import TypedDict, Unpack
+from typing import TYPE_CHECKING, TypedDict
+from typing_extensions import Unpack
 
 from ..exceptions import (
     ConnectionError,

--- a/python/tests/llm/retries/test_model_context_retry.py
+++ b/python/tests/llm/retries/test_model_context_retry.py
@@ -44,10 +44,7 @@ def test_retry_call_with_retry_model_context_uses_context_config(
         return "Hello"
 
     # Override with a RetryModel that has different retry config
-    context_retry_model = llm.retry(
-        llm.Model("mock/override-model"),
-        max_retries=1,
-    )
+    context_retry_model = llm.retry_model("mock/override-model", max_retries=1)
 
     with context_retry_model, pytest.raises(llm.RetriesExhausted) as exc_info:
         # Should fail because context model only has max_retries=1
@@ -94,10 +91,7 @@ def test_regular_call_with_retry_model_context_gets_retry_semantics(
         return "Hello"
 
     # Override with a RetryModel via context
-    context_retry_model = llm.retry(
-        llm.Model("mock/override-model"),
-        max_retries=1,
-    )
+    context_retry_model = llm.retry_model("mock/override-model", max_retries=1)
 
     with context_retry_model:
         response = greet()
@@ -120,10 +114,7 @@ def test_regular_call_with_retry_model_context_respects_retry_config(
         return "Hello"
 
     # Override with a RetryModel that has max_retries=1
-    context_retry_model = llm.retry(
-        llm.Model("mock/override-model"),
-        max_retries=1,
-    )
+    context_retry_model = llm.retry_model("mock/override-model", max_retries=1)
 
     with context_retry_model, pytest.raises(llm.RetriesExhausted) as exc_info:
         # Should fail because context model only has max_retries=1
@@ -146,10 +137,7 @@ async def test_async_regular_call_with_retry_model_context_gets_retry_semantics(
         return "Hello"
 
     # Override with a RetryModel via context
-    context_retry_model = llm.retry(
-        llm.Model("mock/override-model"),
-        max_retries=1,
-    )
+    context_retry_model = llm.retry_model("mock/override-model", max_retries=1)
 
     with context_retry_model:
         response = await greet()
@@ -202,10 +190,7 @@ def test_regular_call_stream_with_retry_model_context_gets_retry_semantics(
         return "Hello"
 
     # Override with a RetryModel via context
-    context_retry_model = llm.retry(
-        llm.Model("mock/override-model"),
-        max_retries=1,
-    )
+    context_retry_model = llm.retry_model("mock/override-model", max_retries=1)
 
     with context_retry_model:
         response = greet.stream()
@@ -265,10 +250,7 @@ async def test_async_regular_call_stream_with_retry_model_context_gets_retry_sem
         return "Hello"
 
     # Override with a RetryModel via context
-    context_retry_model = llm.retry(
-        llm.Model("mock/override-model"),
-        max_retries=1,
-    )
+    context_retry_model = llm.retry_model("mock/override-model", max_retries=1)
 
     with context_retry_model:
         response = await greet.stream()
@@ -302,10 +284,8 @@ def test_retry_call_with_retry_model_context_uses_fallbacks(
         return "Hello"
 
     # Override with a RetryModel that has fallback models
-    context_retry_model = llm.retry(
-        llm.Model("mock/primary"),
-        max_retries=0,
-        fallback_models=["mock/fallback"],
+    context_retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
     )
 
     with context_retry_model:
@@ -331,10 +311,8 @@ async def test_async_retry_call_with_retry_model_context_uses_fallbacks(
         return "Hello"
 
     # Override with a RetryModel that has fallback models
-    context_retry_model = llm.retry(
-        llm.Model("mock/primary"),
-        max_retries=0,
-        fallback_models=["mock/fallback"],
+    context_retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
     )
 
     with context_retry_model:

--- a/python/tests/llm/retries/test_retry_decorator.py
+++ b/python/tests/llm/retries/test_retry_decorator.py
@@ -9,29 +9,6 @@ from .mock_provider import MockProvider
 # --- Sync decorator tests ---
 
 
-def test_retry_on_model(mock_provider: MockProvider) -> None:
-    """Test that retry() works directly on a Model."""
-    model = llm.Model("mock/test-model")
-    retry_model = llm.retry(model, max_retries=2)
-
-    response = retry_model.call("hello")
-
-    assert response.pretty() == "mock response"
-    assert len(response.retry_failures) == 0
-    assert response.model.retry_config.max_retries == 2
-
-
-def test_retry_on_retry_model_updates_config(mock_provider: MockProvider) -> None:
-    """Test that retry() on a RetryModel updates the config."""
-    model = llm.Model("mock/test-model")
-    retry_model = llm.retry(model, max_retries=2)
-    updated_retry_model = llm.retry(retry_model, max_retries=4)
-
-    response = updated_retry_model.call("hello")
-
-    assert response.model.retry_config.max_retries == 4
-
-
 def test_retry_on_call_produces_retry_call(mock_provider: MockProvider) -> None:
     """Test that retry() on a Call produces a RetryCall."""
 

--- a/python/tests/llm/retries/test_retry_models.py
+++ b/python/tests/llm/retries/test_retry_models.py
@@ -7,15 +7,13 @@ from .mock_provider import MockProvider
 
 def test_model_id_property(mock_provider: MockProvider) -> None:  # noqa: ARG001
     """Test that model_id delegates to wrapped model."""
-    model = llm.Model("mock/test-model")
-    retry_model = llm.retry(model, max_retries=2)
+    retry_model = llm.retry_model("mock/test-model", max_retries=2)
 
     assert retry_model.model_id == "mock/test-model"
 
 
 def test_params_property(mock_provider: MockProvider) -> None:  # noqa: ARG001
     """Test that params delegates to wrapped model."""
-    model = llm.Model("mock/test-model")
-    retry_model = llm.retry(model, max_retries=2)
+    retry_model = llm.retry_model("mock/test-model", max_retries=2)
 
     assert retry_model.params is not None

--- a/python/tests/llm/retries/test_retry_responses.py
+++ b/python/tests/llm/retries/test_retry_responses.py
@@ -78,8 +78,9 @@ def test_resume_uses_fallback_model_when_original_succeeded_on_fallback(
     # First call: primary fails, fallback succeeds
     mock_provider.set_exceptions([CONNECTION_ERROR])
 
-    primary = llm.Model("mock/primary")
-    retry_model = llm.retry(primary, max_retries=0, fallback_models=["mock/fallback"])
+    retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
+    )
 
     response = retry_model.call("Hello")
 
@@ -101,8 +102,9 @@ def test_resume_can_fall_back_to_original_if_fallback_fails(
     # First call: primary fails, fallback succeeds
     mock_provider.set_exceptions([CONNECTION_ERROR])
 
-    primary = llm.Model("mock/primary")
-    retry_model = llm.retry(primary, max_retries=0, fallback_models=["mock/fallback"])
+    retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
+    )
 
     response = retry_model.call("Hello")
 
@@ -128,8 +130,9 @@ async def test_async_resume_uses_fallback_model_when_original_succeeded_on_fallb
     # First call: primary fails, fallback succeeds
     mock_provider.set_exceptions([CONNECTION_ERROR])
 
-    primary = llm.Model("mock/primary")
-    retry_model = llm.retry(primary, max_retries=0, fallback_models=["mock/fallback"])
+    retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
+    )
 
     response = await retry_model.call_async("Hello")
 
@@ -152,8 +155,9 @@ async def test_async_resume_can_fall_back_to_original_if_fallback_fails(
     # First call: primary fails, fallback succeeds
     mock_provider.set_exceptions([CONNECTION_ERROR])
 
-    primary = llm.Model("mock/primary")
-    retry_model = llm.retry(primary, max_retries=0, fallback_models=["mock/fallback"])
+    retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
+    )
 
     response = await retry_model.call_async("Hello")
 

--- a/python/tests/llm/retries/test_retry_stream_responses.py
+++ b/python/tests/llm/retries/test_retry_stream_responses.py
@@ -518,8 +518,7 @@ def test_structured_stream_yields_partials(mock_provider: MockProvider) -> None:
     # Set up mock to return valid JSON
     mock_provider.set_stream_text('{"name": "Alice", "age": 30}')
 
-    model = llm.Model("mock/test-model")
-    retry_model = llm.retry(model, max_retries=1)
+    retry_model = llm.retry_model("mock/test-model", max_retries=1)
 
     response = retry_model.stream("Get person", format=Person)
 
@@ -538,8 +537,7 @@ def test_structured_stream_raises_for_output_parser(
     def custom_parser(response: llm.RootResponse[llm.Toolkit, None]) -> str:
         return response.text()
 
-    model = llm.Model("mock/test-model")
-    retry_model = llm.retry(model, max_retries=1)
+    retry_model = llm.retry_model("mock/test-model", max_retries=1)
 
     response = retry_model.stream("Hello", format=custom_parser)
 
@@ -582,8 +580,7 @@ async def test_async_structured_stream_yields_partials(
     # Set up mock to return valid JSON
     mock_provider.set_stream_text('{"name": "Bob", "age": 25}')
 
-    model = llm.Model("mock/test-model")
-    retry_model = llm.retry(model, max_retries=1)
+    retry_model = llm.retry_model("mock/test-model", max_retries=1)
 
     response = await retry_model.stream_async("Get person", format=Person)
 
@@ -603,8 +600,7 @@ async def test_async_structured_stream_raises_for_output_parser(
     def custom_parser(response: llm.RootResponse[llm.Toolkit, None]) -> str:
         return response.text()
 
-    model = llm.Model("mock/test-model")
-    retry_model = llm.retry(model, max_retries=1)
+    retry_model = llm.retry_model("mock/test-model", max_retries=1)
 
     response = await retry_model.stream_async("Hello", format=custom_parser)
 
@@ -701,8 +697,9 @@ def test_resume_uses_fallback_model_when_original_succeeded_on_fallback(
     # First stream: primary fails, fallback succeeds
     mock_provider.set_stream_exceptions([CONNECTION_ERROR])
 
-    primary = llm.Model("mock/primary")
-    retry_model = llm.retry(primary, max_retries=0, fallback_models=["mock/fallback"])
+    retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
+    )
 
     response = retry_model.stream("Hello")
 
@@ -734,8 +731,9 @@ def test_resume_can_fall_back_to_original_if_fallback_fails(
     # First stream: primary fails, fallback succeeds
     mock_provider.set_stream_exceptions([CONNECTION_ERROR])
 
-    primary = llm.Model("mock/primary")
-    retry_model = llm.retry(primary, max_retries=0, fallback_models=["mock/fallback"])
+    retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
+    )
 
     response = retry_model.stream("Hello")
 
@@ -782,8 +780,9 @@ async def test_async_resume_uses_fallback_model_when_original_succeeded_on_fallb
     # First stream: primary fails, fallback succeeds
     mock_provider.set_stream_exceptions([CONNECTION_ERROR])
 
-    primary = llm.Model("mock/primary")
-    retry_model = llm.retry(primary, max_retries=0, fallback_models=["mock/fallback"])
+    retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
+    )
 
     response = await retry_model.stream_async("Hello")
 
@@ -816,8 +815,9 @@ async def test_async_resume_can_fall_back_to_original_if_fallback_fails(
     # First stream: primary fails, fallback succeeds
     mock_provider.set_stream_exceptions([CONNECTION_ERROR])
 
-    primary = llm.Model("mock/primary")
-    retry_model = llm.retry(primary, max_retries=0, fallback_models=["mock/fallback"])
+    retry_model = llm.retry_model(
+        "mock/primary", max_retries=0, fallback_models=["mock/fallback"]
+    )
 
     response = await retry_model.stream_async("Hello")
 

--- a/python/tests/llm/retries/test_retry_validate.py
+++ b/python/tests/llm/retries/test_retry_validate.py
@@ -25,10 +25,7 @@ def test_validate_retries_on_connection_error_during_resume(
     # Resume attempt 1 fails with ConnectionError, retry succeeds
     mock_provider.set_response_texts(["not valid json", '{"name": "Alice", "age": 30}'])
 
-    retry_model = llm.retry(
-        llm.Model("mock/primary"),
-        max_retries=1,
-    )
+    retry_model = llm.retry_model("mock/primary", max_retries=1)
 
     response = retry_model.call("Get person", format=Person)
     assert response.text() == snapshot("not valid json")
@@ -58,8 +55,8 @@ def test_validate_uses_fallback_when_resume_fails(
     # Resume on primary fails with ConnectionError, fallback succeeds
     mock_provider.set_response_texts(["not valid json", '{"name": "Bob", "age": 25}'])
 
-    retry_model = llm.retry(
-        llm.Model("mock/primary"),
+    retry_model = llm.retry_model(
+        "mock/primary",
         max_retries=0,  # No retries on primary, must fall back
         fallback_models=["mock/fallback"],
     )
@@ -96,10 +93,7 @@ async def test_async_validate_retries_on_connection_error_during_resume(
     # Resume attempt 1 fails with ConnectionError, retry succeeds
     mock_provider.set_response_texts(["not valid json", '{"name": "Carol", "age": 35}'])
 
-    retry_model = llm.retry(
-        llm.Model("mock/primary"),
-        max_retries=1,
-    )
+    retry_model = llm.retry_model("mock/primary", max_retries=1)
 
     response = await retry_model.call_async("Get person", format=Person)
     assert response.text() == snapshot("not valid json")
@@ -130,8 +124,8 @@ async def test_async_validate_uses_fallback_when_resume_fails(
     # Resume on primary fails with ConnectionError, fallback succeeds
     mock_provider.set_response_texts(["not valid json", '{"name": "Dave", "age": 40}'])
 
-    retry_model = llm.retry(
-        llm.Model("mock/primary"),
+    retry_model = llm.retry_model(
+        "mock/primary",
         max_retries=0,  # No retries on primary, must fall back
         fallback_models=["mock/fallback"],
     )


### PR DESCRIPTION
Remove support for `llm.retry()` decorator to take models, it's
inconsistent with the other decorators.