### PR TITLE
feat(dispatch-worker): add auth middleware with path-based routing

### DIFF
--- a/cloud/claws/dispatch-worker/src/index.ts
+++ b/cloud/claws/dispatch-worker/src/index.ts
@@ -3,15 +3,17 @@
  *
  * Routes incoming requests to per-claw Cloudflare Sandbox containers.
  *
- * Request flow:
- * 1. Extract clawId from Host header ({clawId}.claws.mirascope.com)
- * 2. Get or create a Sandbox Durable Object for the clawId
- * 3. Route /_internal/* to management endpoints
- * 4. For all other requests:
- *    a. Fetch bootstrap config (OpenClawConfig) from Mirascope API
- *    b. Mount R2 storage with per-claw scoped credentials
- *    c. Start openclaw gateway with env vars from config
- *    d. Proxy HTTP/WebSocket to the gateway
+ * Two routing modes:
+ * 1. Internal (/_internal/*) — clawId from Host header (service binding traffic)
+ * 2. External (/{orgSlug}/{clawSlug}/*) — path-based routing with auth
+ *
+ * For external requests:
+ *    a. Parse org + claw slugs from URL path
+ *    b. Authenticate (webhooks pass-through, Bearer pass-through, session cookie validated)
+ *    c. Resolve slugs → clawId via Cloud internal API
+ *    d. Fetch bootstrap config, start gateway, proxy HTTP/WS
+ *
+ * See cloud/claws/README.md for the full architecture.
  */
 
 import { getSandbox, Sandbox } from "@cloudflare/sandbox";
@@ -21,7 +23,19 @@ import { Hono } from "hono";
 import type { AppEnv, DispatchEnv, OpenClawConfig } from "./types";
 
 import loadingPageHtml from "./assets/loading.html";
-import { fetchBootstrapConfig, reportClawStatus } from "./bootstrap";
+import {
+  type AuthError,
+  authenticate,
+  corsHeaders,
+  handlePreflight,
+  parsePath,
+} from "./auth";
+import {
+  type BootstrapDecodeError,
+  type BootstrapFetchError,
+  fetchBootstrapConfig,
+  reportClawStatus,
+} from "./bootstrap";
 import { getCachedConfig, setCachedConfig } from "./cache";
 import { internal } from "./internal";
 import {
@@ -37,8 +51,10 @@ export { Sandbox };
 // Main app
 const app = new Hono<AppEnv>();
 
-// Middleware: Extract clawId from Host header and initialize sandbox
-app.use("*", async (c, next) => {
+// ---------------------------------------------------------------------------
+// Internal routes: /_internal/* — Host-based clawId extraction (service binding traffic)
+// ---------------------------------------------------------------------------
+app.use("/_internal/*", async (c, next) => {
   const host = c.req.header("Host") || "";
   const clawId = extractClawId(host);
 
@@ -58,67 +74,136 @@ app.use("*", async (c, next) => {
   await next();
 });
 
-// Internal management routes
 app.route("/_internal", internal);
 
-// Catch-all: proxy to gateway
+// ---------------------------------------------------------------------------
+// Auth error → HTTP response mapping
+// ---------------------------------------------------------------------------
+
+function authErrorToResponse(
+  error: AuthError,
+  origin: string | null,
+): Response {
+  const cors = corsHeaders(origin);
+
+  switch (error._tag) {
+    case "ClawResolutionError":
+      return Response.json(
+        { error: "Claw not found" },
+        { status: 404, headers: cors },
+      );
+    case "InvalidSessionError":
+      return Response.json(
+        { error: error.message },
+        { status: 401, headers: cors },
+      );
+    case "UnauthenticatedError":
+      return Response.json(
+        { error: error.message },
+        { status: 401, headers: cors },
+      );
+    case "ApiDecodeError":
+    case "BootstrapDecodeError":
+      return Response.json(
+        { error: "Internal error" },
+        { status: 502, headers: cors },
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// External routes: /{orgSlug}/{clawSlug}/* — path-based routing with auth
+// ---------------------------------------------------------------------------
 app.all("*", async (c) => {
-  const sandbox = c.get("sandbox");
-  const clawId = c.get("clawId");
   const request = c.req.raw;
 
-  // Check if gateway is already running
-  const existing = await findGatewayProcess(sandbox);
-  const isReady = existing !== null && existing.status === "running";
+  // CORS preflight
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
 
+  // Parse path
+  const parsed = parsePath(c.req.path);
+  if (!parsed) {
+    return c.json({ error: "Invalid path — expected /{org}/{claw}/..." }, 400);
+  }
+
+  // Authenticate via Effect
+  const authResult = await Effect.runPromiseExit(
+    authenticate(request, parsed, c.env),
+  );
+
+  if (authResult._tag === "Failure") {
+    const origin = request.headers.get("Origin");
+    // Extract the typed error from the Cause
+    const error = authResult.cause;
+    if (error._tag === "Fail") {
+      return authErrorToResponse(error.error, origin);
+    }
+    // Unexpected defect — should not happen
+    console.error("[auth] Unexpected defect:", error);
+    return c.json({ error: "Internal error" }, 500);
+  }
+
+  const { clawId } = authResult.value;
+  console.log(
+    `[REQ] ${c.req.method} ${c.req.path} clawId=${clawId} (path-based)`,
+  );
+
+  const sandbox = getSandbox(c.env.Sandbox, clawId, { keepAlive: true });
+  c.set("sandbox", sandbox);
+  c.set("clawId", clawId);
+
+  // Rewrite request URL to remainder path before proxying
+  const remainderUrl = new URL(request.url);
+  remainderUrl.pathname = parsed.remainder;
+  const rewrittenRequest = new Request(remainderUrl.toString(), request);
+
+  // Proxy to gateway (same logic as before but with rewritten request)
   const isWebSocket =
     request.headers.get("Upgrade")?.toLowerCase() === "websocket";
   const acceptsHtml = request.headers.get("Accept")?.includes("text/html");
 
-  // Show loading page while gateway starts (for browser requests only)
+  const existing = await findGatewayProcess(sandbox);
+  const isReady = existing !== null && existing.status === "running";
+
   if (!isReady && !isWebSocket && acceptsHtml) {
     console.log("[proxy] Gateway not ready, serving loading page");
-
-    // Start gateway in background
     c.executionCtx.waitUntil(
-      (async () => {
-        try {
-          const config = await getOrFetchConfig(clawId, c.env);
-          await ensureGateway(sandbox, config, c.env);
-          await Effect.runPromise(
-            reportClawStatus(
-              clawId,
-              { status: "active", startedAt: new Date().toISOString() },
-              c.env,
-            ),
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const config = yield* getOrFetchConfig(clawId, c.env);
+          yield* Effect.promise(() => ensureGateway(sandbox, config, c.env));
+          yield* reportClawStatus(
+            clawId,
+            { status: "active", startedAt: new Date().toISOString() },
+            c.env,
           );
-        } catch (err) {
-          console.error("[proxy] Background gateway start failed:", err);
-          await Effect.runPromise(
-            reportClawStatus(
-              clawId,
-              {
-                status: "error",
-                errorMessage: err instanceof Error ? err.message : String(err),
-              },
-              c.env,
-            ),
-          );
-        }
-      })(),
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.gen(function* () {
+              console.error("[proxy] Background gateway start failed:", err);
+              yield* reportClawStatus(
+                clawId,
+                { status: "error", errorMessage: err.message },
+                c.env,
+              );
+            }),
+          ),
+        ),
+      ),
     );
-
     return c.html(loadingPageHtml as unknown as string);
   }
 
-  // Ensure gateway is running (blocking)
-  try {
-    const config = await getOrFetchConfig(clawId, c.env);
-    await ensureGateway(sandbox, config, c.env);
-  } catch (error) {
-    console.error("[proxy] Failed to start gateway:", error);
-    const message = error instanceof Error ? error.message : "Unknown error";
+  const configExit = await Effect.runPromiseExit(
+    getOrFetchConfig(clawId, c.env),
+  );
 
+  if (configExit._tag === "Failure") {
+    const cause = configExit.cause;
+    const message =
+      cause._tag === "Fail" ? cause.error.message : "Unknown error";
+    console.error("[proxy] Failed to get config:", message);
     await Effect.runPromise(
       reportClawStatus(
         clawId,
@@ -126,43 +211,49 @@ app.all("*", async (c) => {
         c.env,
       ),
     );
+    return c.json({ error: "Gateway failed to start", details: message }, 503);
+  }
 
-    return c.json(
-      {
-        error: "Gateway failed to start",
-        details: message,
-        hint: "Check worker logs with: wrangler tail",
-      },
-      503,
+  try {
+    await ensureGateway(sandbox, configExit.value, c.env);
+  } catch (error) {
+    console.error("[proxy] Failed to start gateway:", error);
+    const message = error instanceof Error ? error.message : "Unknown error";
+    await Effect.runPromise(
+      reportClawStatus(
+        clawId,
+        { status: "error", errorMessage: message },
+        c.env,
+      ),
     );
+    return c.json({ error: "Gateway failed to start", details: message }, 503);
   }
 
-  // Proxy to gateway
   if (isWebSocket) {
-    return proxyWebSocket(sandbox, request);
+    return proxyWebSocket(sandbox, rewrittenRequest);
   }
-
-  return proxyHttp(sandbox, request);
+  return proxyHttp(sandbox, rewrittenRequest);
 });
 
 /**
  * Get bootstrap config from cache or fetch from API.
  */
-async function getOrFetchConfig(
+const getOrFetchConfig = (
   clawId: string,
   env: DispatchEnv,
-): Promise<OpenClawConfig> {
-  const cached = getCachedConfig(clawId);
-  if (cached) {
-    console.log("[config] Using cached config for", clawId);
-    return cached;
-  }
+): Effect.Effect<OpenClawConfig, BootstrapFetchError | BootstrapDecodeError> =>
+  Effect.gen(function* () {
+    const cached = getCachedConfig(clawId);
+    if (cached) {
+      console.log("[config] Using cached config for", clawId);
+      return cached;
+    }
 
-  console.log("[config] Fetching bootstrap config for", clawId);
-  const config = await Effect.runPromise(fetchBootstrapConfig(clawId, env));
-  setCachedConfig(clawId, config);
-  return config;
-}
+    console.log("[config] Fetching bootstrap config for", clawId);
+    const config = yield* fetchBootstrapConfig(clawId, env);
+    setCachedConfig(clawId, config);
+    return config;
+  });
 
 export default {
   fetch: app.fetch,


### PR DESCRIPTION
## Auth middleware + path-based routing for the dispatch worker

### What this does

This implements the authentication layer for the dispatch worker, following the URL routing and auth design from `cloud/claws/README.md`.

**Before:** The dispatch worker extracted `clawId` from the `Host` header (e.g., `{clawId}.claws.mirascope.com`) and proxied all requests through with no auth checks. This only worked for internal service-binding traffic.

**After:** The dispatch worker handles two types of traffic:

1. **Internal** (`/_internal/*`) — Still uses Host-based `clawId` extraction. These come from the Cloud backend via Cloudflare service binding (in-process RPC, no network). No auth needed because the service binding *is* the trust boundary.

2. **External** (`/{orgSlug}/{clawSlug}/...`) — New path-based routing. The dispatch worker parses the org+claw slugs from the URL path, resolves them to a `clawId` via the Cloud internal API, then applies the auth decision matrix before proxying.

### Auth decision matrix

```
Path                           Auth Method              Validated By
────────────────────────────── ──────────────────────── ─────────────
/{org}/{claw}/webhook/*        Platform-specific        Gateway (pass-through)
/{org}/{claw}/*  + Bearer      OPENCLAW_GATEWAY_TOKEN   Gateway (pass-through)
/{org}/{claw}/*  + Cookie      Mirascope session        Dispatch worker → Cloud API
/{org}/{claw}/*  (no auth)     Reject                   Dispatch worker (401)
/_internal/*                   Service binding          Implicit (in-process)
```

**Key design decisions:**

- **Webhooks pass through** — Telegram, Slack, Discord etc. each have their own signature verification. The dispatch worker doesn't have platform secrets; the gateway does. So we let webhook traffic through and let the gateway validate.
- **Bearer tokens pass through** — The `OPENCLAW_GATEWAY_TOKEN` lives in the container's env vars. The dispatch worker doesn't have the decrypted token, so it forwards the `Authorization` header and lets the gateway validate.
- **Session cookies are validated at the dispatch worker** — Browser users have a `.mirascope.com` session cookie. The dispatch worker validates this via a new internal Cloud API endpoint (`/api/internal/auth/validate-session`), with a 60s LRU cache to avoid re-validating on every request.
- **No auth = 401** — If none of the above match, reject.

### URL rewriting

After auth, the dispatch worker rewrites the request URL before proxying to the gateway. The gateway sees the *remainder* path, not the full `/{org}/{claw}/...` prefix:

```
Client request:  GET /acme/support-bot/api/chat
Gateway sees:    GET /api/chat
```

### CORS

Since `openclaw.mirascope.com` is a different origin from `mirascope.com`, the Chrome SPA needs CORS headers. This PR adds:
- `Access-Control-Allow-Origin: https://mirascope.com` (not `*`, because credentials)
- `Access-Control-Allow-Credentials: true` (so the session cookie is sent)
- OPTIONS preflight handling at the dispatch worker (not proxied to gateway)

### Files changed

- **`auth.ts`** (new) — `parsePath()`, `authenticate()`, `validateSession()`, `corsHeaders()`, `handlePreflight()`
- **`index.ts`** — Split routing: `/_internal/*` keeps Host-based, everything else uses path-based + auth

### Requires (not in this PR)

- Cloud backend to implement `POST /api/internal/auth/validate-session` (service-binding-only endpoint)
- Session cookie `Domain` set to `.mirascope.com` (so it's sent to `openclaw.mirascope.com`)

Co-authored-by: Verse <verse@mirascope.com>