### PR TITLE
feat(dispatch-worker): add gateway-client.ts for Docker integration tests

### DIFF
--- a/cloud/claws/dispatch-worker/tests/workers/gateway-client.ts
+++ b/cloud/claws/dispatch-worker/tests/workers/gateway-client.ts
@@ -1,0 +1,47 @@
+/**
+ * Client for the Docker OpenClaw gateway used in integration tests.
+ *
+ * The OpenClaw gateway is primarily WebSocket-based and has no REST health
+ * endpoint. Liveness is determined by checking that the HTTP server responds
+ * (any status code, including 404, indicates the server is running).
+ */
+
+export const GATEWAY_URL = process.env.GATEWAY_URL || "http://localhost:18789";
+export const GATEWAY_TOKEN =
+  process.env.OPENCLAW_GATEWAY_TOKEN || "test-gateway-token";
+
+/** Fetch against the Docker OpenClaw gateway with auth header. */
+export async function gatewayFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const url = `${GATEWAY_URL}${path}`;
+  return fetch(url, {
+    ...init,
+    headers: {
+      ...init?.headers,
+      Authorization: `Bearer ${GATEWAY_TOKEN}`,
+    },
+  });
+}
+
+/**
+ * Wait for the gateway HTTP server to become reachable.
+ * Any HTTP response (even 404) means the server is alive.
+ */
+export async function waitForGateway(timeoutMs = 60_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${GATEWAY_URL}/`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      // Any response means the server is up
+      if (res.status > 0) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`Gateway not ready after ${timeoutMs}ms`);
+}


### PR DESCRIPTION
## Gateway client helper for Docker integration tests

### What this does

Adds `gateway-client.ts` — a small HTTP client wrapper for talking to the OpenClaw gateway running in Docker. Used by the Docker integration tests (#2543) to make requests and assert responses.

This keeps test files focused on assertions rather than HTTP plumbing.

### How it fits in the stack

```
#2546  Miniflare integration tests
#2541  Docker Compose + health check
#2542  This PR — Gateway client helper  ← you are here
#2543  Docker integration test suite
#2544  CI job
#2545  Makefile + README
#2547  Auth middleware
#2548  Auth matrix tests
```

Co-authored-by: Verse <verse@mirascope.com>
