### PR TITLE
feat(cloud): initial implementation of deployment/live.ts

### DIFF
--- a/cloud/claws/deployment/live.test.ts
+++ b/cloud/claws/deployment/live.test.ts
@@ -1,0 +1,291 @@
+/**
+ * @fileoverview Tests for the live deployment service.
+ *
+ * Verifies that LiveDeploymentService correctly orchestrates
+ * CloudflareR2Service and CloudflareContainerService to provision,
+ * deprovision, restart, update, and query claw deployments.
+ */
+
+import { Effect, Layer } from "effect";
+import { describe, it, expect } from "vitest";
+
+import type { OpenClawConfig } from "@/claws/deployment/types";
+
+import { DeploymentError } from "@/claws/deployment/errors";
+import { LiveDeploymentService } from "@/claws/deployment/live";
+import { DeploymentService } from "@/claws/deployment/service";
+import { getClawUrl } from "@/claws/deployment/types";
+import { makeMockContainerLayer } from "@/cloudflare/containers/mock";
+import { makeMockR2Layer } from "@/cloudflare/r2/mock";
+
+const testConfig: OpenClawConfig = {
+  clawId: "claw-test-123",
+  clawSlug: "my-claw",
+  organizationId: "org-456",
+  organizationSlug: "my-org",
+  instanceType: "basic",
+  r2: {
+    bucketName: "claw-claw-test-123",
+    accessKeyId: "test-access-key",
+    secretAccessKey: "test-secret-key",
+  },
+  containerEnv: {
+    MIRASCOPE_API_KEY: "key_abc123",
+    ANTHROPIC_API_KEY: "key_abc123",
+    ANTHROPIC_BASE_URL: "https://router.mirascope.com/v1",
+    OPENCLAW_GATEWAY_TOKEN: "gw_token_xyz",
+  },
+};
+
+/** Internal routing hostname — matches clawHostname(clawId) in live.ts. */
+const INTERNAL_HOSTNAME = `${testConfig.clawId}.claws.mirascope.com`;
+
+function createTestLayer() {
+  const r2Layer = makeMockR2Layer();
+  const { layer: containerLayer, seed } = makeMockContainerLayer();
+  const liveLayer = LiveDeploymentService.pipe(
+    Layer.provide(Layer.merge(r2Layer, containerLayer)),
+  );
+  return { layer: liveLayer, seedContainer: seed };
+}
+
+const run = <A, E>(effect: Effect.Effect<A, E, DeploymentService>) => {
+  const { layer } = createTestLayer();
+  return Effect.runPromise(effect.pipe(Effect.provide(layer)));
+};
+
+const runFail = <A, E>(effect: Effect.Effect<A, E, DeploymentService>) => {
+  const { layer } = createTestLayer();
+  return Effect.runPromise(effect.pipe(Effect.flip, Effect.provide(layer)));
+};
+
+describe("LiveDeploymentService", () => {
+  describe("provision", () => {
+    it("creates R2 bucket, credentials, and warms up container", async () => {
+      const status = await run(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.provision(testConfig);
+        }),
+      );
+
+      expect(status.status).toBe("provisioning");
+      expect(status.url).toBe(
+        getClawUrl(testConfig.organizationSlug, testConfig.clawSlug),
+      );
+      expect(status.startedAt).toBeInstanceOf(Date);
+    });
+
+    it("fails when R2 bucket already exists", async () => {
+      const error = await runFail(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          // Provision once
+          yield* deployment.provision(testConfig);
+          // Provision again — bucket already exists
+          return yield* deployment.provision(testConfig);
+        }),
+      );
+
+      expect(error).toBeInstanceOf(DeploymentError);
+      expect((error as DeploymentError).message).toContain(
+        "Failed to create R2 bucket",
+      );
+    });
+  });
+
+  describe("deprovision", () => {
+    it("destroys container and deletes R2 bucket", async () => {
+      await run(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          yield* deployment.provision(testConfig);
+          yield* deployment.deprovision(testConfig.clawId);
+        }),
+      );
+    });
+
+    it("succeeds even if container is already gone", async () => {
+      // Deprovision without provisioning first — should not throw
+      await run(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          yield* deployment.deprovision("nonexistent-claw");
+        }),
+      );
+    });
+  });
+
+  describe("getStatus", () => {
+    it("returns active for running container", async () => {
+      const { layer, seedContainer } = createTestLayer();
+      seedContainer(INTERNAL_HOSTNAME, {
+        status: "running",
+        lastChange: 1700000000000,
+      });
+
+      const status = await Effect.runPromise(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.getStatus(testConfig.clawId);
+        }).pipe(Effect.provide(layer)),
+      );
+
+      expect(status.status).toBe("active");
+      expect(status.startedAt).toEqual(new Date(1700000000000));
+    });
+
+    it("returns active for healthy container", async () => {
+      const { layer, seedContainer } = createTestLayer();
+      seedContainer(INTERNAL_HOSTNAME, { status: "healthy", lastChange: 1000 });
+
+      const status = await Effect.runPromise(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.getStatus(testConfig.clawId);
+        }).pipe(Effect.provide(layer)),
+      );
+
+      expect(status.status).toBe("active");
+    });
+
+    it("returns paused for stopped container", async () => {
+      const { layer, seedContainer } = createTestLayer();
+      seedContainer(INTERNAL_HOSTNAME, {
+        status: "stopped",
+        lastChange: 1000,
+        exitCode: 0,
+      });
+
+      const status = await Effect.runPromise(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.getStatus(testConfig.clawId);
+        }).pipe(Effect.provide(layer)),
+      );
+
+      expect(status.status).toBe("paused");
+    });
+
+    it("returns paused for stopping container", async () => {
+      const { layer, seedContainer } = createTestLayer();
+      seedContainer(INTERNAL_HOSTNAME, { status: "stopping" });
+
+      const status = await Effect.runPromise(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.getStatus(testConfig.clawId);
+        }).pipe(Effect.provide(layer)),
+      );
+
+      expect(status.status).toBe("paused");
+    });
+
+    it("returns error for unknown status", async () => {
+      const { layer, seedContainer } = createTestLayer();
+      seedContainer(INTERNAL_HOSTNAME, { status: "unknown" });
+
+      const status = await Effect.runPromise(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.getStatus(testConfig.clawId);
+        }).pipe(Effect.provide(layer)),
+      );
+
+      expect(status.status).toBe("error");
+    });
+
+    it("returns undefined startedAt when lastChange is missing", async () => {
+      const { layer, seedContainer } = createTestLayer();
+      seedContainer(INTERNAL_HOSTNAME, { status: "running" });
+
+      const status = await Effect.runPromise(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.getStatus(testConfig.clawId);
+        }).pipe(Effect.provide(layer)),
+      );
+
+      expect(status.status).toBe("active");
+      expect(status.startedAt).toBeUndefined();
+    });
+
+    it("fails for non-existent container", async () => {
+      const error = await runFail(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.getStatus("nonexistent");
+        }),
+      );
+
+      expect(error).toBeInstanceOf(DeploymentError);
+      expect((error as DeploymentError).message).toContain(
+        "Failed to get container state",
+      );
+    });
+  });
+
+  describe("restart", () => {
+    it("restarts gateway and returns provisioning status", async () => {
+      const { layer, seedContainer } = createTestLayer();
+      seedContainer(INTERNAL_HOSTNAME);
+
+      const status = await Effect.runPromise(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.restart(testConfig.clawId);
+        }).pipe(Effect.provide(layer)),
+      );
+
+      expect(status.status).toBe("provisioning");
+      expect(status.startedAt).toBeInstanceOf(Date);
+    });
+
+    it("fails for non-existent container", async () => {
+      const error = await runFail(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.restart("nonexistent");
+        }),
+      );
+
+      expect(error).toBeInstanceOf(DeploymentError);
+      expect((error as DeploymentError).message).toContain(
+        "Failed to restart gateway",
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("restarts gateway for config update", async () => {
+      const { layer, seedContainer } = createTestLayer();
+      seedContainer(INTERNAL_HOSTNAME);
+
+      const status = await Effect.runPromise(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.update(testConfig.clawId, {
+            instanceType: "standard-2",
+          });
+        }).pipe(Effect.provide(layer)),
+      );
+
+      expect(status.status).toBe("provisioning");
+      expect(status.startedAt).toBeInstanceOf(Date);
+    });
+
+    it("fails for non-existent container", async () => {
+      const error = await runFail(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          return yield* deployment.update("nonexistent", {});
+        }),
+      );
+
+      expect(error).toBeInstanceOf(DeploymentError);
+      expect((error as DeploymentError).message).toContain(
+        "Failed to restart gateway for config update",
+      );
+    });
+  });
+});

--- a/cloud/claws/deployment/live.ts
+++ b/cloud/claws/deployment/live.ts
@@ -1,0 +1,201 @@
+/**
+ * @fileoverview Live deployment service backed by Cloudflare infrastructure.
+ *
+ * Orchestrates claw provisioning by composing two lower-level services:
+ *
+ * 1. **CloudflareR2Service** — Create/delete R2 buckets, create/revoke
+ *    scoped credentials for per-claw storage.
+ *
+ * 2. **CloudflareContainerService** — Warm up, restart gateway, recreate,
+ *    destroy, and inspect containers via the dispatch worker.
+ *
+ * ## Provision Flow
+ *
+ * ```
+ * provision(config: OpenClawConfig)
+ *   1. Create R2 bucket "claw-{clawId}"
+ *   2. Create scoped R2 credentials for that bucket
+ *   3. Warm up the container (triggers cold start on dispatch worker)
+ *   4. Return DeploymentStatus { status: "provisioning", url }
+ * ```
+ *
+ * The dispatch worker handles the actual container lifecycle:
+ * - On warm-up request, it calls the bootstrap API to get OpenClawConfig
+ * - Starts the container with env vars from the config
+ * - The container mounts R2 via s3fs using the scoped credentials
+ * - Reports "active" status back to Mirascope when ready
+ *
+ * ## Deprovision Flow
+ *
+ * ```
+ * deprovision(clawId)
+ *   1. Destroy the container via dispatch worker
+ *   2. Delete R2 bucket
+ * ```
+ */
+
+import { Effect, Layer } from "effect";
+
+import type { DeploymentStatus } from "@/claws/deployment/service";
+import type { OpenClawConfig } from "@/claws/deployment/types";
+
+import { DeploymentError } from "@/claws/deployment/errors";
+import { DeploymentService } from "@/claws/deployment/service";
+import { getClawUrl } from "@/claws/deployment/types";
+import { CloudflareContainerService } from "@/cloudflare/containers/service";
+import { CloudflareR2Service } from "@/cloudflare/r2/service";
+import { CloudflareApiError } from "@/errors";
+
+/** R2 bucket name for a given claw. */
+function bucketName(clawId: string): string {
+  return `claw-${clawId}`;
+}
+
+/**
+ * Internal routing hostname for a given claw.
+ *
+ * The dispatch worker uses `clawId` to resolve the correct Durable Object
+ * via `idFromName(clawId)`. The public vanity hostname
+ * (`{clawSlug}.{orgSlug}.mirascope.com`) is a separate concern handled
+ * by DNS / the dispatch worker's hostname rewriting.
+ */
+function clawHostname(clawId: string): string {
+  return `${clawId}.claws.mirascope.com`;
+}
+
+/**
+ * Map a CloudflareApiError to a DeploymentError with context.
+ */
+function wrap<A>(
+  context: string,
+  effect: Effect.Effect<A, CloudflareApiError>,
+): Effect.Effect<A, DeploymentError> {
+  return effect.pipe(
+    Effect.mapError(
+      (error) =>
+        new DeploymentError({
+          message: `${context}: ${error.message}`,
+          cause: error,
+        }),
+    ),
+  );
+}
+
+/**
+ * Live deployment service layer.
+ *
+ * Requires `CloudflareR2Service` and `CloudflareContainerService` to be
+ * provided. In production these come from their respective live layers;
+ * in tests, use the mock layers.
+ */
+export const LiveDeploymentService = Layer.effect(
+  DeploymentService,
+  Effect.gen(function* () {
+    const r2 = yield* CloudflareR2Service;
+    const containers = yield* CloudflareContainerService;
+
+    return {
+      provision: (config: OpenClawConfig) =>
+        Effect.gen(function* () {
+          const bucket = bucketName(config.clawId);
+
+          // 1. Create R2 bucket for persistent storage
+          yield* wrap("Failed to create R2 bucket", r2.createBucket(bucket));
+
+          // 2. Create scoped credentials for the bucket
+          yield* wrap(
+            "Failed to create R2 credentials",
+            r2.createScopedCredentials(bucket),
+          );
+
+          // 3. Warm up — triggers the dispatch worker to fetch bootstrap
+          //    config and start the container
+          const host = clawHostname(config.clawId);
+          yield* wrap("Failed to warm up container", containers.warmUp(host));
+
+          // 4. Container will report "active" via status callback
+          return {
+            status: "provisioning",
+            url: getClawUrl(config.organizationSlug, config.clawSlug),
+            startedAt: new Date(),
+          } satisfies DeploymentStatus;
+        }),
+
+      deprovision: (clawId: string) =>
+        Effect.gen(function* () {
+          const bucket = bucketName(clawId);
+          const host = clawHostname(clawId);
+
+          // 1. Destroy the container
+          // TODO: Distinguish "already gone" from real errors — currently
+          // swallowing all errors to avoid failing on already-deprovisioned claws.
+          yield* wrap(
+            "Failed to destroy container",
+            containers.destroy(host),
+          ).pipe(Effect.catchAll(() => Effect.void));
+
+          // 2. Delete R2 bucket
+          // TODO: Same as above — should only swallow "not found" errors.
+          yield* wrap(
+            "Failed to delete R2 bucket",
+            r2.deleteBucket(bucket),
+          ).pipe(Effect.catchAll(() => Effect.void));
+        }),
+
+      getStatus: (clawId: string) =>
+        Effect.gen(function* () {
+          const host = clawHostname(clawId);
+
+          const state = yield* wrap(
+            "Failed to get container state",
+            containers.getState(host),
+          );
+
+          return {
+            status:
+              state.status === "running" || state.status === "healthy"
+                ? "active"
+                : state.status === "stopped" || state.status === "stopping"
+                  ? "paused"
+                  : "error",
+            startedAt: state.lastChange
+              ? new Date(state.lastChange)
+              : undefined,
+          } satisfies DeploymentStatus;
+        }),
+
+      restart: (clawId: string) =>
+        Effect.gen(function* () {
+          const host = clawHostname(clawId);
+
+          // Lightweight: restart gateway process, keep container alive
+          yield* wrap(
+            "Failed to restart gateway",
+            containers.restartGateway(host),
+          );
+
+          return {
+            status: "provisioning",
+            startedAt: new Date(),
+          } satisfies DeploymentStatus;
+        }),
+
+      update: (clawId: string, _config: Partial<OpenClawConfig>) =>
+        Effect.gen(function* () {
+          const host = clawHostname(clawId);
+
+          // Config is stored in DB by the caller. Restart gateway to pick
+          // up fresh config from the bootstrap API.
+          yield* wrap(
+            "Failed to restart gateway for config update",
+            containers.restartGateway(host),
+          );
+
+          return {
+            status: "provisioning",
+            startedAt: new Date(),
+          } satisfies DeploymentStatus;
+        }),
+    };
+  }),
+);


### PR DESCRIPTION
updates to containers interface, distinguishing recreating container
from restarting gateway

this tends to scope cloudflare/containers to openclaw containers in
particular, but that's okay because it's coupled with an
openclaw-focused dispatch worker; can rename later. non urgent until we
are trying to support "other" claws anyway.