### PR TITLE
feat(dispatch-worker): add Docker integration test infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,53 @@ jobs:
       - name: Run integration tests
         run: bun run test:integration
 
+  dispatch-worker-docker-tests:
+    name: Dispatch Worker Docker Tests
+    needs: changes
+    if: needs.changes.outputs.dispatch-worker == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      OPENCLAW_SRC: ${{ github.workspace }}/openclaw
+    defaults:
+      run:
+        working-directory: cloud/claws/dispatch-worker
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: openclaw/openclaw
+          path: openclaw
+
+      - name: Setup `bun`
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build & start OpenClaw gateway
+        working-directory: cloud/claws/dispatch-worker/tests/docker
+        run: |
+          docker compose -f docker-compose.yml up -d --build --wait || {
+            echo "=== Container logs ==="
+            docker compose -f docker-compose.yml logs --no-color
+            exit 1
+          }
+
+      - name: Run Docker integration tests
+        run: bun run test:docker
+
+      - name: Gateway logs (on failure)
+        if: failure()
+        working-directory: cloud/claws/dispatch-worker/tests/docker
+        run: docker compose -f docker-compose.yml logs --no-color 2>/dev/null || true
+
+      - name: Teardown
+        if: always()
+        working-directory: cloud/claws/dispatch-worker/tests/docker
+        run: docker compose -f docker-compose.yml down -v
+
   ci-success:
     name: CI Success
     needs:
@@ -305,6 +352,7 @@ jobs:
         cloud-tests,
         dispatch-worker-lint,
         dispatch-worker-tests,
+        dispatch-worker-docker-tests,
       ]
     runs-on: ubuntu-latest
     if: always()

--- a/cloud/claws/dispatch-worker/bun.lock
+++ b/cloud/claws/dispatch-worker/bun.lock
@@ -9,10 +9,12 @@
       "devDependencies": {
         "@cloudflare/sandbox": "*",
         "@cloudflare/workers-types": "^4.20250109.0",
+        "@types/ws": "^8.18.1",
         "oxlint": "^1.42.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
         "wrangler": "^4.50.0",
+        "ws": "^8.19.0",
       },
     },
   },
@@ -233,6 +235,10 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
@@ -325,6 +331,8 @@
 
     "undici": ["undici@7.18.2", "", {}, "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="],
 
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
@@ -337,10 +345,12 @@
 
     "wrangler": ["wrangler@4.63.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.12.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.0", "miniflare": "4.20260205.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260205.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260205.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-+R04jF7Eb8K3KRMSgoXpcIdLb8GC62eoSGusYh1pyrSMm/10E0hbKkd7phMJO4HxXc6R7mOHC5SSoX9eof30Uw=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
   }
 }

--- a/cloud/claws/dispatch-worker/package.json
+++ b/cloud/claws/dispatch-worker/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "test:unit": "vitest run -c vitest.config.ts",
     "test:integration": "vitest run -c vitest.integration.config.ts",
+    "test:docker": "vitest run -c vitest.docker.config.ts",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -22,9 +23,11 @@
   "devDependencies": {
     "@cloudflare/sandbox": "*",
     "@cloudflare/workers-types": "^4.20250109.0",
+    "@types/ws": "^8.18.1",
     "oxlint": "^1.42.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18",
-    "wrangler": "^4.50.0"
+    "wrangler": "^4.50.0",
+    "ws": "^8.19.0"
   }
 }

--- a/cloud/claws/dispatch-worker/tests/docker/README.md
+++ b/cloud/claws/dispatch-worker/tests/docker/README.md
@@ -1,0 +1,40 @@
+# Dispatch Worker Docker Integration Tests
+
+Integration tests that run against a real OpenClaw gateway in a Docker container.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Access to the `openclaw` repo (for building the container image)
+- `bun` installed
+
+## Quick Start
+
+```bash
+# Set the path to your openclaw repo checkout
+export OPENCLAW_SRC=/path/to/openclaw
+
+# Start the gateway (from cloud/claws/dispatch-worker/tests/docker/)
+docker compose up -d --build --wait
+
+# Run tests (from cloud/claws/dispatch-worker/)
+bun run test:docker
+
+# Stop the gateway (from cloud/claws/dispatch-worker/tests/docker/)
+docker compose down -v
+```
+
+## Configuration
+
+| Variable                 | Default                  | Description                                |
+| ------------------------ | ------------------------ | ------------------------------------------ |
+| `GATEWAY_URL`            | `http://localhost:18789` | Gateway URL for tests                      |
+| `OPENCLAW_GATEWAY_TOKEN` | `test-gateway-token`     | Auth token                                 |
+| `OPENCLAW_SRC`           | _(required)_             | Path to openclaw source (for Docker build) |
+
+## Notes
+
+- The OpenClaw gateway is **WebSocket-based** and has no REST health endpoint
+- Health checks verify the HTTP server responds (any status = alive)
+- The container binds to `0.0.0.0:18789` via `--bind lan`
+- In CI, `OPENCLAW_SRC` points to a separate checkout of the openclaw repo

--- a/cloud/claws/dispatch-worker/tests/docker/docker-compose.yml
+++ b/cloud/claws/dispatch-worker/tests/docker/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  openclaw-gateway:
+    build:
+      context: ${OPENCLAW_SRC:?Set OPENCLAW_SRC to the path of your openclaw repo checkout}
+      dockerfile: Dockerfile
+    command:
+      [
+        "node",
+        "dist/index.js",
+        "gateway",
+        "--allow-unconfigured",
+        "--bind",
+        "lan",
+        "--port",
+        "18789",
+      ]
+    environment:
+      - OPENCLAW_GATEWAY_TOKEN=test-gateway-token
+      - OPENCLAW_GATEWAY_PASSWORD=test-password
+      - NODE_ENV=test
+      # OpenClaw needs ~500MB heap during startup; Node defaults to ~512MB on CI
+      - NODE_OPTIONS=--max-old-space-size=2048
+    ports:
+      - "18789:18789"
+    healthcheck:
+      # OpenClaw is WebSocket-based with no REST health endpoint.
+      # Any HTTP response (even 404) means the server is alive.
+      # Uses node instead of curl since curl may not be in the image.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://localhost:18789/',r=>{process.exit(r.statusCode?0:1)}).on('error',()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 30s
+    # Note: resource limits removed to avoid OOM kills in CI.
+    # GitHub Actions runners have 7GB RAM which is sufficient.

--- a/cloud/claws/dispatch-worker/tests/docker/wait-for-gateway.sh
+++ b/cloud/claws/dispatch-worker/tests/docker/wait-for-gateway.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:18789}"
+MAX_WAIT="${MAX_WAIT:-60}"
+
+echo "Waiting for OpenClaw gateway at $GATEWAY_URL..."
+elapsed=0
+while [ $elapsed -lt $MAX_WAIT ]; do
+  # Gateway has no REST health endpoint; any HTTP response means it's alive
+  status=$(curl -s -o /dev/null -w "%{http_code}" "$GATEWAY_URL/" 2>/dev/null || true)
+  if [ -n "$status" ] && [ "$status" != "000" ]; then
+    echo "Gateway ready after ${elapsed}s (HTTP $status)"
+    exit 0
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+
+echo "Gateway failed to start within ${MAX_WAIT}s"
+exit 1

--- a/cloud/claws/dispatch-worker/tests/integration/proxy-docker.test.ts
+++ b/cloud/claws/dispatch-worker/tests/integration/proxy-docker.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import WebSocket from "ws";
+
+import {
+  GATEWAY_URL,
+  GATEWAY_TOKEN,
+  gatewayFetch,
+  waitForGateway,
+} from "../workers/gateway-client";
+
+describe("proxy → Docker OpenClaw gateway", () => {
+  beforeAll(async () => {
+    await waitForGateway();
+  }, 90_000);
+
+  it("HTTP server is reachable", async () => {
+    const res = await gatewayFetch("/");
+    // Gateway returns 404 for unknown paths — that's fine, means it's alive
+    expect(res.status).toBeGreaterThan(0);
+  });
+
+  it("authenticated HTTP request succeeds", async () => {
+    // gatewayFetch includes the Authorization header with GATEWAY_TOKEN
+    const res = await gatewayFetch("/api/health");
+    // Even if /api/health doesn't exist, auth should not be rejected
+    // (vs an unauthenticated request which may get 401/403)
+    expect([200, 404]).toContain(res.status);
+  });
+
+  it("WebSocket upgrade is supported", async () => {
+    const wsUrl = GATEWAY_URL.replace(/^http/, "ws");
+    const ws = new WebSocket(wsUrl);
+    try {
+      const opened = await new Promise<boolean>((resolve) => {
+        ws.addEventListener("open", () => resolve(true));
+        ws.addEventListener("error", () => resolve(false));
+        setTimeout(() => resolve(false), 5000);
+      });
+      expect(opened).toBe(true);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("authenticated WebSocket connection receives messages", async () => {
+    // Pass token during WebSocket upgrade via query param
+    const wsUrl = `${GATEWAY_URL.replace(/^http/, "ws")}?token=${GATEWAY_TOKEN}`;
+    const ws = new WebSocket(wsUrl);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        ws.addEventListener("open", () => resolve());
+        ws.addEventListener("error", () =>
+          reject(new Error("WebSocket connection failed")),
+        );
+        setTimeout(() => reject(new Error("WebSocket open timed out")), 5000);
+      });
+
+      // Send a health check request
+      ws.send(
+        JSON.stringify({ type: "req", id: "auth-test", method: "health" }),
+      );
+
+      const response = await new Promise<string>((resolve) => {
+        ws.addEventListener("message", (ev: WebSocket.MessageEvent) =>
+          resolve(String(ev.data)),
+        );
+        setTimeout(() => resolve("timeout"), 5000);
+      });
+
+      // Authenticated connection should get a response (not timeout)
+      expect(response).not.toBe("timeout");
+    } finally {
+      ws.close();
+    }
+  });
+});

--- a/cloud/claws/dispatch-worker/tests/workers/gateway-client.ts
+++ b/cloud/claws/dispatch-worker/tests/workers/gateway-client.ts
@@ -1,0 +1,47 @@
+/**
+ * Client for the Docker OpenClaw gateway used in integration tests.
+ *
+ * The OpenClaw gateway is primarily WebSocket-based and has no REST health
+ * endpoint. Liveness is determined by checking that the HTTP server responds
+ * (any status code, including 404, indicates the server is running).
+ */
+
+export const GATEWAY_URL = process.env.GATEWAY_URL || "http://localhost:18789";
+export const GATEWAY_TOKEN =
+  process.env.OPENCLAW_GATEWAY_TOKEN || "test-gateway-token";
+
+/** Fetch against the Docker OpenClaw gateway with auth header. */
+export async function gatewayFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const url = `${GATEWAY_URL}${path}`;
+  return fetch(url, {
+    ...init,
+    headers: {
+      ...init?.headers,
+      Authorization: `Bearer ${GATEWAY_TOKEN}`,
+    },
+  });
+}
+
+/**
+ * Wait for the gateway HTTP server to become reachable.
+ * Any HTTP response (even 404) means the server is alive.
+ */
+export async function waitForGateway(timeoutMs = 60_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${GATEWAY_URL}/`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      // Any response means the server is up
+      if (res.status > 0) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`Gateway not ready after ${timeoutMs}ms`);
+}

--- a/cloud/claws/dispatch-worker/vitest.docker.config.ts
+++ b/cloud/claws/dispatch-worker/vitest.docker.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/integration/*-docker.test.ts"],
+    testTimeout: 30_000,
+    hookTimeout: 90_000,
+  },
+});


### PR DESCRIPTION
## Docker integration test infrastructure

Adds end-to-end Docker smoke tests for the dispatch worker, running against a real OpenClaw gateway container. Consolidates previously separate PRs #2541-2545 into one reviewable unit.

### What's included

- **`tests/docker/docker-compose.yml`** — Builds and runs an OpenClaw gateway container with health checks
- **`tests/docker/wait-for-gateway.sh`** — Waits for gateway HTTP liveness before running tests
- **`tests/workers/gateway-client.ts`** — Test helper for HTTP/WS connectivity with auth
- **`tests/integration/proxy-docker.test.ts`** — Smoke tests: HTTP reachability, authenticated HTTP, WebSocket upgrade, authenticated WS messaging
- **`vitest.docker.config.ts`** — Vitest config for Docker test suite
- **`.github/workflows/ci.yml`** — New CI job: builds from `openclaw/openclaw` source, runs tests, captures logs on failure
- **`tests/docker/README.md`** — Quick start guide and configuration reference

### Stack position

```
#2546  Miniflare integration tests
#2555  This PR — Docker test infrastructure  ← you are here
#2547  Auth middleware
#2548  Auth matrix tests
#2553  Effect refactor
#2554  validate-session endpoint
```

Co-authored-by: Verse <verse@mirascope.com>