### PR TITLE
feat(cloud): return R2 credentials from DeploymentService.provision()

### DIFF
--- a/cloud/claws/deployment/live.test.ts
+++ b/cloud/claws/deployment/live.test.ts
@@ -74,6 +74,11 @@ describe("LiveDeploymentService", () => {
         getClawUrl(testConfig.organizationSlug, testConfig.clawSlug),
       );
       expect(status.startedAt).toBeInstanceOf(Date);
+      expect(status.bucketName).toBe(`claw-${testConfig.clawId}`);
+      expect(status.r2Credentials).toBeDefined();
+      expect(status.r2Credentials!.tokenId).toBeDefined();
+      expect(status.r2Credentials!.accessKeyId).toBeDefined();
+      expect(status.r2Credentials!.secretAccessKey).toBeDefined();
     });
 
     it("fails when R2 bucket already exists", async () => {

--- a/cloud/claws/deployment/live.ts
+++ b/cloud/claws/deployment/live.ts
@@ -103,7 +103,7 @@ export const LiveDeploymentService = Layer.effect(
           yield* wrap("Failed to create R2 bucket", r2.createBucket(bucket));
 
           // 2. Create scoped credentials for the bucket
-          yield* wrap(
+          const credentials = yield* wrap(
             "Failed to create R2 credentials",
             r2.createScopedCredentials(bucket),
           );
@@ -118,6 +118,8 @@ export const LiveDeploymentService = Layer.effect(
             status: "provisioning",
             url: getClawUrl(config.organizationSlug, config.clawSlug),
             startedAt: new Date(),
+            bucketName: bucket,
+            r2Credentials: credentials,
           } satisfies DeploymentStatus;
         }),
 

--- a/cloud/claws/deployment/mock.test.ts
+++ b/cloud/claws/deployment/mock.test.ts
@@ -83,6 +83,13 @@ describe("MockDeploymentService", () => {
       );
       expect(status.startedAt).toBeInstanceOf(Date);
       expect(status.errorMessage).toBeUndefined();
+      expect(status.bucketName).toBe(`claw-${testConfig.clawId}`);
+      expect(status.r2Credentials).toBeDefined();
+      expect(status.r2Credentials!.tokenId).toContain(testConfig.clawId);
+      expect(status.r2Credentials!.accessKeyId).toContain(testConfig.clawId);
+      expect(status.r2Credentials!.secretAccessKey).toContain(
+        testConfig.clawId,
+      );
     });
   });
 

--- a/cloud/claws/deployment/mock.ts
+++ b/cloud/claws/deployment/mock.ts
@@ -45,6 +45,12 @@ export const MockDeploymentService = Layer.succeed(DeploymentService, {
         status: "active",
         url: getClawUrl(config.organizationSlug, config.clawSlug),
         startedAt: new Date(),
+        bucketName: `claw-${config.clawId}`,
+        r2Credentials: {
+          tokenId: `mock-token-${config.clawId}`,
+          accessKeyId: `mock-access-${config.clawId}`,
+          secretAccessKey: `mock-secret-${config.clawId}`,
+        },
       };
 
       mockStatuses.set(config.clawId, status);

--- a/cloud/claws/deployment/service.ts
+++ b/cloud/claws/deployment/service.ts
@@ -35,6 +35,7 @@
 import { Context, Effect } from "effect";
 
 import type { ClawStatus, OpenClawConfig } from "@/claws/deployment/types";
+import type { R2ScopedCredentials } from "@/cloudflare/r2/types";
 
 import { DeploymentError } from "@/claws/deployment/errors";
 
@@ -46,6 +47,10 @@ export interface DeploymentStatus {
   url?: string;
   startedAt?: Date;
   errorMessage?: string;
+  /** R2 bucket name created during provisioning (only present after provision). */
+  bucketName?: string;
+  /** R2 scoped credentials created during provisioning (only present after provision). */
+  r2Credentials?: R2ScopedCredentials;
 }
 
 /**


### PR DESCRIPTION
The CRUD service needs bucket name and scoped R2 credentials from
provisioning to store in the database. Update DeploymentStatus to
include these fields so callers can persist them.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>