### PR TITLE
ci: add Docker integration test job for dispatch-worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,53 @@ jobs:
       - name: Run integration tests
         run: bun run test:integration
 
+  dispatch-worker-docker-tests:
+    name: Dispatch Worker Docker Tests
+    needs: changes
+    if: needs.changes.outputs.dispatch-worker == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      OPENCLAW_SRC: ${{ github.workspace }}/openclaw
+    defaults:
+      run:
+        working-directory: cloud/claws/dispatch-worker
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: openclaw/openclaw
+          path: openclaw
+
+      - name: Setup `bun`
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build & start OpenClaw gateway
+        working-directory: cloud/claws/dispatch-worker/tests/docker
+        run: |
+          docker compose -f docker-compose.yml up -d --build --wait || {
+            echo "=== Container logs ==="
+            docker compose -f docker-compose.yml logs --no-color
+            exit 1
+          }
+
+      - name: Run Docker integration tests
+        run: bun run test:docker
+
+      - name: Gateway logs (on failure)
+        if: failure()
+        working-directory: cloud/claws/dispatch-worker/tests/docker
+        run: docker compose -f docker-compose.yml logs --no-color 2>/dev/null || true
+
+      - name: Teardown
+        if: always()
+        working-directory: cloud/claws/dispatch-worker/tests/docker
+        run: docker compose -f docker-compose.yml down -v
+
   ci-success:
     name: CI Success
     needs:
@@ -305,6 +352,7 @@ jobs:
         cloud-tests,
         dispatch-worker-lint,
         dispatch-worker-tests,
+        dispatch-worker-docker-tests,
       ]
     runs-on: ubuntu-latest
     if: always()


### PR DESCRIPTION
## CI job for Docker integration tests

### What this does

Adds a `dispatch-worker-docker-tests` job to the CI workflow that:

1. Checks out the mirascope repo
2. Checks out the `mirascope/openclaw` repo (needed to build the gateway container)
3. Builds and starts the OpenClaw gateway via `docker compose up`
4. Runs `bun run test:docker`
5. Tears down the container (always, even on failure)

### Key details

- **`OPENCLAW_SRC`** is set as a job-level env var pointing to the checked-out openclaw repo at `${{ github.workspace }}/openclaw`
- Uses raw `docker compose` commands (not `make`) since the Makefile convenience layer is added in #2545
- The teardown step runs with `if: always()` so containers are cleaned up even on test failure
- Job timeout: 20 minutes (gateway build + startup + tests)
- Only runs when dispatch-worker files change (via the existing `changes` detection job)

### How it fits in the stack

```
#2546  Miniflare integration tests
#2541  Docker Compose + health check
#2542  Gateway client helper
#2543  Docker test suite + vitest config
#2544  This PR — CI job  ← you are here
#2545  Makefile + README
#2547  Auth middleware
#2548  Auth matrix tests
```

Co-authored-by: Verse <verse@mirascope.com>
