### PR TITLE
refactor(dispatch-worker): migrate bootstrap.ts to Effect-ts

### DIFF
--- a/cloud/claws/dispatch-worker/bun.lock
+++ b/cloud/claws/dispatch-worker/bun.lock
@@ -4,11 +4,13 @@
     "": {
       "name": "claw-dispatch-worker",
       "dependencies": {
+        "effect": "^3.19.13",
         "hono": "^4.11.6",
       },
       "devDependencies": {
         "@cloudflare/sandbox": "*",
         "@cloudflare/workers-types": "^4.20250109.0",
+        "@effect/vitest": "^0.27.0",
         "@types/ws": "^8.18.1",
         "oxlint": "^1.42.0",
         "typescript": "^5.9.3",
@@ -40,6 +42,8 @@
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260206.0", "", {}, "sha512-rHbE1XM3mfwzoyOiKm1oFRTp00Cv4U5UiuMDQwmu/pc79yOA3nDiOC0lue8aOpobBrP4tPHQqsPcWG606Zrw/w=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@effect/vitest": ["@effect/vitest@0.27.0", "", { "peerDependencies": { "effect": "^3.19.0", "vitest": "^3.2.0" } }, "sha512-8bM7n9xlMUYw9GqPIVgXFwFm2jf27m/R7psI64PGpwU5+26iwyxp9eAXEsfT5S6lqztYfpQQ1Ubp5o6HfNYzJQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
@@ -263,6 +267,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "effect": ["effect@3.19.16", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-7+XC3vGrbAhCHd8LTFHvnZjRpZKZ8YHRZqJTkpNoxcJ2mCyNs2SwI+6VkV/ij8Y3YW7wfBN4EbU06/F5+m/wkQ=="],
+
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
@@ -272,6 +278,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -300,6 +308,8 @@
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 

--- a/cloud/claws/dispatch-worker/package.json
+++ b/cloud/claws/dispatch-worker/package.json
@@ -18,11 +18,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "effect": "^3.19.13",
     "hono": "^4.11.6"
   },
   "devDependencies": {
     "@cloudflare/sandbox": "*",
     "@cloudflare/workers-types": "^4.20250109.0",
+    "@effect/vitest": "^0.27.0",
     "@types/ws": "^8.18.1",
     "oxlint": "^1.42.0",
     "typescript": "^5.9.3",

--- a/cloud/claws/dispatch-worker/src/bootstrap.ts
+++ b/cloud/claws/dispatch-worker/src/bootstrap.ts
@@ -10,7 +10,40 @@
  * environment.
  */
 
+import { Data, Effect } from "effect";
+
 import type { DispatchEnv, OpenClawConfig } from "./types";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/** Bootstrap config fetch failed (network or non-OK response). */
+export class BootstrapFetchError extends Data.TaggedError(
+  "BootstrapFetchError",
+)<{
+  readonly clawId: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** Response JSON decode failed. */
+export class BootstrapDecodeError extends Data.TaggedError(
+  "BootstrapDecodeError",
+)<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** Claw slug resolution failed. */
+export class ClawResolutionError extends Data.TaggedError(
+  "ClawResolutionError",
+)<{
+  readonly orgSlug: string;
+  readonly clawSlug: string;
+  readonly statusCode: number;
+  readonly body: string;
+}> {}
 
 // ---------------------------------------------------------------------------
 // Internal fetch via service binding
@@ -36,79 +69,126 @@ function internalFetch(
 
 /**
  * Fetch the bootstrap config for a claw by its ID.
- *
- * @param clawId - The unique claw identifier
- * @param env - Worker environment bindings
- * @returns The full OpenClawConfig including R2 credentials and container env vars
- * @throws Error if the API call fails or returns a non-OK response
  */
-export async function fetchBootstrapConfig(
+export const fetchBootstrapConfig = (
   clawId: string,
   env: DispatchEnv,
-): Promise<OpenClawConfig> {
-  const response = await internalFetch(
-    env,
-    `/api/internal/claws/${clawId}/bootstrap`,
-    {
-      method: "GET",
-      headers: { "Content-Type": "application/json" },
-    },
-  );
+): Effect.Effect<OpenClawConfig, BootstrapFetchError | BootstrapDecodeError> =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        internalFetch(env, `/api/internal/claws/${clawId}/bootstrap`, {
+          method: "GET",
+          headers: { "Content-Type": "application/json" },
+        }),
+      catch: (cause) =>
+        new BootstrapFetchError({
+          clawId,
+          message: `Bootstrap fetch failed for claw ${clawId}`,
+          cause,
+        }),
+    });
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => "(no body)");
-    throw new Error(
-      `Bootstrap config fetch failed for claw ${clawId}: ${response.status} ${response.statusText} — ${body}`,
-    );
-  }
+    if (!response.ok) {
+      const body = yield* Effect.tryPromise({
+        try: () => response.text(),
+        catch: () =>
+          new BootstrapFetchError({
+            clawId,
+            message: `Bootstrap fetch failed for claw ${clawId}: ${response.status} ${response.statusText}`,
+          }),
+      });
+      return yield* new BootstrapFetchError({
+        clawId,
+        message: `Bootstrap config fetch failed for claw ${clawId}: ${response.status} ${response.statusText} — ${body}`,
+      });
+    }
 
-  return (await response.json()) as OpenClawConfig;
-}
+    return yield* Effect.tryPromise({
+      try: () => response.json() as Promise<OpenClawConfig>,
+      catch: (cause) =>
+        new BootstrapDecodeError({
+          message: `Failed to decode bootstrap config for claw ${clawId}`,
+          cause,
+        }),
+    });
+  });
 
 /**
  * Resolve org/claw slugs to a clawId.
  *
- * The dispatch worker receives requests at {clawSlug}.{orgSlug}.mirascope.com
- * and needs the stable clawId to key the Durable Object. This endpoint
- * resolves the slugs.
- *
- * @param orgSlug - Organization slug from hostname
- * @param clawSlug - Claw slug from hostname
- * @param env - Worker environment bindings
- * @returns The resolved clawId and organizationId
+ * Used by both the auth middleware (path-based routing) and legacy
+ * host-based routing.
  */
-export async function resolveClawId(
+export const resolveClawId = (
   orgSlug: string,
   clawSlug: string,
   env: DispatchEnv,
-): Promise<{ clawId: string; organizationId: string }> {
-  const response = await internalFetch(
-    env,
-    `/api/internal/claws/resolve/${orgSlug}/${clawSlug}`,
-    {
-      method: "GET",
-      headers: { "Content-Type": "application/json" },
-    },
-  );
+): Effect.Effect<
+  { clawId: string; organizationId: string },
+  ClawResolutionError
+> =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        internalFetch(
+          env,
+          `/api/internal/claws/resolve/${orgSlug}/${clawSlug}`,
+          {
+            method: "GET",
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      catch: (cause) =>
+        new ClawResolutionError({
+          orgSlug,
+          clawSlug,
+          statusCode: 0,
+          body: `Network error: ${cause}`,
+        }),
+    });
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => "(no body)");
-    throw new Error(
-      `Claw resolution failed for ${clawSlug}.${orgSlug}: ${response.status} ${response.statusText} — ${body}`,
-    );
-  }
+    if (!response.ok) {
+      const body = yield* Effect.tryPromise({
+        try: () => response.text(),
+        catch: () =>
+          new ClawResolutionError({
+            orgSlug,
+            clawSlug,
+            statusCode: response.status,
+            body: "(could not read body)",
+          }),
+      });
+      return yield* new ClawResolutionError({
+        orgSlug,
+        clawSlug,
+        statusCode: response.status,
+        body,
+      });
+    }
 
-  return (await response.json()) as { clawId: string; organizationId: string };
-}
+    return yield* Effect.tryPromise({
+      try: () =>
+        response.json() as Promise<{
+          clawId: string;
+          organizationId: string;
+        }>,
+      catch: (cause) =>
+        new ClawResolutionError({
+          orgSlug,
+          clawSlug,
+          statusCode: response.status,
+          body: `Failed to decode response: ${cause}`,
+        }),
+    });
+  });
 
 /**
  * Report claw status back to the Mirascope API.
  *
- * @param clawId - The claw identifier
- * @param status - Status report payload
- * @param env - Worker environment bindings
+ * Fire-and-forget — logs errors but never fails.
  */
-export async function reportClawStatus(
+export const reportClawStatus = (
   clawId: string,
   status: {
     status: string;
@@ -116,24 +196,26 @@ export async function reportClawStatus(
     startedAt?: string;
   },
   env: DispatchEnv,
-): Promise<void> {
-  try {
-    const response = await internalFetch(
-      env,
-      `/api/internal/claws/${clawId}/status`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(status),
-      },
-    );
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        internalFetch(env, `/api/internal/claws/${clawId}/status`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(status),
+        }),
+      catch: (err) => err,
+    }).pipe(Effect.either);
 
-    if (!response.ok) {
+    if (result._tag === "Left") {
+      console.error(`Status report error for claw ${clawId}:`, result.left);
+      return;
+    }
+
+    if (!result.right.ok) {
       console.error(
-        `Status report failed for claw ${clawId}: ${response.status} ${response.statusText}`,
+        `Status report failed for claw ${clawId}: ${result.right.status} ${result.right.statusText}`,
       );
     }
-  } catch (err) {
-    console.error(`Status report error for claw ${clawId}:`, err);
-  }
-}
+  });


### PR DESCRIPTION
## Migrate bootstrap.ts to Effect-ts

Converts all bootstrap functions from imperative async/await to Effect-ts, establishing the Effect foundation that the auth middleware PR (#2547) builds on.

### Changes

- **bootstrap.ts** — All functions return typed Effects: fetchBootstrapConfig, resolveClawId, reportClawStatus
- **bootstrap.test.ts** — Rewritten with @effect/vitest: it.effect + yield* + Effect.flip
- **index.ts** — Wraps bootstrap calls with Effect.runPromise (full Effect boundary in #2547)
- **test-harness-worker.ts** — Updated for Effect bootstrap API
- **package.json** — Added effect + @effect/vitest deps

### Error types

- BootstrapFetchError — network/non-OK from bootstrap endpoint
- BootstrapDecodeError — JSON parse failure on bootstrap response  
- ClawResolutionError — slug resolution failure (network, non-OK, or decode)

### Stack

#2546 → #2555 → **#2556 (this)** → #2547 → #2548 → #2554

Co-authored-by: Verse <verse@mirascope.com>