### PR TITLE
fix: add /cloud/* catch-all redirect for old bookmarks

### DIFF
--- a/cloud/app/routes/cloud.$.tsx
+++ b/cloud/app/routes/cloud.$.tsx
@@ -1,0 +1,34 @@
+import { createFileRoute, Navigate, useParams } from "@tanstack/react-router";
+
+import { useOrganization } from "@/app/contexts/organization";
+
+/**
+ * Catch-all redirect for legacy /cloud/* bookmarks.
+ *
+ * Redirects paths like /cloud/claws/my-claw to /$orgSlug/claws/my-claw
+ * using the user's currently selected organization.
+ */
+function CloudCatchAllRedirect() {
+  const { _splat } = useParams({ strict: false });
+  const { selectedOrganization, isLoading } = useOrganization();
+
+  if (isLoading) return null;
+
+  if (selectedOrganization) {
+    const remainder = _splat ? `/${_splat}` : "";
+    return (
+      <Navigate
+        to={`/$orgSlug${remainder}`}
+        params={{ orgSlug: selectedOrganization.slug }}
+        replace
+      />
+    );
+  }
+
+  // No org selected, redirect to login
+  return <Navigate to="/login" replace />;
+}
+
+export const Route = createFileRoute("/cloud/$")({
+  component: CloudCatchAllRedirect,
+});


### PR DESCRIPTION
Redirects legacy /cloud/claws/..., /cloud/projects/..., and
/cloud/settings/... paths to their /$orgSlug equivalents.

Co-authored-by: Verse <verse@mirascope.com>