### PR TITLE
refactor: extract useCurrentSection hook

### DIFF
--- a/cloud/app/components/blocks/navigation/mobile-navigation.tsx
+++ b/cloud/app/components/blocks/navigation/mobile-navigation.tsx
@@ -4,6 +4,7 @@ import { FolderKanban, Home } from "lucide-react";
 import { AccountMenu } from "@/app/components/blocks/navigation/account-menu";
 import { ClawIcon } from "@/app/components/icons/claw-icon";
 import { useOrganization } from "@/app/contexts/organization";
+import { useCurrentSection } from "@/app/hooks/use-current-section";
 import { isCloudAppRoute } from "@/app/lib/route-utils";
 import { cn } from "@/app/lib/utils";
 
@@ -33,6 +34,7 @@ export default function MobileNavigation({
   const currentPath = router.location.pathname;
   const { selectedOrganization } = useOrganization();
   const orgSlug = selectedOrganization?.slug ?? "";
+  const section = useCurrentSection();
 
   if (!isOpen) return null;
 
@@ -43,10 +45,6 @@ export default function MobileNavigation({
     }
     return currentPath === href || currentPath.startsWith(href + "/");
   };
-
-  // Parse path segments for cloud route active state
-  const segments = currentPath.split("/").filter(Boolean);
-  const section = segments[1]; // "claws", "projects", "settings", etc.
 
   if (isCloudRoute) {
     const cloudLinks = [

--- a/cloud/app/components/cloud-nav-icons.tsx
+++ b/cloud/app/components/cloud-nav-icons.tsx
@@ -1,4 +1,4 @@
-import { Link, useRouterState } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { FolderKanban, Home } from "lucide-react";
 
 import { ClawIcon } from "@/app/components/icons/claw-icon";
@@ -8,17 +8,13 @@ import {
   TooltipTrigger,
 } from "@/app/components/ui/tooltip";
 import { useOrganization } from "@/app/contexts/organization";
+import { useCurrentSection } from "@/app/hooks/use-current-section";
 import { cn } from "@/app/lib/utils";
 
 export function CloudNavIcons() {
-  const router = useRouterState();
-  const currentPath = router.location.pathname;
   const { selectedOrganization } = useOrganization();
   const orgSlug = selectedOrganization?.slug ?? "";
-
-  // Parse path: /{orgSlug}/section/...
-  const segments = currentPath.split("/").filter(Boolean);
-  const section = segments[1]; // "claws", "projects", "settings", etc.
+  const section = useCurrentSection();
 
   const isHome = !section || section === "settings";
   const isClaws = section === "claws";

--- a/cloud/app/components/sidebar.tsx
+++ b/cloud/app/components/sidebar.tsx
@@ -2,6 +2,7 @@ import { useRouterState } from "@tanstack/react-router";
 
 import { ClawsSidebar } from "@/app/components/claws-sidebar";
 import { ProjectsSidebar } from "@/app/components/projects-sidebar";
+import { useCurrentSection } from "@/app/hooks/use-current-section";
 import { isCloudAppRoute } from "@/app/lib/route-utils";
 
 export function Sidebar() {
@@ -10,9 +11,7 @@ export function Sidebar() {
 
   if (!isCloudAppRoute(currentPath)) return null;
 
-  // Parse path: /{orgSlug}/claws/... or /{orgSlug}/projects/...
-  const segments = currentPath.split("/").filter(Boolean);
-  const section = segments[1]; // "claws", "projects", "settings", etc.
+  const section = useCurrentSection();
 
   const showProjectsSidebar = section === "projects";
   const showClawsSidebar = section === "claws";

--- a/cloud/app/hooks/use-current-section.ts
+++ b/cloud/app/hooks/use-current-section.ts
@@ -1,0 +1,14 @@
+import { useRouterState } from "@tanstack/react-router";
+
+/**
+ * Returns the current "section" segment from the URL path.
+ *
+ * Given a path like `/{orgSlug}/{section}/...`, this returns the section
+ * string (e.g. "claws", "projects", "settings") or `undefined` if there
+ * is no second segment.
+ */
+export function useCurrentSection(): string | undefined {
+  const router = useRouterState();
+  const segments = router.location.pathname.split("/").filter(Boolean);
+  return segments[1]; // "claws", "projects", "settings", etc.
+}


### PR DESCRIPTION
Replace repeated path-segment parsing across nav components with a
shared useCurrentSection() hook.

Co-authored-by: Verse <verse@mirascope.com>