### PR TITLE
fix(python-sdk): RetryResponse.resume respects model context override

### DIFF
--- a/python/mirascope/llm/retries/retry_responses.py
+++ b/python/mirascope/llm/retries/retry_responses.py
@@ -11,7 +11,7 @@ from ..responses import (
     ContextResponse,
     Response,
 )
-from .utils import RetryFailure
+from .utils import RetryFailure, get_retry_model_from_context
 
 if TYPE_CHECKING:
     from .retry_models import RetryModel
@@ -54,12 +54,15 @@ class RetryResponse(Response[FormattableT]):
     def model(self) -> "RetryModel":
         """A RetryModel with the successful model as active.
 
-        This RetryModel has the same pool of available models, but with the
-        model that succeeded set as the active model. This means:
+        If a model is set in context (via `llm.model()` or `llm.retry_model()`),
+        that model is used instead, wrapped with this response's retry config.
+
+        Otherwise, this RetryModel has the same pool of available models, but with
+        the model that succeeded set as the active model. This means:
         - `response.model.model_id` equals `response.model_id`
         - `response.resume()` will try the successful model first
         """
-        return self._retry_model
+        return get_retry_model_from_context(self._retry_model)
 
     @overload
     def resume(
@@ -122,12 +125,15 @@ class AsyncRetryResponse(AsyncResponse[FormattableT]):
     def model(self) -> "RetryModel":
         """A RetryModel with the successful model as active.
 
-        This RetryModel has the same pool of available models, but with the
-        model that succeeded set as the active model. This means:
+        If a model is set in context (via `llm.model()` or `llm.retry_model()`),
+        that model is used instead, wrapped with this response's retry config.
+
+        Otherwise, this RetryModel has the same pool of available models, but with
+        the model that succeeded set as the active model. This means:
         - `response.model.model_id` equals `response.model_id`
         - `response.resume()` will try the successful model first
         """
-        return self._retry_model
+        return get_retry_model_from_context(self._retry_model)
 
     @overload
     async def resume(
@@ -192,12 +198,15 @@ class ContextRetryResponse(
     def model(self) -> "RetryModel":
         """A RetryModel with the successful model as active.
 
-        This RetryModel has the same pool of available models, but with the
-        model that succeeded set as the active model. This means:
+        If a model is set in context (via `llm.model()` or `llm.retry_model()`),
+        that model is used instead, wrapped with this response's retry config.
+
+        Otherwise, this RetryModel has the same pool of available models, but with
+        the model that succeeded set as the active model. This means:
         - `response.model.model_id` equals `response.model_id`
         - `response.resume()` will try the successful model first
         """
-        return self._retry_model
+        return get_retry_model_from_context(self._retry_model)
 
     @overload
     def resume(
@@ -269,12 +278,15 @@ class AsyncContextRetryResponse(
     def model(self) -> "RetryModel":
         """A RetryModel with the successful model as active.
 
-        This RetryModel has the same pool of available models, but with the
-        model that succeeded set as the active model. This means:
+        If a model is set in context (via `llm.model()` or `llm.retry_model()`),
+        that model is used instead, wrapped with this response's retry config.
+
+        Otherwise, this RetryModel has the same pool of available models, but with
+        the model that succeeded set as the active model. This means:
         - `response.model.model_id` equals `response.model_id`
         - `response.resume()` will try the successful model first
         """
-        return self._retry_model
+        return get_retry_model_from_context(self._retry_model)
 
     @overload
     async def resume(

--- a/python/mirascope/llm/retries/retry_stream_responses.py
+++ b/python/mirascope/llm/retries/retry_stream_responses.py
@@ -17,7 +17,7 @@ from ..responses import (
     ContextStreamResponse,
     StreamResponse,
 )
-from .utils import RetryFailure
+from .utils import RetryFailure, get_retry_model_from_context
 
 if TYPE_CHECKING:
     from .retry_models import RetryModel
@@ -85,8 +85,12 @@ class RetryStreamResponse(StreamResponse[FormattableT]):
 
     @property
     def model(self) -> "RetryModel":
-        """A RetryModel with parameters matching this response."""
-        return self._current_variant
+        """A RetryModel with parameters matching this response.
+
+        If a model is set in context (via `llm.model()` or `llm.retry_model()`),
+        that model is used instead, wrapped with this response's retry config.
+        """
+        return get_retry_model_from_context(self._current_variant)
 
     def _reset_stream(self, variant: "RetryModel") -> None:
         """Reset to a fresh stream for a new retry attempt."""
@@ -209,8 +213,12 @@ class AsyncRetryStreamResponse(AsyncStreamResponse[FormattableT]):
 
     @property
     def model(self) -> "RetryModel":
-        """A RetryModel with parameters matching this response."""
-        return self._current_variant
+        """A RetryModel with parameters matching this response.
+
+        If a model is set in context (via `llm.model()` or `llm.retry_model()`),
+        that model is used instead, wrapped with this response's retry config.
+        """
+        return get_retry_model_from_context(self._current_variant)
 
     async def _reset_stream(self, variant: "RetryModel") -> None:
         """Reset to a fresh stream for a new retry attempt."""
@@ -333,8 +341,12 @@ class ContextRetryStreamResponse(
 
     @property
     def model(self) -> "RetryModel":
-        """A RetryModel with parameters matching this response."""
-        return self._current_variant
+        """A RetryModel with parameters matching this response.
+
+        If a model is set in context (via `llm.model()` or `llm.retry_model()`),
+        that model is used instead, wrapped with this response's retry config.
+        """
+        return get_retry_model_from_context(self._current_variant)
 
     def _reset_stream(self, variant: "RetryModel") -> None:
         """Reset to a fresh stream for a new retry attempt."""
@@ -468,8 +480,12 @@ class AsyncContextRetryStreamResponse(
 
     @property
     def model(self) -> "RetryModel":
-        """A RetryModel with parameters matching this response."""
-        return self._current_variant
+        """A RetryModel with parameters matching this response.
+
+        If a model is set in context (via `llm.model()` or `llm.retry_model()`),
+        that model is used instead, wrapped with this response's retry config.
+        """
+        return get_retry_model_from_context(self._current_variant)
 
     async def _reset_stream(self, variant: "RetryModel") -> None:
         """Reset to a fresh stream for a new retry attempt."""

--- a/python/mirascope/llm/retries/utils.py
+++ b/python/mirascope/llm/retries/utils.py
@@ -12,6 +12,30 @@ if TYPE_CHECKING:
     from ..models import Model
     from .retry_models import RetryModel
 
+
+def get_retry_model_from_context(stored_retry_model: "RetryModel") -> "RetryModel":
+    """Get the RetryModel to use, checking context for overrides.
+
+    If a model is set in context (via `llm.model()` or `llm.retry_model()`),
+    that model is used instead, wrapped with this response's retry config.
+
+    Args:
+        stored_retry_model: The RetryModel stored on the response.
+
+    Returns:
+        Either the context model (wrapped in RetryModel if needed) or the stored model.
+    """
+    from ..models import model_from_context
+    from .retry_models import RetryModel
+
+    context_model = model_from_context()
+    if context_model is not None:
+        if isinstance(context_model, RetryModel):
+            return context_model
+        return RetryModel(context_model, stored_retry_model.retry_config)
+    return stored_retry_model
+
+
 _ResultT = TypeVar("_ResultT")
 
 


### PR DESCRIPTION
For consistency with Response.resume