### PR TITLE
refactor(python-sdk): simplify llm.StreamRestarted error

### DIFF
--- a/python/mirascope/llm/exceptions.py
+++ b/python/mirascope/llm/exceptions.py
@@ -411,24 +411,19 @@ class StreamRestarted(Error):
                     print(chunk, end="", flush=True)
                 break  # Success
             except llm.StreamRestarted as e:
-                print(f"\\n[Retry {e.attempt} after: {e.failure.exception}]")
+                print(e.message)
                 # Loop continues, re-iterates the response
         ```
     """
-
-    attempt: int
-    """The attempt number we're now on (2, 3, ...)."""
 
     failure: "RetryFailure"
     """The failure that triggered the restart."""
 
     def __init__(
         self,
-        attempt: int,
         failure: "RetryFailure",
     ) -> None:
-        message = f"Stream restarted (attempt {attempt}) due to: {failure.exception}"
+        message = f"Stream restarted due to: {failure.exception}"
         super().__init__(message)
-        self.attempt = attempt
         self.failure = failure
         self.__cause__ = failure.exception

--- a/python/mirascope/llm/retries/retry_stream_responses.py
+++ b/python/mirascope/llm/retries/retry_stream_responses.py
@@ -47,7 +47,7 @@ class RetryStreamResponse(StreamResponse[FormattableT]):
                     print(chunk, end="", flush=True)
                 break  # Success
             except llm.StreamRestarted as e:
-                print(f"\\n[Retry {e.attempt} after: {e.error}]")
+                print(e.message)
         ```
     """
 
@@ -124,7 +124,6 @@ class RetryStreamResponse(StreamResponse[FormattableT]):
             self._reset_stream(self._current_variant)
 
             raise StreamRestarted(
-                attempt=len(self.retry_failures),
                 failure=failure,
             ) from e
 
@@ -169,7 +168,7 @@ class AsyncRetryStreamResponse(AsyncStreamResponse[FormattableT]):
                     print(chunk, end="", flush=True)
                 break  # Success
             except llm.StreamRestarted as e:
-                print(f"\\n[Retry {e.attempt} after: {e.error}]")
+                print(e.message)
         ```
     """
 
@@ -250,7 +249,6 @@ class AsyncRetryStreamResponse(AsyncStreamResponse[FormattableT]):
             await self._reset_stream(self._current_variant)
 
             raise StreamRestarted(
-                attempt=len(self.retry_failures),
                 failure=failure,
             ) from e
 
@@ -289,7 +287,6 @@ class ContextRetryStreamResponse(
 
     Example:
         ```python
-        ctx = llm.Context(deps=my_deps)
         response = retry_model.context_stream("Tell me a story", ctx=ctx)
 
         while True:
@@ -298,7 +295,7 @@ class ContextRetryStreamResponse(
                     print(chunk, end="", flush=True)
                 break  # Success
             except llm.StreamRestarted as e:
-                print(f"\\n[Retry {e.attempt} after: {e.error}]")
+                print(e.message)
         ```
     """
 
@@ -375,7 +372,6 @@ class ContextRetryStreamResponse(
             self._reset_stream(self._current_variant)
 
             raise StreamRestarted(
-                attempt=len(self.retry_failures),
                 failure=failure,
             ) from e
 
@@ -427,7 +423,7 @@ class AsyncContextRetryStreamResponse(
                     print(chunk, end="", flush=True)
                 break  # Success
             except llm.StreamRestarted as e:
-                print(f"\\n[Retry {e.attempt} after: {e.error}]")
+                print(e.message)
         ```
     """
 
@@ -512,7 +508,6 @@ class AsyncContextRetryStreamResponse(
             await self._reset_stream(self._current_variant)
 
             raise StreamRestarted(
-                attempt=len(self.retry_failures),
                 failure=failure,
             ) from e
 

--- a/python/tests/llm/retries/test_context_retry_stream_responses.py
+++ b/python/tests/llm/retries/test_context_retry_stream_responses.py
@@ -40,7 +40,6 @@ def test_context_stream_raises_stream_restarted_on_error(
     with pytest.raises(llm.StreamRestarted) as exc_info:
         list(response.text_stream())
 
-    assert exc_info.value.attempt == 1
     assert exc_info.value.failure.exception is CONNECTION_ERROR
     assert len(response.retry_failures) == 1
     assert [f.exception for f in response.retry_failures] == [CONNECTION_ERROR]
@@ -275,7 +274,6 @@ async def test_async_context_stream_raises_stream_restarted_on_error(
     with pytest.raises(llm.StreamRestarted) as exc_info:
         _ = [chunk async for chunk in response.text_stream()]
 
-    assert exc_info.value.attempt == 1
     assert exc_info.value.failure.exception is TIMEOUT_ERROR
     assert len(response.retry_failures) == 1
 

--- a/python/tests/llm/retries/test_retry_fallback.py
+++ b/python/tests/llm/retries/test_retry_fallback.py
@@ -151,10 +151,8 @@ def test_stream_fallback_model_tried_after_primary_exhausted(
     response = retry_model.stream("Hello")
 
     # First iteration fails, triggers StreamRestarted
-    with pytest.raises(llm.StreamRestarted) as exc_info:
+    with pytest.raises(llm.StreamRestarted):
         list(response.chunk_stream())
-
-    assert exc_info.value.attempt == 1
 
     # After restart, should use fallback model
     assert response.model.model_id == "mock/fallback"
@@ -186,21 +184,18 @@ def test_stream_fallback_model_gets_own_retry_budget(
     response = retry_model.stream("Hello")
 
     # First iteration: primary attempt 1 fails
-    with pytest.raises(llm.StreamRestarted) as exc_info:
+    with pytest.raises(llm.StreamRestarted):
         list(response.chunk_stream())
-    assert exc_info.value.attempt == 1
     assert response.model.model_id == "mock/primary"  # Still on primary (has retries)
 
     # Second iteration: primary attempt 2 (retry) fails, moves to fallback
-    with pytest.raises(llm.StreamRestarted) as exc_info:
+    with pytest.raises(llm.StreamRestarted):
         list(response.chunk_stream())
-    assert exc_info.value.attempt == 2
     assert response.model.model_id == "mock/fallback"  # Now on fallback
 
     # Third iteration: fallback attempt 1 fails
-    with pytest.raises(llm.StreamRestarted) as exc_info:
+    with pytest.raises(llm.StreamRestarted):
         list(response.chunk_stream())
-    assert exc_info.value.attempt == 3
     assert response.model.model_id == "mock/fallback"  # Still on fallback (has retries)
 
     # Fourth iteration: fallback attempt 2 succeeds
@@ -257,10 +252,9 @@ async def test_stream_async_fallback_model_tried_after_primary_exhausted(
     response = await retry_model.stream_async("Hello")
 
     # First iteration fails
-    with pytest.raises(llm.StreamRestarted) as exc_info:
+    with pytest.raises(llm.StreamRestarted):
         async for _ in response.chunk_stream():
             pass
-    assert exc_info.value.attempt == 1
 
     # After restart, should use fallback model
     assert response.model.model_id == "mock/fallback"

--- a/python/tests/llm/retries/test_retry_stream_responses.py
+++ b/python/tests/llm/retries/test_retry_stream_responses.py
@@ -45,7 +45,6 @@ def test_stream_raises_stream_restarted_on_error(mock_provider: MockProvider) ->
     with pytest.raises(llm.StreamRestarted) as exc_info:
         list(response.text_stream())
 
-    assert exc_info.value.attempt == 1
     assert exc_info.value.failure.exception is CONNECTION_ERROR
     assert len(response.retry_failures) == 1
     assert [f.exception for f in response.retry_failures] == [CONNECTION_ERROR]
@@ -184,7 +183,6 @@ async def test_stream_async_raises_stream_restarted_on_error(
     with pytest.raises(llm.StreamRestarted) as exc_info:
         _ = [chunk async for chunk in response.text_stream()]
 
-    assert exc_info.value.attempt == 1
     assert exc_info.value.failure.exception is TIMEOUT_ERROR
     assert len(response.retry_failures) == 1
 


### PR DESCRIPTION
Remove attempt # tracking, it's a bit confusing and unnecessary. Can use
len(response.retry_failures) if needed.