### PR TITLE
feat: add validate-session internal endpoint for dispatch worker auth

### DIFF
--- a/cloud/auth/errors.ts
+++ b/cloud/auth/errors.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- pure error class definitions, no branching logic */
 import { Data } from "effect";
 
 export class OAuthError extends Data.TaggedError("OAuthError")<{

--- a/cloud/auth/oauth.ts
+++ b/cloud/auth/oauth.ts
@@ -1,4 +1,3 @@
-/* v8 ignore start -- OAuth flows require network requests to external providers */
 /**
  * @fileoverview OAuth authentication flow implementation.
  *

--- a/cloud/cloudflare/containers/service.ts
+++ b/cloud/cloudflare/containers/service.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- service interface (Context.Tag), no testable logic */
 /**
  * @fileoverview Cloudflare container service interface for dispatch worker management.
  *

--- a/cloud/cloudflare/containers/types.ts
+++ b/cloud/cloudflare/containers/types.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- pure type definitions */
 /**
  * @fileoverview Types for Cloudflare container/Durable Object management.
  *

--- a/cloud/cloudflare/r2/service.ts
+++ b/cloud/cloudflare/r2/service.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- service interface (Context.Tag), no testable logic */
 /**
  * @fileoverview Cloudflare R2 service interface for bucket lifecycle management.
  *

--- a/cloud/cloudflare/r2/types.ts
+++ b/cloud/cloudflare/r2/types.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- pure type definitions */
 /**
  * @fileoverview Types for Cloudflare R2 bucket management.
  *


### PR DESCRIPTION
## Add validate-session internal endpoint

Adds the `/api/internal/auth/validate-session` endpoint that the dispatch worker's auth middleware calls when a browser user hits a claw URL with a session cookie.

### What it does

1. Validates the session ID → gets user from DB
2. Resolves org/claw slugs → gets clawId + organizationId (reuses `resolveClawHandler`)
3. Checks user's claw access via `memberships.getRole`:
   - Org OWNER/ADMIN → implicit ADMIN access
   - Explicit claw membership → that role
   - No access → 401
4. Returns `{ userId, clawId, organizationId, role }`

### Files changed

- **`cloud/api/claws-internal.handlers.ts`** — Added `validateSessionHandler`, `ValidateSessionRequestSchema`, `ValidateSessionResponseSchema`
- **`cloud/app/routes/api.internal.$.tsx`** — Wired up `POST /api/internal/auth/validate-session` route

### Why this is needed

The dispatch worker auth middleware (PR #2547) has four auth paths:
- Webhook → pass-through
- Bearer token → pass-through (gateway validates)
- **Session cookie → validate via this endpoint** ← was missing
- No auth → 401

Without this endpoint, browser-based access to claws would always fail.

### Stack position

```
#2547  Auth middleware
#2548  Auth matrix tests
#2553  Effect refactor
#2554  This PR — validate-session endpoint  ← you are here
```

Co-authored-by: Verse <verse@mirascope.com>