### PR TITLE
chore(cloud): bring back titles

### DIFF
--- a/cloud/app/routes/dev/audit-metadata.tsx
+++ b/cloud/app/routes/dev/audit-metadata.tsx
@@ -8,6 +8,7 @@ import {
   getAllContentMeta,
   getAllDevMeta,
 } from "@/app/lib/content/virtual-module";
+import { createPageHead } from "@/app/lib/seo/head";
 
 /**
  * Convert a route path to a filename for social cards.
@@ -19,6 +20,12 @@ function routeToFilename(route: string): string {
 }
 
 export const Route = createFileRoute("/dev/audit-metadata")({
+  head: () =>
+    createPageHead({
+      route: "/dev/audit-metadata",
+      title: "Developer Tools - SEO Metadata Audit",
+      description: "Audit page metadata and social cards",
+    }),
   component: AuditMetadata,
   loader: () => {
     const devPages = getAllDevMeta();

--- a/cloud/app/routes/dev/claw-cards.tsx
+++ b/cloud/app/routes/dev/claw-cards.tsx
@@ -6,6 +6,7 @@ import DevLayout from "@/app/components/blocks/dev/dev-layout";
 import LoadingContent from "@/app/components/blocks/loading-content";
 import { ClawCard } from "@/app/components/claw-card";
 import { getAllDevMeta } from "@/app/lib/content/virtual-module";
+import { createPageHead } from "@/app/lib/seo/head";
 
 const baseClaw: Claw = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -51,6 +52,12 @@ const instanceTypes: Claw["instanceType"][] = [
 ];
 
 export const Route = createFileRoute("/dev/claw-cards")({
+  head: () =>
+    createPageHead({
+      route: "/dev/claw-cards",
+      title: "Developer Tools - Claw Cards",
+      description: "Preview claw card component variants",
+    }),
   component: ClawCardsDevPage,
   loader: () => {
     const devPages = getAllDevMeta();

--- a/cloud/app/routes/dev/index.tsx
+++ b/cloud/app/routes/dev/index.tsx
@@ -4,8 +4,16 @@ import { useMemo } from "react";
 import DevLayout from "@/app/components/blocks/dev/dev-layout";
 import LoadingContent from "@/app/components/blocks/loading-content";
 import { getAllDevMeta } from "@/app/lib/content/virtual-module";
+import { createPageHead } from "@/app/lib/seo/head";
 
 export const Route = createFileRoute("/dev/")({
+  head: () =>
+    createPageHead({
+      route: "/dev",
+      title: "Developer Tools",
+      description:
+        "Development tools and utilities for maintaining the Mirascope website",
+    }),
   component: DevIndexPage,
   loader: () => {
     const devPages = getAllDevMeta();

--- a/cloud/app/routes/dev/layout-test.tsx
+++ b/cloud/app/routes/dev/layout-test.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import ContentLayout from "@/app/components/content-layout";
+import { createPageHead } from "@/app/lib/seo/head";
 
 /**
  * Test component for visualizing ContentLayout behavior
@@ -8,6 +9,12 @@ import ContentLayout from "@/app/components/content-layout";
  * Note: Footer is handled by root layout and doesn't need to be included here
  */
 export const Route = createFileRoute("/dev/layout-test")({
+  head: () =>
+    createPageHead({
+      route: "/dev/layout-test",
+      title: "Developer Tools - Layout Test",
+      description: "Test ContentLayout component behavior",
+    }),
   component: LayoutTestPage,
 });
 

--- a/cloud/app/routes/dev/social-card.tsx
+++ b/cloud/app/routes/dev/social-card.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import DevLayout from "@/app/components/blocks/dev/dev-layout";
 import LoadingContent from "@/app/components/blocks/loading-content";
 import { getAllDevMeta } from "@/app/lib/content/virtual-module";
+import { createPageHead } from "@/app/lib/seo/head";
 import { getTitleFontSize } from "@/app/lib/social-cards/element";
 import {
   loadAssetsBrowser,
@@ -11,6 +12,12 @@ import {
 } from "@/app/lib/social-cards/render-browser";
 
 export const Route = createFileRoute("/dev/social-card")({
+  head: () =>
+    createPageHead({
+      route: "/dev/social-card",
+      title: "Developer Tools - Social Card Preview",
+      description: "Preview and test social card designs",
+    }),
   component: SocialCardPreview,
   loader: () => {
     const devPages = getAllDevMeta();

--- a/content/dev/buttons-test.mdx
+++ b/content/dev/buttons-test.mdx
@@ -1,5 +1,5 @@
 ---
-title: Button Variants Test
+title: Developer Tools - Button Variants Test
 description: A comprehensive showcase of all button variants and sizes
 ---
 

--- a/content/dev/callout-test.mdx
+++ b/content/dev/callout-test.mdx
@@ -1,5 +1,5 @@
 ---
-title: Callout Component Test
+title: Developer Tools - Callout Component Test
 description: A showcase of all available callout components with their variations
 ---
 

--- a/content/dev/code-block-length-test.mdx
+++ b/content/dev/code-block-length-test.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Code Block Length Test"
+title: "Developer Tools - Code Block Length Test"
 description: "Testing code blocks with different line counts"
 ---
 

--- a/content/dev/code-highlight-test.mdx
+++ b/content/dev/code-highlight-test.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Highlighting Test
+title: Developer Tools - Code Highlighting Test
 description: Example of line highlighting in code blocks
 ---
 

--- a/content/dev/color-themes.mdx
+++ b/content/dev/color-themes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Color Themes Test Page
+title: Developer Tools - Color Themes Test Page
 description: Explore color theming and ShadCn UI components
 ---
 

--- a/content/dev/icon-test.mdx
+++ b/content/dev/icon-test.mdx
@@ -1,5 +1,5 @@
 ---
-title: Icon Component Test
+title: Developer Tools - Icon Component Test
 description: Testing the dynamic Lucide icon component
 ---
 

--- a/content/dev/mermaid-test.mdx
+++ b/content/dev/mermaid-test.mdx
@@ -1,5 +1,5 @@
 ---
-title: Mermaid Diagram Test
+title: Developer Tools - Mermaid Diagram Test
 description: Testing various Mermaid diagram types with theme integration
 ---
 

--- a/content/dev/style-test.mdx
+++ b/content/dev/style-test.mdx
@@ -1,5 +1,5 @@
 ---
-title: Style Test Page
+title: Developer Tools - Style Test Page
 description: A comprehensive showcase of all UI components for visual consistency testing
 ---
 

--- a/content/dev/table-test.mdx
+++ b/content/dev/table-test.mdx
@@ -1,5 +1,5 @@
 ---
-title: Markdown Table Test
+title: Developer Tools - Markdown Table Test
 description: Testing markdown table rendering
 ---
 


### PR DESCRIPTION
While Search Engine exclusion is now handled in `robots.txt`, we still need titles. Bring them back.

Prefix sub-routes with `Developer Tools - ...` to identify them easily amongst non-dev routes.