### PR TITLE
refactor(cloud): split provisioning and warming up container

### DIFF
--- a/cloud/claws/deployment/mock.test.ts
+++ b/cloud/claws/deployment/mock.test.ts
@@ -204,6 +204,17 @@ describe("MockDeploymentService", () => {
     });
   });
 
+  describe("warmUp", () => {
+    it("completes without error", async () => {
+      await run(
+        Effect.gen(function* () {
+          const deployment = yield* DeploymentService;
+          yield* deployment.warmUp("any-claw-id");
+        }),
+      );
+    });
+  });
+
   describe("resetMockDeploymentState", () => {
     it("clears all mock state", async () => {
       // Provision a claw

--- a/cloud/claws/deployment/mock.ts
+++ b/cloud/claws/deployment/mock.ts
@@ -119,6 +119,11 @@ export const MockDeploymentService = Layer.succeed(DeploymentService, {
       mockStatuses.set(clawId, status);
       return status;
     }),
+
+  warmUp: (_clawId: string) =>
+    Effect.gen(function* () {
+      yield* Effect.sleep("50 millis");
+    }),
 });
 
 /**

--- a/cloud/claws/deployment/service.ts
+++ b/cloud/claws/deployment/service.ts
@@ -92,6 +92,15 @@ export interface DeploymentServiceInterface {
     clawId: string,
     config: Partial<OpenClawConfig>,
   ) => Effect.Effect<DeploymentStatus, DeploymentError>;
+
+  /**
+   * Warm up a claw's container, triggering a cold start on the dispatch worker.
+   *
+   * This is intentionally separate from `provision` so the caller can persist
+   * R2 credentials to the database between provisioning infrastructure and
+   * triggering the dispatch worker (which reads credentials via the bootstrap API).
+   */
+  readonly warmUp: (clawId: string) => Effect.Effect<void, DeploymentError>;
 }
 
 /**


### PR DESCRIPTION
warming up container depends on the dispatch worker having access to the
r2 tokens, which is only possible *after* calling provision so that the
caller can put those tokens in the db.