### PR TITLE
feat(dispatch-worker): add miniflare integration tests for bootstrap functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,8 +286,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run tests
-        run: bun run test
+      - name: Run unit tests
+        run: bun run test:unit
+
+      - name: Run integration tests
+        run: bun run test:integration
 
   ci-success:
     name: CI Success

--- a/cloud/claws/dispatch-worker/package.json
+++ b/cloud/claws/dispatch-worker/package.json
@@ -12,6 +12,8 @@
     "lint:oxlint": "oxlint .",
     "lint": "bun run typecheck && bun run lint:oxlint",
     "test": "vitest run",
+    "test:unit": "vitest run -c vitest.config.ts",
+    "test:integration": "vitest run -c vitest.integration.config.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/cloud/claws/dispatch-worker/tests/integration/bootstrap.integration.test.ts
+++ b/cloud/claws/dispatch-worker/tests/integration/bootstrap.integration.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Integration tests for bootstrap functions via real Miniflare service bindings.
+ *
+ * These tests spin up a Miniflare instance with:
+ * - A test harness worker (main) that exposes bootstrap functions via HTTP
+ * - A mock cloud worker bound as MIRASCOPE_CLOUD via function service binding
+ *
+ * This validates that service binding fetch calls work end-to-end through
+ * the Workers runtime, unlike unit tests which mock the binding entirely.
+ */
+import * as esbuild from "esbuild";
+import { Miniflare } from "miniflare";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import mockCloudWorker from "../workers/mock-cloud-worker";
+
+let mf: Miniflare;
+
+async function bundleWorker(entryPoint: string): Promise<string> {
+  const result = await esbuild.build({
+    entryPoints: [entryPoint],
+    bundle: true,
+    format: "esm",
+    target: "esnext",
+    write: false,
+    conditions: ["workerd", "worker", "browser"],
+    external: ["cloudflare:*", "node:*"],
+  });
+  return result.outputFiles[0].text;
+}
+
+beforeAll(async () => {
+  const base = path.resolve(import.meta.dirname, "..");
+  const harnessScript = await bundleWorker(
+    path.join(base, "workers/test-harness-worker.ts"),
+  );
+
+  mf = new Miniflare({
+    modules: true,
+    script: harnessScript,
+    compatibilityDate: "2025-05-06",
+    compatibilityFlags: ["nodejs_compat"],
+
+    // Use function-based service binding so the URL is properly forwarded
+    // (named worker bindings in Miniflare forward the original request URL)
+    serviceBindings: {
+      MIRASCOPE_CLOUD: mockCloudWorker.fetch,
+    },
+  });
+
+  await mf.ready;
+});
+
+afterAll(async () => {
+  await mf?.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// fetchBootstrapConfig
+// ---------------------------------------------------------------------------
+
+describe("fetchBootstrapConfig (integration)", () => {
+  it("fetches config via real service binding", async () => {
+    const res = await mf.dispatchFetch("http://test/bootstrap/claw-123");
+    expect(res.ok).toBe(true);
+
+    const config = (await res.json()) as Record<string, unknown>;
+    expect(config.clawId).toBe("claw-123");
+    expect(config.clawSlug).toBe("test-claw");
+    expect(config.organizationId).toBe("org-456");
+    expect((config.r2 as any).bucketName).toBe("claw-claw-123");
+  });
+
+  it("returns error for nonexistent claw", async () => {
+    const res = await mf.dispatchFetch("http://test/bootstrap/nonexistent");
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("404");
+    expect(body.error).toContain("nonexistent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveClawId
+// ---------------------------------------------------------------------------
+
+describe("resolveClawId (integration)", () => {
+  it("resolves slugs to clawId via service binding", async () => {
+    const res = await mf.dispatchFetch("http://test/resolve/test-org/my-claw");
+    expect(res.ok).toBe(true);
+
+    const result = (await res.json()) as Record<string, string>;
+    expect(result.clawId).toBe("resolved-my-claw");
+    expect(result.organizationId).toBe("org-test-org");
+  });
+
+  it("returns error for unknown org", async () => {
+    const res = await mf.dispatchFetch(
+      "http://test/resolve/unknown-org/some-claw",
+    );
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("404");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reportClawStatus
+// ---------------------------------------------------------------------------
+
+describe("reportClawStatus (integration)", () => {
+  it("posts status via service binding without throwing", async () => {
+    const res = await mf.dispatchFetch("http://test/status/claw-123", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: "active",
+        startedAt: "2025-01-01T00:00:00Z",
+      }),
+    });
+    expect(res.ok).toBe(true);
+
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+});

--- a/cloud/claws/dispatch-worker/tests/workers/mock-cloud-worker.ts
+++ b/cloud/claws/dispatch-worker/tests/workers/mock-cloud-worker.ts
@@ -1,0 +1,65 @@
+/**
+ * Mock Mirascope Cloud worker for integration tests.
+ *
+ * Simulates the internal API endpoints that the dispatch worker
+ * calls via the MIRASCOPE_CLOUD service binding.
+ */
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const { pathname } = url;
+
+    // POST /api/internal/claws/:clawId/status
+    const statusMatch = pathname.match(
+      /^\/api\/internal\/claws\/([\w-]+)\/status$/,
+    );
+    if (statusMatch && request.method === "POST") {
+      const body = await request.json();
+      return Response.json({ ok: true, received: body });
+    }
+
+    // GET /api/internal/claws/resolve/:orgSlug/:clawSlug
+    const resolveMatch = pathname.match(
+      /^\/api\/internal\/claws\/resolve\/([\w-]+)\/([\w-]+)$/,
+    );
+    if (resolveMatch) {
+      const [, orgSlug, clawSlug] = resolveMatch;
+      if (orgSlug === "unknown-org") {
+        return new Response("organization not found", { status: 404 });
+      }
+      return Response.json({
+        clawId: `resolved-${clawSlug}`,
+        organizationId: `org-${orgSlug}`,
+      });
+    }
+
+    // GET /api/internal/claws/:clawId/bootstrap
+    const bootstrapMatch = pathname.match(
+      /^\/api\/internal\/claws\/([\w-]+)\/bootstrap$/,
+    );
+    if (bootstrapMatch) {
+      const [, clawId] = bootstrapMatch;
+      if (clawId === "nonexistent") {
+        return new Response("claw not found", { status: 404 });
+      }
+      return Response.json({
+        clawId,
+        clawSlug: "test-claw",
+        organizationId: "org-456",
+        organizationSlug: "test-org",
+        instanceType: "basic",
+        r2: {
+          bucketName: `claw-${clawId}`,
+          accessKeyId: "ak-test",
+          secretAccessKey: "sk-test",
+        },
+        containerEnv: {
+          MIRASCOPE_API_KEY: "mk-test",
+          OPENCLAW_GATEWAY_TOKEN: "gw-tok",
+        },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+};

--- a/cloud/claws/dispatch-worker/tests/workers/test-harness-worker.ts
+++ b/cloud/claws/dispatch-worker/tests/workers/test-harness-worker.ts
@@ -1,0 +1,58 @@
+import type { DispatchEnv } from "../../src/types";
+
+/**
+ * Test harness worker for integration tests.
+ *
+ * Exposes bootstrap functions via HTTP so integration tests can invoke
+ * them through a real Miniflare worker runtime with real service bindings.
+ *
+ * Routes:
+ *   GET  /bootstrap/:clawId       → fetchBootstrapConfig
+ *   GET  /resolve/:orgSlug/:claw  → resolveClawId
+ *   POST /status/:clawId          → reportClawStatus
+ */
+import {
+  fetchBootstrapConfig,
+  resolveClawId,
+  reportClawStatus,
+} from "../../src/bootstrap";
+
+export default {
+  async fetch(request: Request, env: DispatchEnv): Promise<Response> {
+    const url = new URL(request.url);
+    const { pathname } = url;
+
+    try {
+      // GET /bootstrap/:clawId
+      const bootstrapMatch = pathname.match(/^\/bootstrap\/([\w-]+)$/);
+      if (bootstrapMatch) {
+        const config = await fetchBootstrapConfig(bootstrapMatch[1], env);
+        return Response.json(config);
+      }
+
+      // GET /resolve/:orgSlug/:clawSlug
+      const resolveMatch = pathname.match(/^\/resolve\/([\w-]+)\/([\w-]+)$/);
+      if (resolveMatch) {
+        const result = await resolveClawId(
+          resolveMatch[1],
+          resolveMatch[2],
+          env,
+        );
+        return Response.json(result);
+      }
+
+      // POST /status/:clawId
+      const statusMatch = pathname.match(/^\/status\/([\w-]+)$/);
+      if (statusMatch && request.method === "POST") {
+        const body = await request.json();
+        await reportClawStatus(statusMatch[1], body as any, env);
+        return Response.json({ ok: true });
+      }
+
+      return new Response("unknown route", { status: 404 });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return Response.json({ error: message }, { status: 500 });
+    }
+  },
+};

--- a/cloud/claws/dispatch-worker/vitest.config.ts
+++ b/cloud/claws/dispatch-worker/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    exclude: ["src/**/*.integration.test.ts"],
   },
 });

--- a/cloud/claws/dispatch-worker/vitest.integration.config.ts
+++ b/cloud/claws/dispatch-worker/vitest.integration.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/integration/**/*.integration.test.ts"],
+    // Integration tests spin up Miniflare instances which need more time
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Miniflare integration tests for dispatch worker bootstrap functions

### Context

The dispatch worker (`cloud/claws/dispatch-worker/`) routes requests to per-claw Cloudflare Sandbox containers. It communicates with the Mirascope Cloud backend via Cloudflare **service bindings** — in-process RPC calls that look like `fetch()` but never hit the network.

The existing unit tests mock the service binding entirely (just spy on `env.MIRASCOPE_CLOUD.fetch`). This validates the dispatch worker's logic but doesn't test the actual service binding behavior — request/response serialization, URL routing through the binding, error propagation, etc.

### What this does

Adds integration tests that spin up a real **Miniflare** instance (Cloudflare's local Workers runtime) with:
- A **test harness worker** (main) that exposes bootstrap functions via HTTP
- A **mock cloud worker** bound as `MIRASCOPE_CLOUD` via a function-based service binding

This lets us test that `fetchBootstrapConfig()`, `resolveClawId()`, and `reportClawStatus()` work correctly through a real Workers runtime with real service binding semantics.

### Why Miniflare (not `@cloudflare/vitest-pool-workers`)

The project uses vitest 4.x, but `@cloudflare/vitest-pool-workers` requires vitest 2.x-3.2.x. Rather than downgrade, we use Miniflare programmatically — same underlying runtime, just invoked from standard vitest.

### Files

- **`src/integration/bootstrap.integration.test.ts`** — 5 tests covering bootstrap config fetch, claw slug resolution, and status reporting through real service bindings
- **`src/integration/test-harness-worker.ts`** — Thin HTTP wrapper exposing bootstrap functions for the test to call
- **`src/integration/mock-cloud-worker.ts`** — Simulates the Mirascope Cloud internal API (bootstrap, resolve, status endpoints)
- **`vitest.integration.config.ts`** — Separate vitest config for integration tests (longer timeouts)
- **`package.json`** — Added `test:unit` and `test:integration` scripts; added `esbuild` and `miniflare` dev deps

### How it fits in the stack

This is the foundation of the dispatch worker test infrastructure. The stack builds up testing layers:

1. **This PR** — Miniflare integration tests (fast, in-process, tests service binding behavior)
2. #2541-#2545 — Docker harness (real OpenClaw gateway in a container, tests HTTP/WS proxy)
3. #2547 — Auth middleware implementation
4. #2548 — Auth matrix miniflare tests (17 tests covering all auth paths)

Co-authored-by: Verse <verse@mirascope.com>
