### PR TITLE
docs(dispatch-worker): add README for Docker tests

### DIFF
--- a/cloud/claws/dispatch-worker/tests/docker/README.md
+++ b/cloud/claws/dispatch-worker/tests/docker/README.md
@@ -1,0 +1,40 @@
+# Dispatch Worker Docker Integration Tests
+
+Integration tests that run against a real OpenClaw gateway in a Docker container.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Access to the `openclaw` repo (for building the container image)
+- `bun` installed
+
+## Quick Start
+
+```bash
+# Set the path to your openclaw repo checkout
+export OPENCLAW_SRC=/path/to/openclaw
+
+# Start the gateway (from cloud/claws/dispatch-worker/tests/docker/)
+docker compose up -d --build --wait
+
+# Run tests (from cloud/claws/dispatch-worker/)
+bun run test:docker
+
+# Stop the gateway (from cloud/claws/dispatch-worker/tests/docker/)
+docker compose down -v
+```
+
+## Configuration
+
+| Variable                 | Default                  | Description                                |
+| ------------------------ | ------------------------ | ------------------------------------------ |
+| `GATEWAY_URL`            | `http://localhost:18789` | Gateway URL for tests                      |
+| `OPENCLAW_GATEWAY_TOKEN` | `test-gateway-token`     | Auth token                                 |
+| `OPENCLAW_SRC`           | _(required)_             | Path to openclaw source (for Docker build) |
+
+## Notes
+
+- The OpenClaw gateway is **WebSocket-based** and has no REST health endpoint
+- Health checks verify the HTTP server responds (any status = alive)
+- The container binds to `0.0.0.0:18789` via `--bind lan`
+- In CI, `OPENCLAW_SRC` points to a separate checkout of the openclaw repo


### PR DESCRIPTION
## README for Docker test harness

Adds a README documenting how to run the Docker integration tests locally.

### What this does

- **`tests/docker/README.md`** — Quick start guide, env var reference, and notes on the gateway health check behavior.

### How it fits in the stack

```
#2546  Miniflare integration tests
#2541  Docker Compose + health check
#2542  Gateway client helper
#2543  Docker test suite + vitest config
#2544  CI job
#2545  This PR — README  ← you are here
#2547  Auth middleware
#2548  Auth matrix tests
```

Co-authored-by: Verse <verse@mirascope.com>