### PR TITLE
fix(claws): route warm-up through dispatch worker instead of direct container fetch

### DIFF
--- a/cloud/cloudflare/containers/live.ts
+++ b/cloud/cloudflare/containers/live.ts
@@ -147,18 +147,11 @@ function makeContainerService(
 
     warmUp: (hostname: string) =>
       Effect.gen(function* () {
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(`https://${hostname}/`, {
-              method: "GET",
-              signal: AbortSignal.timeout(30_000),
-            }),
-          catch: (error) =>
-            new CloudflareApiError({
-              message: `Warm-up request failed for ${hostname}`,
-              cause: error,
-            }),
-        });
+        const response = yield* dispatchFetch(
+          hostname,
+          "/_internal/warm-up",
+          "POST",
+        );
         if (!response.ok) {
           return yield* Effect.fail(
             new CloudflareApiError({


### PR DESCRIPTION
The warm-up request was using a direct fetch to the container hostname,
which routes to the Sandbox DO's defaultPort (3000). The gateway runs on
port 18789, causing 530 errors. This change routes warm-up through the
dispatch worker like all other lifecycle operations.

- Add POST /_internal/warm-up endpoint to dispatch worker
- Change warmUp in live.ts to use dispatchFetch instead of direct fetch
- Update tests for both changes

Co-authored-by: Verse <verse@mirascope.com>