### PR TITLE
refactor(dispatch-worker): migrate auth to Effect-ts

### DIFF
--- a/cloud/claws/dispatch-worker/bun.lock
+++ b/cloud/claws/dispatch-worker/bun.lock
@@ -4,11 +4,13 @@
     "": {
       "name": "claw-dispatch-worker",
       "dependencies": {
+        "effect": "^3.19.13",
         "hono": "^4.11.6",
       },
       "devDependencies": {
         "@cloudflare/sandbox": "*",
         "@cloudflare/workers-types": "^4.20250109.0",
+        "@effect/vitest": "^0.27.0",
         "@types/ws": "^8.18.1",
         "oxlint": "^1.42.0",
         "typescript": "^5.9.3",
@@ -40,6 +42,8 @@
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260206.0", "", {}, "sha512-rHbE1XM3mfwzoyOiKm1oFRTp00Cv4U5UiuMDQwmu/pc79yOA3nDiOC0lue8aOpobBrP4tPHQqsPcWG606Zrw/w=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@effect/vitest": ["@effect/vitest@0.27.0", "", { "peerDependencies": { "effect": "^3.19.0", "vitest": "^3.2.0" } }, "sha512-8bM7n9xlMUYw9GqPIVgXFwFm2jf27m/R7psI64PGpwU5+26iwyxp9eAXEsfT5S6lqztYfpQQ1Ubp5o6HfNYzJQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
@@ -263,6 +267,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "effect": ["effect@3.19.16", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-7+XC3vGrbAhCHd8LTFHvnZjRpZKZ8YHRZqJTkpNoxcJ2mCyNs2SwI+6VkV/ij8Y3YW7wfBN4EbU06/F5+m/wkQ=="],
+
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
@@ -272,6 +278,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -300,6 +308,8 @@
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 

--- a/cloud/claws/dispatch-worker/package.json
+++ b/cloud/claws/dispatch-worker/package.json
@@ -18,11 +18,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "effect": "^3.19.13",
     "hono": "^4.11.6"
   },
   "devDependencies": {
     "@cloudflare/sandbox": "*",
     "@cloudflare/workers-types": "^4.20250109.0",
+    "@effect/vitest": "^0.27.0",
     "@types/ws": "^8.18.1",
     "oxlint": "^1.42.0",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Refactor auth + bootstrap to Effect-ts

Migrates the dispatch worker's auth and bootstrap layers from imperative async/await to Effect-ts, addressing William's review feedback on #2547.

### What changed

**`auth.ts`** — All functions now return typed Effects:
- `authenticate()` → `Effect<AuthSuccess, AuthError>`
- `validateSession()` → `Effect<CachedSession, InvalidSessionError | ApiDecodeError>`
- Removed inline `resolveClawIdFromSlugs` — now uses `resolveClawId` from bootstrap.ts (consolidated)
- Error types: `ClawResolutionError | BootstrapDecodeError | InvalidSessionError | UnauthenticatedError | ApiDecodeError`

**`bootstrap.ts`** — Fully migrated to Effect:
- `fetchBootstrapConfig()` → `Effect<OpenClawConfig, BootstrapFetchError | BootstrapDecodeError>`
- `resolveClawId()` → `Effect<{clawId, orgId}, ClawResolutionError | BootstrapDecodeError>` (single source of truth, was duplicated in auth.ts)
- `reportClawStatus()` → `Effect<void>` (fire-and-forget, logs errors internally)
- All `response.json()` calls wrapped in `Effect.tryPromise` with typed decode errors
- No more `throw` anywhere

**`index.ts`** — Updated Hono handler:
- Auth uses `Effect.runPromiseExit()` with exhaustive error → HTTP status mapping
- `getOrFetchConfig` is now an Effect
- `reportClawStatus` calls use `Effect.runPromise`
- `ensureGateway` (still imperative) wrapped in `Effect.promise()` at call sites

**Tests:**
- `bootstrap.test.ts` — Updated to use `Effect.runPromise`/`runPromiseExit`, added decode error test
- `test-harness-worker.ts` — Uses `Effect.runPromiseExit` with proper error serialization
- `auth-harness-worker.ts` — Updated error type handling for consolidated errors
- All **47 unit + 22 integration tests pass**

### Stack position

```
#2546  Miniflare integration tests
#2541  Docker Compose + health check
#2542  Gateway client
#2543  Docker test suite + vitest config
#2544  CI job
#2545  README
#2547  Auth middleware (imperative)
#2548  Auth matrix tests
#2553  This PR — Effect refactor  ← you are here
```

Co-authored-by: Verse <verse@mirascope.com>