### PR TITLE
feat(cloud): add internal only handlers used by dispatch worker

### DIFF
--- a/cloud/api/claws-internal.handlers.ts
+++ b/cloud/api/claws-internal.handlers.ts
@@ -1,0 +1,109 @@
+/**
+ * Internal handlers for the dispatch worker API.
+ *
+ * WARNING: These handlers are NOT part of the public HTTP API. They must NOT
+ * be wired into the public router (router.ts) or registered in
+ * MirascopeCloudApi. The dispatch worker calls these via Cloudflare service
+ * binding (in-process RPC, never hits the public internet).
+ *
+ * The bootstrap handler returns SECURITY-SENSITIVE data (R2 credentials,
+ * API keys, integration tokens). The service binding is the only auth
+ * boundary — there is no token or network-level isolation beyond it.
+ */
+import { Effect } from "effect";
+import { Schema } from "effect";
+
+import { NotFoundError } from "@/errors";
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+export const ClawResolveResponseSchema = Schema.Struct({
+  clawId: Schema.String,
+  organizationId: Schema.String,
+});
+
+export type ClawResolveResponse = typeof ClawResolveResponseSchema.Type;
+
+const ClawR2ConfigSchema = Schema.Struct({
+  bucketName: Schema.String,
+  accessKeyId: Schema.String,
+  secretAccessKey: Schema.String,
+});
+
+export const OpenClawConfigSchema = Schema.Struct({
+  clawId: Schema.String,
+  clawSlug: Schema.String,
+  organizationId: Schema.String,
+  organizationSlug: Schema.String,
+  instanceType: Schema.String,
+  r2: ClawR2ConfigSchema,
+  containerEnv: Schema.Record({
+    key: Schema.String,
+    value: Schema.Union(Schema.String, Schema.Undefined),
+  }),
+});
+
+export type OpenClawConfigResponse = typeof OpenClawConfigSchema.Type;
+
+export const ClawStatusReportSchema = Schema.Struct({
+  status: Schema.Literal(
+    "pending",
+    "provisioning",
+    "active",
+    "paused",
+    "error",
+  ),
+  errorMessage: Schema.optional(Schema.NullOr(Schema.String)),
+  startedAt: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+export type ClawStatusReport = typeof ClawStatusReportSchema.Type;
+
+// ---------------------------------------------------------------------------
+// Handlers — TODO implementations
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve org/claw slugs to a stable clawId.
+ *
+ * The dispatch worker extracts slugs from the incoming hostname
+ * ({clawSlug}.{orgSlug}.mirascope.com) and calls this to get the clawId
+ * used as the Durable Object key. Results are LRU-cached by the worker.
+ */
+export const resolveClawHandler = (
+  _orgSlug: string,
+  _clawSlug: string,
+): Effect.Effect<ClawResolveResponse, NotFoundError> =>
+  Effect.fail(new NotFoundError({ message: "resolve: not yet implemented" }));
+
+/**
+ * Return the full OpenClawConfig for a given clawId.
+ *
+ * Called by the dispatch worker on cold start to get R2 credentials,
+ * container env vars, and instance type. The implementation must decrypt
+ * secretsEncrypted from the DB before including them in the response.
+ *
+ * SECURITY-SENSITIVE — the response contains R2 scoped credentials
+ * (accessKeyId, secretAccessKey) and container env vars (API keys,
+ * integration tokens).
+ */
+export const bootstrapClawHandler = (
+  _clawId: string,
+): Effect.Effect<OpenClawConfigResponse, NotFoundError> =>
+  Effect.fail(new NotFoundError({ message: "bootstrap: not yet implemented" }));
+
+/**
+ * Accept a status report from the dispatch worker.
+ *
+ * Updates the claw's status in the DB (e.g. "active", "error")
+ * along with optional error message and startedAt timestamp.
+ */
+export const reportClawStatusHandler = (
+  _clawId: string,
+  _payload: ClawStatusReport,
+): Effect.Effect<void, NotFoundError> =>
+  Effect.fail(
+    new NotFoundError({ message: "reportStatus: not yet implemented" }),
+  );

--- a/cloud/api/claws.test.ts
+++ b/cloud/api/claws.test.ts
@@ -3,7 +3,13 @@ import { ParseError } from "effect/ParseResult";
 
 import type { PublicClaw } from "@/db/schema";
 
+import {
+  resolveClawHandler,
+  bootstrapClawHandler,
+  reportClawStatusHandler,
+} from "@/api/claws-internal.handlers";
 import { CreateClawRequestSchema } from "@/api/claws.handlers";
+import { NotFoundError } from "@/errors";
 import { describe, it, expect, TestApiContext } from "@/tests/api";
 
 describe("CreateClawRequestSchema validation", () => {
@@ -33,6 +39,36 @@ describe("CreateClawRequestSchema validation", () => {
     });
     expect(result.name).toBe("Valid Claw Name");
   });
+});
+
+describe("Internal handler stubs (TODO)", () => {
+  it.effect("resolveClawHandler returns NotFoundError", () =>
+    Effect.gen(function* () {
+      const error = yield* resolveClawHandler("org-slug", "claw-slug").pipe(
+        Effect.flip,
+      );
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(error.message).toContain("not yet implemented");
+    }),
+  );
+
+  it.effect("bootstrapClawHandler returns NotFoundError", () =>
+    Effect.gen(function* () {
+      const error = yield* bootstrapClawHandler("claw-id").pipe(Effect.flip);
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(error.message).toContain("not yet implemented");
+    }),
+  );
+
+  it.effect("reportClawStatusHandler returns NotFoundError", () =>
+    Effect.gen(function* () {
+      const error = yield* reportClawStatusHandler("claw-id", {
+        status: "active",
+      }).pipe(Effect.flip);
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect(error.message).toContain("not yet implemented");
+    }),
+  );
 });
 
 describe.sequential("Claws API", (it) => {

--- a/cloud/claws/deployment/types.ts
+++ b/cloud/claws/deployment/types.ts
@@ -59,7 +59,7 @@ export interface ClawR2Config {
  * The dispatch worker fetches this when it needs to start or configure a claw's
  * container.
  *
- * @endpoint GET /api/internal/claws/:orgSlug/:clawSlug/bootstrap
+ * @endpoint GET /api/internal/claws/:clawId/bootstrap
  */
 export interface OpenClawConfig {
   /** Unique identifier for the claw */


### PR DESCRIPTION
See comments. Should not be part of public API (no http exposure)