### PR TITLE
feat(seo): use title length based font size and line height

### DIFF
--- a/cloud/app/lib/social-cards/element.ts
+++ b/cloud/app/lib/social-cards/element.ts
@@ -10,6 +10,29 @@
 export const CARD_WIDTH = 1200;
 export const CARD_HEIGHT = 630;
 
+/** Font size breakpoints based on title length */
+const FONT_SIZE_BREAKPOINTS = [
+  { maxChars: 13, fontSize: 152, label: "XS" },
+  { maxChars: 27, fontSize: 128, label: "S" },
+  { maxChars: 42, fontSize: 100, label: "SM" },
+  { maxChars: 59, fontSize: 95, label: "M" },
+  { maxChars: 80, fontSize: 75, label: "L" },
+  { maxChars: Infinity, fontSize: 60, label: "XL" },
+] as const;
+
+export function getTitleFontSize(title: string): {
+  fontSize: number;
+  label: string;
+} {
+  const length = title.length;
+  for (const { maxChars, fontSize, label } of FONT_SIZE_BREAKPOINTS) {
+    if (length <= maxChars) {
+      return { fontSize, label };
+    }
+  }
+  return { fontSize: 60, label: "XL" };
+}
+
 /**
  * Create the social card element structure as a plain object
  * Satori accepts both React elements and plain object representations
@@ -56,12 +79,19 @@ export function createSocialCardElement(
           type: "div",
           props: {
             style: {
-              fontFamily: "Williams Handwriting",
-              fontSize: 68,
+              // Box model
+              maxWidth: "80%",
+              paddingTop: 100,
+              // Typography
+              fontFamily: "Williams Handwriting, cursive",
+              fontSize: getTitleFontSize(title).fontSize,
+              lineHeight: title.length > 40 ? 1.3 : 1.2,
               color: "#ffffff",
               textAlign: "center",
-              lineHeight: 1.3,
-              maxWidth: "80%",
+              // Text wrapping
+              overflowWrap: "break-word",
+              hyphens: "auto",
+              // Effects
               textShadow:
                 "0 2px 6px rgba(0, 0, 0, 0.3), 0 4px 14px rgba(0, 0, 0, 0.2)",
             },

--- a/cloud/app/routes/dev/social-card.tsx
+++ b/cloud/app/routes/dev/social-card.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import DevLayout from "@/app/components/blocks/dev/dev-layout";
 import LoadingContent from "@/app/components/blocks/loading-content";
 import { getAllDevMeta } from "@/app/lib/content/virtual-module";
+import { getTitleFontSize } from "@/app/lib/social-cards/element";
 import {
   loadAssetsBrowser,
   renderSocialCardToDataUrl,
@@ -112,7 +113,8 @@ function SocialCardPreview() {
               Title
             </label>
             <span className="text-sm text-gray-500">
-              {title.length} characters
+              {title.length} characters — {getTitleFontSize(title).fontSize}px (
+              {getTitleFontSize(title).label})
             </span>
           </div>
           <input


### PR DESCRIPTION
Same font-size and line-height strategy as in the old website.

### Before

![image.png](https://app.graphite.com/user-attachments/assets/c8d03f80-a8c4-45c2-a075-82689d0fa74b.png)

### After

![image.png](https://app.graphite.com/user-attachments/assets/e35a1a34-a91b-4809-ab04-3c6d7841402d.png)

