### PR TITLE
feat(dispatch-worker): add Docker Compose config and health check script

### DIFF
--- a/cloud/claws/dispatch-worker/tests/docker/docker-compose.yml
+++ b/cloud/claws/dispatch-worker/tests/docker/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  openclaw-gateway:
+    build:
+      context: ${OPENCLAW_SRC:?Set OPENCLAW_SRC to the path of your openclaw repo checkout}
+      dockerfile: Dockerfile
+    command:
+      [
+        "node",
+        "dist/index.js",
+        "gateway",
+        "--allow-unconfigured",
+        "--bind",
+        "lan",
+        "--port",
+        "18789",
+      ]
+    environment:
+      - OPENCLAW_GATEWAY_TOKEN=test-gateway-token
+      - OPENCLAW_GATEWAY_PASSWORD=test-password
+      - NODE_ENV=test
+      # OpenClaw needs ~500MB heap during startup; Node defaults to ~512MB on CI
+      - NODE_OPTIONS=--max-old-space-size=2048
+    ports:
+      - "18789:18789"
+    healthcheck:
+      # OpenClaw is WebSocket-based with no REST health endpoint.
+      # Any HTTP response (even 404) means the server is alive.
+      # Uses node instead of curl since curl may not be in the image.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://localhost:18789/',r=>{process.exit(r.statusCode?0:1)}).on('error',()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 30s
+    # Note: resource limits removed to avoid OOM kills in CI.
+    # GitHub Actions runners have 7GB RAM which is sufficient.

--- a/cloud/claws/dispatch-worker/tests/docker/wait-for-gateway.sh
+++ b/cloud/claws/dispatch-worker/tests/docker/wait-for-gateway.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:18789}"
+MAX_WAIT="${MAX_WAIT:-60}"
+
+echo "Waiting for OpenClaw gateway at $GATEWAY_URL..."
+elapsed=0
+while [ $elapsed -lt $MAX_WAIT ]; do
+  # Gateway has no REST health endpoint; any HTTP response means it's alive
+  status=$(curl -s -o /dev/null -w "%{http_code}" "$GATEWAY_URL/" 2>/dev/null || true)
+  if [ -n "$status" ] && [ "$status" != "000" ]; then
+    echo "Gateway ready after ${elapsed}s (HTTP $status)"
+    exit 0
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+
+echo "Gateway failed to start within ${MAX_WAIT}s"
+exit 1


### PR DESCRIPTION
## Docker Compose config and health check for dispatch worker testing

### Context

The dispatch worker proxies HTTP and WebSocket requests to an OpenClaw gateway running inside a Cloudflare Sandbox container. To test this proxy behavior locally and in CI, we need a real OpenClaw gateway running — not a mock.

This PR adds Docker infrastructure to run a real OpenClaw gateway container for integration testing.

### What this does

- **`docker-compose.yml`** — Defines an `openclaw-gateway` service that builds from the OpenClaw repo source and runs the gateway in test mode (`--allow-unconfigured --bind lan --port 18789`). Includes a health check using Node built-in HTTP client (no curl dependency). Sets `NODE_OPTIONS=--max-old-space-size=2048` since OpenClaw needs ~500MB heap at startup.

- **`wait-for-gateway.sh`** — Polling script that waits for the gateway HTTP server to respond before tests run. Uses curl to check for any HTTP response (any status code = alive) with configurable timeout.

### Key design decisions

- **Build from source, not a published image** — OpenClaw does not publish Docker images yet. The `OPENCLAW_SRC` env var points to your local checkout of the openclaw repo. It is required (fails with a clear error if unset).
- **Node for health check, not curl** — The Docker health check uses `node -e` since curl may not be in the image. The wait script uses curl (available on CI runners and dev machines).
- **Port 18789** — Matches the gateway default port in the dispatch worker config.
- **No resource limits** — GitHub Actions runners have 7GB RAM which is sufficient. Removed explicit limits to avoid V8 heap OOM during gateway startup.