### PR TITLE
fix: guard against empty orgSlug in navigation

### DIFF
--- a/cloud/app/routes/pricing.tsx
+++ b/cloud/app/routes/pricing.tsx
@@ -33,26 +33,21 @@ function getTierButton(
     );
   }
 
+  // Guard against empty orgSlug — fall back to login
+  const billingHref = orgSlug ? `/${orgSlug}/settings/billing` : "/login";
+
   const isPlanUpgrade = isUpgrade(currentPlan, tier);
 
   if (isPlanUpgrade) {
     return (
-      <ButtonLink
-        href={`/${orgSlug}/settings/billing`}
-        variant="default"
-        className="w-full"
-      >
+      <ButtonLink href={billingHref} variant="default" className="w-full">
         Upgrade
       </ButtonLink>
     );
   }
 
   return (
-    <ButtonLink
-      href={`/${orgSlug}/settings/billing`}
-      variant="outline"
-      className="w-full"
-    >
+    <ButtonLink href={billingHref} variant="outline" className="w-full">
       Downgrade
     </ButtonLink>
   );


### PR DESCRIPTION
Prevent broken URLs when org hasn't loaded yet. Pricing page billing
links fall back to /login for unauthenticated users.

Co-authored-by: Verse <verse@mirascope.com>