### PR TITLE
refactor(cloud): use it.effect in container mock tests

### DIFF
--- a/cloud/analytics/google-client.test.ts
+++ b/cloud/analytics/google-client.test.ts
@@ -2,8 +2,9 @@
  * @fileoverview Tests for Google Analytics Effect-native service.
  */
 
+import { describe, it, expect } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 
 import { GoogleAnalytics } from "@/analytics/google-client";
 

--- a/cloud/analytics/posthog-client.test.ts
+++ b/cloud/analytics/posthog-client.test.ts
@@ -2,8 +2,9 @@
  * @fileoverview Tests for PostHog Effect-native service.
  */
 
+import { describe, it, expect } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 
 import { PostHog } from "@/analytics/posthog-client";
 

--- a/cloud/analytics/service.test.ts
+++ b/cloud/analytics/service.test.ts
@@ -2,8 +2,9 @@
  * @fileoverview Tests for Analytics aggregator service.
  */
 
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, vi } from "vitest";
+import { vi } from "vitest";
 
 import { GoogleAnalytics } from "@/analytics/google-client";
 import { PostHog } from "@/analytics/posthog-client";

--- a/cloud/api/router/cost-estimator.test.ts
+++ b/cloud/api/router/cost-estimator.test.ts
@@ -1,5 +1,6 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 import { estimateCost } from "@/api/router/cost-estimator";
 import * as pricing from "@/api/router/pricing";

--- a/cloud/api/router/non-streaming.test.ts
+++ b/cloud/api/router/non-streaming.test.ts
@@ -1,5 +1,6 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, vi } from "vitest";
+import { vi } from "vitest";
 
 import type { ModelPricing } from "@/api/router/pricing";
 import type { ProxyResult } from "@/api/router/proxy";

--- a/cloud/api/router/pricing.test.ts
+++ b/cloud/api/router/pricing.test.ts
@@ -1,5 +1,6 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 import {
   fetchModelsDotDevPricingData,

--- a/cloud/api/router/proxy.test.ts
+++ b/cloud/api/router/proxy.test.ts
@@ -1,5 +1,6 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 import { PROVIDER_CONFIGS } from "@/api/router/providers";
 import { proxyToProvider, extractProviderPath } from "@/api/router/proxy";

--- a/cloud/api/router/streaming.test.ts
+++ b/cloud/api/router/streaming.test.ts
@@ -1,5 +1,6 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 import { parseStreamingResponse } from "@/api/router/streaming";
 import { ProxyError } from "@/errors";

--- a/cloud/api/utils.test.ts
+++ b/cloud/api/utils.test.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, it, expect } from "vitest";
 
 import { handleErrors, handleDefects } from "@/api/utils";
 import { NotFoundError, UnauthorizedError, DatabaseError } from "@/errors";

--- a/cloud/claws/deployment/live.test.ts
+++ b/cloud/claws/deployment/live.test.ts
@@ -6,8 +6,8 @@
  * deprovision, restart, update, and query claw deployments.
  */
 
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect } from "vitest";
 
 import type { ProvisionClawConfig } from "@/claws/deployment/types";
 
@@ -104,39 +104,35 @@ describe("LiveDeploymentService", () => {
   });
 
   describe("getStatus", () => {
-    it("returns active for running container", async () => {
+    it.effect("returns active for running container", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME, {
         status: "running",
         lastChange: 1700000000000,
       });
 
-      const status = await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          return yield* deployment.getStatus(testConfig.clawId);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        const status = yield* deployment.getStatus(testConfig.clawId);
 
-      expect(status.status).toBe("active");
-      expect(status.startedAt).toEqual(new Date(1700000000000));
+        expect(status.status).toBe("active");
+        expect(status.startedAt).toEqual(new Date(1700000000000));
+      }).pipe(Effect.provide(layer));
     });
 
-    it("returns active for healthy container", async () => {
+    it.effect("returns active for healthy container", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME, { status: "healthy", lastChange: 1000 });
 
-      const status = await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          return yield* deployment.getStatus(testConfig.clawId);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        const status = yield* deployment.getStatus(testConfig.clawId);
 
-      expect(status.status).toBe("active");
+        expect(status.status).toBe("active");
+      }).pipe(Effect.provide(layer));
     });
 
-    it("returns paused for stopped container", async () => {
+    it.effect("returns paused for stopped container", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME, {
         status: "stopped",
@@ -144,57 +140,49 @@ describe("LiveDeploymentService", () => {
         exitCode: 0,
       });
 
-      const status = await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          return yield* deployment.getStatus(testConfig.clawId);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        const status = yield* deployment.getStatus(testConfig.clawId);
 
-      expect(status.status).toBe("paused");
+        expect(status.status).toBe("paused");
+      }).pipe(Effect.provide(layer));
     });
 
-    it("returns paused for stopping container", async () => {
+    it.effect("returns paused for stopping container", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME, { status: "stopping" });
 
-      const status = await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          return yield* deployment.getStatus(testConfig.clawId);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        const status = yield* deployment.getStatus(testConfig.clawId);
 
-      expect(status.status).toBe("paused");
+        expect(status.status).toBe("paused");
+      }).pipe(Effect.provide(layer));
     });
 
-    it("returns error for unknown status", async () => {
+    it.effect("returns error for unknown status", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME, { status: "unknown" });
 
-      const status = await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          return yield* deployment.getStatus(testConfig.clawId);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        const status = yield* deployment.getStatus(testConfig.clawId);
 
-      expect(status.status).toBe("error");
+        expect(status.status).toBe("error");
+      }).pipe(Effect.provide(layer));
     });
 
-    it("returns undefined startedAt when lastChange is missing", async () => {
+    it.effect("returns undefined startedAt when lastChange is missing", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME, { status: "running" });
 
-      const status = await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          return yield* deployment.getStatus(testConfig.clawId);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        const status = yield* deployment.getStatus(testConfig.clawId);
 
-      expect(status.status).toBe("active");
-      expect(status.startedAt).toBeUndefined();
+        expect(status.status).toBe("active");
+        expect(status.startedAt).toBeUndefined();
+      }).pipe(Effect.provide(layer));
     });
 
     it("fails for non-existent container", async () => {
@@ -213,19 +201,17 @@ describe("LiveDeploymentService", () => {
   });
 
   describe("restart", () => {
-    it("restarts gateway and returns provisioning status", async () => {
+    it.effect("restarts gateway and returns provisioning status", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME);
 
-      const status = await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          return yield* deployment.restart(testConfig.clawId);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        const status = yield* deployment.restart(testConfig.clawId);
 
-      expect(status.status).toBe("provisioning");
-      expect(status.startedAt).toBeInstanceOf(Date);
+        expect(status.status).toBe("provisioning");
+        expect(status.startedAt).toBeInstanceOf(Date);
+      }).pipe(Effect.provide(layer));
     });
 
     it("fails for non-existent container", async () => {
@@ -244,44 +230,40 @@ describe("LiveDeploymentService", () => {
   });
 
   describe("update", () => {
-    it("restarts gateway for non-instance-type config update", async () => {
+    it.effect("restarts gateway for non-instance-type config update", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME);
 
-      const status = await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          return yield* deployment.update(testConfig.clawId, {
-            containerEnv: {
-              MIRASCOPE_API_KEY: "key_abc123",
-              ANTHROPIC_API_KEY: "key_abc123",
-              ANTHROPIC_BASE_URL: "https://router.mirascope.com/v1",
-              OPENCLAW_GATEWAY_TOKEN: "gw_token_xyz",
-              TELEGRAM_BOT_TOKEN: "new-token",
-            },
-          });
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        const status = yield* deployment.update(testConfig.clawId, {
+          containerEnv: {
+            MIRASCOPE_API_KEY: "key_abc123",
+            ANTHROPIC_API_KEY: "key_abc123",
+            ANTHROPIC_BASE_URL: "https://router.mirascope.com/v1",
+            OPENCLAW_GATEWAY_TOKEN: "gw_token_xyz",
+            TELEGRAM_BOT_TOKEN: "new-token",
+          },
+        });
 
-      expect(status.status).toBe("provisioning");
-      expect(status.startedAt).toBeInstanceOf(Date);
+        expect(status.status).toBe("provisioning");
+        expect(status.startedAt).toBeInstanceOf(Date);
+      }).pipe(Effect.provide(layer));
     });
 
-    it("recreates container when instance type changes", async () => {
+    it.effect("recreates container when instance type changes", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME);
 
-      const status = await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          return yield* deployment.update(testConfig.clawId, {
-            instanceType: "standard-2",
-          });
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        const status = yield* deployment.update(testConfig.clawId, {
+          instanceType: "standard-2",
+        });
 
-      expect(status.status).toBe("provisioning");
-      expect(status.startedAt).toBeInstanceOf(Date);
+        expect(status.status).toBe("provisioning");
+        expect(status.startedAt).toBeInstanceOf(Date);
+      }).pipe(Effect.provide(layer));
     });
 
     it("fails for non-existent container on gateway restart", async () => {
@@ -316,16 +298,14 @@ describe("LiveDeploymentService", () => {
   });
 
   describe("warmUp", () => {
-    it("sends warm-up request to dispatch worker", async () => {
+    it.effect("sends warm-up request to dispatch worker", () => {
       const { layer, seedContainer } = createTestLayer();
       seedContainer(INTERNAL_HOSTNAME);
 
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const deployment = yield* ClawDeploymentService;
-          yield* deployment.warmUp(testConfig.clawId);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const deployment = yield* ClawDeploymentService;
+        yield* deployment.warmUp(testConfig.clawId);
+      }).pipe(Effect.provide(layer));
     });
 
     it("triggers cold start for new container", async () => {

--- a/cloud/cloudflare/client.test.ts
+++ b/cloud/cloudflare/client.test.ts
@@ -7,23 +7,16 @@
  * - Converts errors to CloudflareApiError
  */
 
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 import { CloudflareHttp } from "@/cloudflare/client";
 import { CloudflareApiError } from "@/errors";
 
 const TEST_TOKEN = "test-api-token-abc123";
 
-const run = <A, E>(effect: Effect.Effect<A, E, CloudflareHttp>) =>
-  Effect.runPromise(
-    effect.pipe(Effect.provide(CloudflareHttp.Live(TEST_TOKEN))),
-  );
-
-const runFail = <A, E>(effect: Effect.Effect<A, E, CloudflareHttp>) =>
-  Effect.runPromise(
-    effect.pipe(Effect.flip, Effect.provide(CloudflareHttp.Live(TEST_TOKEN))),
-  );
+const TestLayer = CloudflareHttp.Live(TEST_TOKEN);
 
 describe("CloudflareHttp", () => {
   beforeEach(() => {
@@ -38,7 +31,7 @@ describe("CloudflareHttp", () => {
   });
 
   describe("request", () => {
-    it("unwraps successful response envelope", async () => {
+    it.effect("unwraps successful response envelope", () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -50,20 +43,18 @@ describe("CloudflareHttp", () => {
         ),
       );
 
-      const result = await run(
-        Effect.gen(function* () {
-          const client = yield* CloudflareHttp;
-          return yield* client.request<{ id: string; name: string }>({
-            method: "GET",
-            path: "/accounts/abc/r2/buckets/test-bucket",
-          });
-        }),
-      );
+      return Effect.gen(function* () {
+        const client = yield* CloudflareHttp;
+        const result = yield* client.request<{ id: string; name: string }>({
+          method: "GET",
+          path: "/accounts/abc/r2/buckets/test-bucket",
+        });
 
-      expect(result).toEqual({ id: "bucket-123", name: "test-bucket" });
+        expect(result).toEqual({ id: "bucket-123", name: "test-bucket" });
+      }).pipe(Effect.provide(TestLayer));
     });
 
-    it("sends correct authorization header", async () => {
+    it.effect("sends correct authorization header", () => {
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -75,24 +66,22 @@ describe("CloudflareHttp", () => {
         ),
       );
 
-      await run(
-        Effect.gen(function* () {
-          const client = yield* CloudflareHttp;
-          return yield* client.request({
-            method: "GET",
-            path: "/test",
-          });
-        }),
-      );
+      return Effect.gen(function* () {
+        const client = yield* CloudflareHttp;
+        yield* client.request({
+          method: "GET",
+          path: "/test",
+        });
 
-      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toBe("https://api.cloudflare.com/client/v4/test");
-      expect((init.headers as Record<string, string>).Authorization).toBe(
-        `Bearer ${TEST_TOKEN}`,
-      );
+        const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe("https://api.cloudflare.com/client/v4/test");
+        expect((init.headers as Record<string, string>).Authorization).toBe(
+          `Bearer ${TEST_TOKEN}`,
+        );
+      }).pipe(Effect.provide(TestLayer));
     });
 
-    it("sends JSON body for POST requests", async () => {
+    it.effect("sends JSON body for POST requests", () => {
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -104,23 +93,21 @@ describe("CloudflareHttp", () => {
         ),
       );
 
-      await run(
-        Effect.gen(function* () {
-          const client = yield* CloudflareHttp;
-          return yield* client.request({
-            method: "POST",
-            path: "/test",
-            body: { name: "my-bucket" },
-          });
-        }),
-      );
+      return Effect.gen(function* () {
+        const client = yield* CloudflareHttp;
+        yield* client.request({
+          method: "POST",
+          path: "/test",
+          body: { name: "my-bucket" },
+        });
 
-      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(init.method).toBe("POST");
-      expect(init.body).toBe(JSON.stringify({ name: "my-bucket" }));
+        const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(init.method).toBe("POST");
+        expect(init.body).toBe(JSON.stringify({ name: "my-bucket" }));
+      }).pipe(Effect.provide(TestLayer));
     });
 
-    it("fails with CloudflareApiError on API error response", async () => {
+    it.effect("fails with CloudflareApiError on API error response", () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -135,44 +122,46 @@ describe("CloudflareHttp", () => {
         ),
       );
 
-      const error = await runFail(
-        Effect.gen(function* () {
-          const client = yield* CloudflareHttp;
-          return yield* client.request({
+      return Effect.gen(function* () {
+        const client = yield* CloudflareHttp;
+        const error = yield* client
+          .request({
             method: "GET",
             path: "/test",
-          });
-        }),
-      );
+          })
+          .pipe(Effect.flip);
 
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      const apiError = error as CloudflareApiError;
-      expect(apiError.message).toContain("Bucket not found");
-      expect(apiError.message).toContain("Access denied");
-      expect(apiError.message).toContain("[10006]");
-      expect(apiError.message).toContain("[10007]");
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        const apiError = error as CloudflareApiError;
+        expect(apiError.message).toContain("Bucket not found");
+        expect(apiError.message).toContain("Access denied");
+        expect(apiError.message).toContain("[10006]");
+        expect(apiError.message).toContain("[10007]");
+      }).pipe(Effect.provide(TestLayer));
     });
 
-    it("fails with CloudflareApiError on network error", async () => {
+    it.effect("fails with CloudflareApiError on network error", () => {
       vi.spyOn(globalThis, "fetch").mockRejectedValue(
         new Error("Network timeout"),
       );
 
-      const error = await runFail(
-        Effect.gen(function* () {
-          const client = yield* CloudflareHttp;
-          return yield* client.request({
+      return Effect.gen(function* () {
+        const client = yield* CloudflareHttp;
+        const error = yield* client
+          .request({
             method: "GET",
             path: "/test",
-          });
-        }),
-      );
+          })
+          .pipe(Effect.flip);
 
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain("request failed");
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain(
+          "request failed",
+        );
+      }).pipe(Effect.provide(TestLayer));
     });
 
-    it("fails with CloudflareApiError on invalid JSON response", async () => {
+    it.effect("fails with CloudflareApiError on invalid JSON response", () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response("not json", {
           status: 200,
@@ -180,23 +169,23 @@ describe("CloudflareHttp", () => {
         }),
       );
 
-      const error = await runFail(
-        Effect.gen(function* () {
-          const client = yield* CloudflareHttp;
-          return yield* client.request({
+      return Effect.gen(function* () {
+        const client = yield* CloudflareHttp;
+        const error = yield* client
+          .request({
             method: "GET",
             path: "/test",
-          });
-        }),
-      );
+          })
+          .pipe(Effect.flip);
 
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain(
-        "Failed to parse",
-      );
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain(
+          "Failed to parse",
+        );
+      }).pipe(Effect.provide(TestLayer));
     });
 
-    it("does not send body for GET requests", async () => {
+    it.effect("does not send body for GET requests", () => {
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -208,21 +197,19 @@ describe("CloudflareHttp", () => {
         ),
       );
 
-      await run(
-        Effect.gen(function* () {
-          const client = yield* CloudflareHttp;
-          return yield* client.request({
-            method: "GET",
-            path: "/test",
-          });
-        }),
-      );
+      return Effect.gen(function* () {
+        const client = yield* CloudflareHttp;
+        yield* client.request({
+          method: "GET",
+          path: "/test",
+        });
 
-      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(init.body).toBeUndefined();
+        const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(init.body).toBeUndefined();
+      }).pipe(Effect.provide(TestLayer));
     });
 
-    it("merges custom headers with defaults", async () => {
+    it.effect("merges custom headers with defaults", () => {
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -234,24 +221,22 @@ describe("CloudflareHttp", () => {
         ),
       );
 
-      await run(
-        Effect.gen(function* () {
-          const client = yield* CloudflareHttp;
-          return yield* client.request({
-            method: "POST",
-            path: "/test",
-            headers: { "cf-r2-jurisdiction": "eu" },
-          });
-        }),
-      );
+      return Effect.gen(function* () {
+        const client = yield* CloudflareHttp;
+        yield* client.request({
+          method: "POST",
+          path: "/test",
+          headers: { "cf-r2-jurisdiction": "eu" },
+        });
 
-      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      const headers = init.headers as Record<string, string>;
-      expect(headers["cf-r2-jurisdiction"]).toBe("eu");
-      expect(headers.Authorization).toBe(`Bearer ${TEST_TOKEN}`);
+        const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        const headers = init.headers as Record<string, string>;
+        expect(headers["cf-r2-jurisdiction"]).toBe("eu");
+        expect(headers.Authorization).toBe(`Bearer ${TEST_TOKEN}`);
+      }).pipe(Effect.provide(TestLayer));
     });
 
-    it("handles empty errors array in failure response", async () => {
+    it.effect("handles empty errors array in failure response", () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -263,18 +248,20 @@ describe("CloudflareHttp", () => {
         ),
       );
 
-      const error = await runFail(
-        Effect.gen(function* () {
-          const client = yield* CloudflareHttp;
-          return yield* client.request({
+      return Effect.gen(function* () {
+        const client = yield* CloudflareHttp;
+        const error = yield* client
+          .request({
             method: "GET",
             path: "/test",
-          });
-        }),
-      );
+          })
+          .pipe(Effect.flip);
 
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain("Unknown error");
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain(
+          "Unknown error",
+        );
+      }).pipe(Effect.provide(TestLayer));
     });
   });
 });

--- a/cloud/cloudflare/containers/live.test.ts
+++ b/cloud/cloudflare/containers/live.test.ts
@@ -5,8 +5,9 @@
  * container service makes correct API calls and transforms responses properly.
  */
 
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { vi, beforeEach } from "vitest";
 
 import type {
   CloudflareHttpClient,
@@ -67,29 +68,27 @@ describe("LiveCloudflareContainerService", () => {
   });
 
   describe("recreate", () => {
-    it("sends POST to dispatch worker /_internal/recreate", async () => {
+    it.effect("sends POST to dispatch worker /_internal/recreate", () => {
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          yield* containers.recreate(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        yield* containers.recreate(TEST_HOSTNAME);
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        "https://dispatch.test.workers.dev/_internal/recreate",
-        expect.objectContaining({
-          method: "POST",
-          headers: expect.objectContaining({
-            Host: TEST_HOSTNAME,
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "https://dispatch.test.workers.dev/_internal/recreate",
+          expect.objectContaining({
+            method: "POST",
+            headers: expect.objectContaining({
+              Host: TEST_HOSTNAME,
+            }),
           }),
-        }),
-      );
+        );
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails when dispatch worker returns error", async () => {
+    it.effect("fails when dispatch worker returns error", () => {
       fetchSpy.mockResolvedValue(
         new Response("Internal Server Error", {
           status: 500,
@@ -100,45 +99,45 @@ describe("LiveCloudflareContainerService", () => {
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.recreate(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain(
-        "Recreate failed",
-      );
-      expect((error as CloudflareApiError).message).toContain("500");
+        }).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain(
+          "Recreate failed",
+        );
+        expect((error as CloudflareApiError).message).toContain("500");
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("restartGateway", () => {
-    it("sends POST to dispatch worker /_internal/restart-gateway", async () => {
-      const handler: RequestHandler = () => Effect.succeed({});
-      const layer = createTestLayer(handler);
+    it.effect(
+      "sends POST to dispatch worker /_internal/restart-gateway",
+      () => {
+        const handler: RequestHandler = () => Effect.succeed({});
+        const layer = createTestLayer(handler);
 
-      await Effect.runPromise(
-        Effect.gen(function* () {
+        return Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           yield* containers.restartGateway(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        "https://dispatch.test.workers.dev/_internal/restart-gateway",
-        expect.objectContaining({
-          method: "POST",
-          headers: expect.objectContaining({
-            Host: TEST_HOSTNAME,
-          }),
-        }),
-      );
-    });
+          expect(fetchSpy).toHaveBeenCalledWith(
+            "https://dispatch.test.workers.dev/_internal/restart-gateway",
+            expect.objectContaining({
+              method: "POST",
+              headers: expect.objectContaining({
+                Host: TEST_HOSTNAME,
+              }),
+            }),
+          );
+        }).pipe(Effect.provide(layer));
+      },
+    );
 
-    it("fails when dispatch worker returns error", async () => {
+    it.effect("fails when dispatch worker returns error", () => {
       fetchSpy.mockResolvedValue(
         new Response("Internal Server Error", {
           status: 500,
@@ -149,42 +148,39 @@ describe("LiveCloudflareContainerService", () => {
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.restartGateway(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain(
-        "Restart gateway failed",
-      );
-      expect((error as CloudflareApiError).message).toContain("500");
+        }).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain(
+          "Restart gateway failed",
+        );
+        expect((error as CloudflareApiError).message).toContain("500");
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("destroy", () => {
-    it("sends POST to dispatch worker /_internal/destroy", async () => {
+    it.effect("sends POST to dispatch worker /_internal/destroy", () => {
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          yield* containers.destroy(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        yield* containers.destroy(TEST_HOSTNAME);
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        "https://dispatch.test.workers.dev/_internal/destroy",
-        expect.objectContaining({
-          method: "POST",
-        }),
-      );
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "https://dispatch.test.workers.dev/_internal/destroy",
+          expect.objectContaining({
+            method: "POST",
+          }),
+        );
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails when dispatch worker returns error", async () => {
+    it.effect("fails when dispatch worker returns error", () => {
       fetchSpy.mockResolvedValue(
         new Response("Not Found", { status: 404, statusText: "Not Found" }),
       );
@@ -192,20 +188,21 @@ describe("LiveCloudflareContainerService", () => {
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.destroy(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain("Destroy failed");
+        }).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain(
+          "Destroy failed",
+        );
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("getState", () => {
-    it("sends GET to dispatch worker /_internal/state", async () => {
+    it.effect("sends GET to dispatch worker /_internal/state", () => {
       fetchSpy.mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -219,28 +216,26 @@ describe("LiveCloudflareContainerService", () => {
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      const state = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const state = yield* containers.getState(TEST_HOSTNAME);
 
-      expect(state.status).toBe("running");
-      expect(state.lastChange).toBe(1705300200000);
+        expect(state.status).toBe("running");
+        expect(state.lastChange).toBe(1705300200000);
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        "https://dispatch.test.workers.dev/_internal/state",
-        expect.objectContaining({
-          method: "GET",
-          headers: expect.objectContaining({
-            Host: TEST_HOSTNAME,
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "https://dispatch.test.workers.dev/_internal/state",
+          expect.objectContaining({
+            method: "GET",
+            headers: expect.objectContaining({
+              Host: TEST_HOSTNAME,
+            }),
           }),
-        }),
-      );
+        );
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails when dispatch worker returns error", async () => {
+    it.effect("fails when dispatch worker returns error", () => {
       fetchSpy.mockResolvedValue(
         new Response("Not Found", { status: 404, statusText: "Not Found" }),
       );
@@ -248,57 +243,53 @@ describe("LiveCloudflareContainerService", () => {
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
+        }).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails when response JSON is invalid", async () => {
+    it.effect("fails when response JSON is invalid", () => {
       fetchSpy.mockResolvedValue(new Response("not json", { status: 200 }));
 
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain(
-        "Failed to parse",
-      );
+        }).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain(
+          "Failed to parse",
+        );
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("warmUp", () => {
-    it("sends GET request to hostname", async () => {
+    it.effect("sends GET request to hostname", () => {
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          yield* containers.warmUp(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        yield* containers.warmUp(TEST_HOSTNAME);
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        `https://${TEST_HOSTNAME}/`,
-        expect.objectContaining({
-          method: "GET",
-        }),
-      );
+        expect(fetchSpy).toHaveBeenCalledWith(
+          `https://${TEST_HOSTNAME}/`,
+          expect.objectContaining({
+            method: "GET",
+          }),
+        );
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails when HTTP response is not ok", async () => {
+    it.effect("fails when HTTP response is not ok", () => {
       fetchSpy.mockResolvedValue(
         new Response("Bad Gateway", {
           status: 502,
@@ -309,38 +300,38 @@ describe("LiveCloudflareContainerService", () => {
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.warmUp(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain("Warm-up failed");
-      expect((error as CloudflareApiError).message).toContain("502");
+        }).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain(
+          "Warm-up failed",
+        );
+        expect((error as CloudflareApiError).message).toContain("502");
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails on network error", async () => {
+    it.effect("fails on network error", () => {
       fetchSpy.mockRejectedValue(new Error("Connection refused"));
 
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.warmUp(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain("Warm-up");
+        }).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain("Warm-up");
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("listInstances", () => {
-    it("sends GET to Cloudflare API and returns instances", async () => {
+    it.effect("sends GET to Cloudflare API and returns instances", () => {
       const requestSpy = vi.fn();
       const handler: RequestHandler = (options) => {
         requestSpy(options);
@@ -352,25 +343,23 @@ describe("LiveCloudflareContainerService", () => {
 
       const layer = createTestLayer(handler);
 
-      const instances = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.listInstances();
-        }).pipe(Effect.provide(layer)),
-      );
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const instances = yield* containers.listInstances();
 
-      expect(instances).toHaveLength(2);
-      expect(instances[0]).toEqual({ id: "aabbccdd", hasStoredData: true });
-      expect(instances[1]).toEqual({ id: "eeff0011", hasStoredData: false });
+        expect(instances).toHaveLength(2);
+        expect(instances[0]).toEqual({ id: "aabbccdd", hasStoredData: true });
+        expect(instances[1]).toEqual({ id: "eeff0011", hasStoredData: false });
 
-      const call = requestSpy.mock.calls[0][0] as CloudflareRequestOptions;
-      expect(call.method).toBe("GET");
-      expect(call.path).toContain(
-        "/accounts/test-account-id/workers/durable_objects/namespaces/test-namespace-id/objects",
-      );
+        const call = requestSpy.mock.calls[0][0] as CloudflareRequestOptions;
+        expect(call.method).toBe("GET");
+        expect(call.path).toContain(
+          "/accounts/test-account-id/workers/durable_objects/namespaces/test-namespace-id/objects",
+        );
+      }).pipe(Effect.provide(layer));
     });
 
-    it("propagates API errors", async () => {
+    it.effect("propagates API errors", () => {
       const handler: RequestHandler = () =>
         Effect.fail(
           new CloudflareApiError({
@@ -380,35 +369,33 @@ describe("LiveCloudflareContainerService", () => {
 
       const layer = createTestLayer(handler);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.listInstances();
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
+        }).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("dispatch worker network errors", () => {
-    it("wraps fetch errors in CloudflareApiError", async () => {
+    it.effect("wraps fetch errors in CloudflareApiError", () => {
       fetchSpy.mockRejectedValue(new Error("DNS resolution failed"));
 
       const handler: RequestHandler = () => Effect.succeed({});
       const layer = createTestLayer(handler);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.recreate(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain(
-        "Dispatch worker request failed",
-      );
+        }).pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain(
+          "Dispatch worker request failed",
+        );
+      }).pipe(Effect.provide(layer));
     });
   });
 });

--- a/cloud/cloudflare/containers/mock.test.ts
+++ b/cloud/cloudflare/containers/mock.test.ts
@@ -8,8 +8,8 @@
  * isolated state without needing reset functions.
  */
 
+import { describe, it, expect } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, it, expect } from "vitest";
 
 import { makeMockContainerLayer } from "@/cloudflare/containers/mock";
 import { CloudflareContainerService } from "@/cloudflare/containers/service";
@@ -19,193 +19,167 @@ const TEST_HOSTNAME = "my-claw.my-org.mirascope.com";
 
 describe("MockCloudflareContainerService", () => {
   describe("recreate", () => {
-    it("recreates a running container", async () => {
+    it.effect("recreates a running container", () => {
       const { layer, seed } = makeMockContainerLayer();
       seed(TEST_HOSTNAME);
 
-      const state = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          yield* containers.recreate(TEST_HOSTNAME);
-          return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
-
-      expect(state.status).toBe("running");
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        yield* containers.recreate(TEST_HOSTNAME);
+        const state = yield* containers.getState(TEST_HOSTNAME);
+        expect(state.status).toBe("running");
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails for non-existent container", async () => {
+    it.effect("fails for non-existent container", () => {
       const { layer } = makeMockContainerLayer();
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.recreate("unknown.host.com");
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain("not found");
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const error = yield* containers
+          .recreate("unknown.host.com")
+          .pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain("not found");
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("restartGateway", () => {
-    it("restarts gateway in a running container", async () => {
+    it.effect("restarts gateway in a running container", () => {
       const { layer, seed } = makeMockContainerLayer();
       seed(TEST_HOSTNAME);
 
-      const state = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          yield* containers.restartGateway(TEST_HOSTNAME);
-          return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
-
-      expect(state.status).toBe("running");
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        yield* containers.restartGateway(TEST_HOSTNAME);
+        const state = yield* containers.getState(TEST_HOSTNAME);
+        expect(state.status).toBe("running");
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails for non-existent container", async () => {
+    it.effect("fails for non-existent container", () => {
       const { layer } = makeMockContainerLayer();
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.restartGateway("unknown.host.com");
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain("not found");
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const error = yield* containers
+          .restartGateway("unknown.host.com")
+          .pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain("not found");
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("destroy", () => {
-    it("destroys a running container", async () => {
+    it.effect("destroys a running container", () => {
       const { layer, seed } = makeMockContainerLayer();
       seed(TEST_HOSTNAME);
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          yield* containers.destroy(TEST_HOSTNAME);
-          return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        yield* containers.destroy(TEST_HOSTNAME);
+        const error = yield* containers
+          .getState(TEST_HOSTNAME)
+          .pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails for non-existent container", async () => {
+    it.effect("fails for non-existent container", () => {
       const { layer } = makeMockContainerLayer();
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.destroy("unknown.host.com");
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const error = yield* containers
+          .destroy("unknown.host.com")
+          .pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("getState", () => {
-    it("returns state for running container", async () => {
+    it.effect("returns state for running container", () => {
       const { layer, seed } = makeMockContainerLayer();
       seed(TEST_HOSTNAME, { status: "healthy", lastChange: 1000 });
 
-      const state = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
-
-      expect(state.status).toBe("healthy");
-      expect(state.lastChange).toBe(1000);
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const state = yield* containers.getState(TEST_HOSTNAME);
+        expect(state.status).toBe("healthy");
+        expect(state.lastChange).toBe(1000);
+      }).pipe(Effect.provide(layer));
     });
 
-    it("fails for non-existent container", async () => {
+    it.effect("fails for non-existent container", () => {
       const { layer } = makeMockContainerLayer();
 
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.getState("unknown.host.com");
-        }).pipe(Effect.flip, Effect.provide(layer)),
-      );
-
-      expect(error).toBeInstanceOf(CloudflareApiError);
-      expect((error as CloudflareApiError).message).toContain("not found");
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const error = yield* containers
+          .getState("unknown.host.com")
+          .pipe(Effect.flip);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+        expect((error as CloudflareApiError).message).toContain("not found");
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("warmUp", () => {
-    it("initializes a container", async () => {
+    it.effect("initializes a container", () => {
       const { layer } = makeMockContainerLayer();
 
-      const state = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          yield* containers.warmUp(TEST_HOSTNAME);
-          return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
-
-      expect(state.status).toBe("running");
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        yield* containers.warmUp(TEST_HOSTNAME);
+        const state = yield* containers.getState(TEST_HOSTNAME);
+        expect(state.status).toBe("running");
+      }).pipe(Effect.provide(layer));
     });
 
-    it("does not overwrite existing container state", async () => {
+    it.effect("does not overwrite existing container state", () => {
       const { layer, seed } = makeMockContainerLayer();
       seed(TEST_HOSTNAME, { status: "healthy", lastChange: 1000 });
 
-      const state = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          yield* containers.warmUp(TEST_HOSTNAME);
-          return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
-
-      expect(state.status).toBe("healthy");
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        yield* containers.warmUp(TEST_HOSTNAME);
+        const state = yield* containers.getState(TEST_HOSTNAME);
+        expect(state.status).toBe("healthy");
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("listInstances", () => {
-    it("returns empty list when no containers exist", async () => {
+    it.effect("returns empty list when no containers exist", () => {
       const { layer } = makeMockContainerLayer();
 
-      const instances = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.listInstances();
-        }).pipe(Effect.provide(layer)),
-      );
-
-      expect(instances).toHaveLength(0);
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const instances = yield* containers.listInstances();
+        expect(instances).toHaveLength(0);
+      }).pipe(Effect.provide(layer));
     });
 
-    it("returns all seeded containers", async () => {
+    it.effect("returns all seeded containers", () => {
       const { layer, seed } = makeMockContainerLayer();
       seed("c1.org.mirascope.com");
       seed("c2.org.mirascope.com");
       seed("c3.org.mirascope.com");
 
-      const instances = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.listInstances();
-        }).pipe(Effect.provide(layer)),
-      );
-
-      expect(instances).toHaveLength(3);
-      expect(instances.every((i) => i.hasStoredData)).toBe(true);
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const instances = yield* containers.listInstances();
+        expect(instances).toHaveLength(3);
+        expect(instances.every((i) => i.hasStoredData)).toBe(true);
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("seed", () => {
-    it("seeds container with custom state", async () => {
+    it.effect("seeds container with custom state", () => {
       const { layer, seed } = makeMockContainerLayer();
       seed(TEST_HOSTNAME, {
         status: "stopped",
@@ -213,43 +187,38 @@ describe("MockCloudflareContainerService", () => {
         exitCode: 1,
       });
 
-      const state = await Effect.runPromise(
-        Effect.gen(function* () {
-          const containers = yield* CloudflareContainerService;
-          return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.provide(layer)),
-      );
-
-      expect(state.status).toBe("stopped");
-      expect(state.exitCode).toBe(1);
+      return Effect.gen(function* () {
+        const containers = yield* CloudflareContainerService;
+        const state = yield* containers.getState(TEST_HOSTNAME);
+        expect(state.status).toBe("stopped");
+        expect(state.exitCode).toBe(1);
+      }).pipe(Effect.provide(layer));
     });
   });
 
   describe("state isolation", () => {
-    it("each layer has independent state", async () => {
+    it.effect("each layer has independent state", () => {
       const mock1 = makeMockContainerLayer();
       const mock2 = makeMockContainerLayer();
       mock1.seed(TEST_HOSTNAME);
 
-      // Should exist in layer1
-      const state = await Effect.runPromise(
-        Effect.gen(function* () {
+      return Effect.gen(function* () {
+        // Should exist in layer1
+        const state = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.provide(mock1.layer)),
-      );
+        }).pipe(Effect.provide(mock1.layer));
 
-      expect(state.status).toBe("running");
+        expect(state.status).toBe("running");
 
-      // Should not exist in layer2
-      const error = await Effect.runPromise(
-        Effect.gen(function* () {
+        // Should not exist in layer2
+        const error = yield* Effect.gen(function* () {
           const containers = yield* CloudflareContainerService;
           return yield* containers.getState(TEST_HOSTNAME);
-        }).pipe(Effect.flip, Effect.provide(mock2.layer)),
-      );
+        }).pipe(Effect.flip, Effect.provide(mock2.layer));
 
-      expect(error).toBeInstanceOf(CloudflareApiError);
+        expect(error).toBeInstanceOf(CloudflareApiError);
+      });
     });
   });
 });

--- a/cloud/emails/audience.test.ts
+++ b/cloud/emails/audience.test.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect } from "vitest";
 
 import { Emails } from "@/emails/service";
 import { ResendError } from "@/errors";
@@ -11,46 +11,48 @@ import {
 
 describe("Audience", () => {
   describe("add", () => {
-    it("creates contact and adds to audience segment with correct parameters", () => {
-      let capturedCreateParams: unknown;
-      let capturedAddParams: unknown;
-      const expectedParams = TestAudienceAddParamsFixture();
-      const response = TestAudienceAddResponseFixture();
+    it.live(
+      "creates contact and adds to audience segment with correct parameters",
+      () => {
+        let capturedCreateParams: unknown;
+        let capturedAddParams: unknown;
+        const expectedParams = TestAudienceAddParamsFixture();
+        const response = TestAudienceAddResponseFixture();
 
-      return Effect.gen(function* () {
-        const emails = yield* Emails;
+        return Effect.gen(function* () {
+          const emails = yield* Emails;
 
-        const result = yield* emails.audience.add("user@example.com");
+          const result = yield* emails.audience.add("user@example.com");
 
-        expect(capturedCreateParams).toEqual({ email: "user@example.com" });
-        expect(capturedAddParams).toEqual(expectedParams);
-        expect(result).toEqual(response);
-      }).pipe(
-        Effect.provide(
-          Emails.Default.pipe(
-            Layer.provide(
-              MockResendAudience.layer(
-                (params) => {
-                  capturedAddParams = params;
-                  return Effect.succeed(response);
-                },
-                "seg_test_mock",
-                (params) => {
-                  capturedCreateParams = params;
-                  return Effect.succeed({
-                    id: "contact_123",
-                    object: "contact",
-                  });
-                },
+          expect(capturedCreateParams).toEqual({ email: "user@example.com" });
+          expect(capturedAddParams).toEqual(expectedParams);
+          expect(result).toEqual(response);
+        }).pipe(
+          Effect.provide(
+            Emails.Default.pipe(
+              Layer.provide(
+                MockResendAudience.layer(
+                  (params) => {
+                    capturedAddParams = params;
+                    return Effect.succeed(response);
+                  },
+                  "seg_test_mock",
+                  (params) => {
+                    capturedCreateParams = params;
+                    return Effect.succeed({
+                      id: "contact_123",
+                      object: "contact",
+                    });
+                  },
+                ),
               ),
             ),
           ),
-        ),
-        Effect.runPromise,
-      );
-    });
+        );
+      },
+    );
 
-    it("continues to add to segment when contact already exists", () => {
+    it.live("continues to add to segment when contact already exists", () => {
       let segmentAddCalled = false;
       const response = TestAudienceAddResponseFixture();
 
@@ -79,40 +81,41 @@ describe("Audience", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("propagates error when contact creation fails for non-duplicate reasons", () => {
-      return Effect.gen(function* () {
-        const emails = yield* Emails;
+    it.live(
+      "propagates error when contact creation fails for non-duplicate reasons",
+      () => {
+        return Effect.gen(function* () {
+          const emails = yield* Emails;
 
-        const result = yield* emails.audience
-          .add("user@example.com")
-          .pipe(Effect.flip);
+          const result = yield* emails.audience
+            .add("user@example.com")
+            .pipe(Effect.flip);
 
-        expect(result).toBeInstanceOf(ResendError);
-        expect(result.message).toBe("Rate limit exceeded");
-      }).pipe(
-        Effect.provide(
-          Emails.Default.pipe(
-            Layer.provide(
-              MockResendAudience.layer(
-                () => Effect.succeed({ id: "contact_123" }),
-                "seg_test_mock",
-                () =>
-                  Effect.fail(
-                    new ResendError({ message: "Rate limit exceeded" }),
-                  ),
+          expect(result).toBeInstanceOf(ResendError);
+          expect(result.message).toBe("Rate limit exceeded");
+        }).pipe(
+          Effect.provide(
+            Emails.Default.pipe(
+              Layer.provide(
+                MockResendAudience.layer(
+                  () => Effect.succeed({ id: "contact_123" }),
+                  "seg_test_mock",
+                  () =>
+                    Effect.fail(
+                      new ResendError({ message: "Rate limit exceeded" }),
+                    ),
+                ),
               ),
             ),
           ),
-        ),
-        Effect.runPromise,
-      );
-    });
+        );
+      },
+    );
 
-    it("uses the configured segment ID", () => {
+    it.live("uses the configured segment ID", () => {
       let capturedSegmentId: string | undefined;
       const response = TestAudienceAddResponseFixture();
 
@@ -133,11 +136,10 @@ describe("Audience", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("returns ResendError when add fails", () => {
+    it.live("returns ResendError when add fails", () => {
       return Effect.gen(function* () {
         const emails = yield* Emails;
 
@@ -161,11 +163,10 @@ describe("Audience", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("returns ResendError for invalid email address", () => {
+    it.live("returns ResendError for invalid email address", () => {
       return Effect.gen(function* () {
         const emails = yield* Emails;
 
@@ -189,11 +190,10 @@ describe("Audience", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("handles multiple email additions", () => {
+    it.live("handles multiple email additions", () => {
       const addedEmails: string[] = [];
 
       return Effect.gen(function* () {
@@ -221,7 +221,6 @@ describe("Audience", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
   });

--- a/cloud/emails/service.test.ts
+++ b/cloud/emails/service.test.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect } from "vitest";
 
 import { Emails } from "@/emails/service";
 import { ResendError } from "@/errors";
@@ -11,7 +11,7 @@ import {
 
 describe("Email", () => {
   describe("send", () => {
-    it("sends email with correct parameters", () => {
+    it.live("sends email with correct parameters", () => {
       let capturedParams: unknown;
       const sendParams = TestEmailSendParamsFixture();
       const response = TestEmailSendResponseFixture();
@@ -34,11 +34,10 @@ describe("Email", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("sends email with multiple recipients", () => {
+    it.live("sends email with multiple recipients", () => {
       const sendParams = TestEmailSendParamsFixture({
         to: ["user1@example.com", "user2@example.com"],
       });
@@ -56,11 +55,10 @@ describe("Email", () => {
             Layer.provide(MockResend.layer(() => Effect.succeed(response))),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("sends email with cc and bcc", () => {
+    it.live("sends email with cc and bcc", () => {
       let capturedParams: unknown;
       const sendParams = TestEmailSendParamsFixture({
         cc: "cc@example.com",
@@ -86,11 +84,10 @@ describe("Email", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("sends email with text content", () => {
+    it.live("sends email with text content", () => {
       let capturedParams: unknown;
       const sendParams = TestEmailSendParamsFixture({
         html: undefined,
@@ -116,11 +113,10 @@ describe("Email", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("sends email with attachments", () => {
+    it.live("sends email with attachments", () => {
       let capturedParams: unknown;
       const sendParams = TestEmailSendParamsFixture({
         attachments: [
@@ -150,11 +146,10 @@ describe("Email", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("sends email with replyTo", () => {
+    it.live("sends email with replyTo", () => {
       let capturedParams: unknown;
       const sendParams = TestEmailSendParamsFixture({
         replyTo: "support@example.com",
@@ -179,11 +174,10 @@ describe("Email", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("returns ResendError when send fails", () => {
+    it.live("returns ResendError when send fails", () => {
       const sendParams = TestEmailSendParamsFixture();
 
       return Effect.gen(function* () {
@@ -205,11 +199,10 @@ describe("Email", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("returns ResendError for invalid email address", () => {
+    it.live("returns ResendError for invalid email address", () => {
       const sendParams = TestEmailSendParamsFixture({ from: "invalid-email" });
 
       return Effect.gen(function* () {
@@ -233,13 +226,12 @@ describe("Email", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
   });
 
   describe("DefaultRetries", () => {
-    it("retries on failure and eventually succeeds", () => {
+    it.live("retries on failure and eventually succeeds", () => {
       let attemptCount = 0;
       const sendParams = TestEmailSendParamsFixture();
       const response = TestEmailSendResponseFixture();
@@ -270,42 +262,43 @@ describe("Email", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
 
-    it("catches all errors after retries exhausted and returns void", () => {
-      let attemptCount = 0;
-      const sendParams = TestEmailSendParamsFixture();
+    it.live(
+      "catches all errors after retries exhausted and returns void",
+      () => {
+        let attemptCount = 0;
+        const sendParams = TestEmailSendParamsFixture();
 
-      return Effect.gen(function* () {
-        const email = yield* Emails;
+        return Effect.gen(function* () {
+          const email = yield* Emails;
 
-        // Should not throw even after all retries fail
-        yield* email
-          .send(sendParams)
-          .pipe(Emails.DefaultRetries("Failed to send test email"));
+          // Should not throw even after all retries fail
+          yield* email
+            .send(sendParams)
+            .pipe(Emails.DefaultRetries("Failed to send test email"));
 
-        // Should have tried 5 times (1 initial + 4 retries)
-        expect(attemptCount).toBe(5);
-      }).pipe(
-        Effect.provide(
-          Emails.Default.pipe(
-            Layer.provide(
-              MockResend.layer(() => {
-                attemptCount++;
-                return Effect.fail(
-                  new ResendError({ message: "Persistent error" }),
-                );
-              }),
+          // Should have tried 5 times (1 initial + 4 retries)
+          expect(attemptCount).toBe(5);
+        }).pipe(
+          Effect.provide(
+            Emails.Default.pipe(
+              Layer.provide(
+                MockResend.layer(() => {
+                  attemptCount++;
+                  return Effect.fail(
+                    new ResendError({ message: "Persistent error" }),
+                  );
+                }),
+              ),
             ),
           ),
-        ),
-        Effect.runPromise,
-      );
-    });
+        );
+      },
+    );
 
-    it("logs warning with error message when retries exhausted", () => {
+    it.live("logs warning with error message when retries exhausted", () => {
       const sendParams = TestEmailSendParamsFixture();
       const customErrorMessage = "Custom error message for logging";
 
@@ -326,7 +319,6 @@ describe("Email", () => {
             ),
           ),
         ),
-        Effect.runPromise,
       );
     });
   });

--- a/cloud/payments/service.test.ts
+++ b/cloud/payments/service.test.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect } from "vitest";
 
 import { Payments } from "@/payments/service";
 import { MockDrizzleORMLayer } from "@/tests/mock-drizzle";

--- a/cloud/settings.test.ts
+++ b/cloud/settings.test.ts
@@ -1,13 +1,6 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Either } from "effect";
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach,
-  assert,
-} from "vitest";
+import { vi, beforeEach, afterEach, assert } from "vitest";
 
 import { SettingsValidationError } from "@/errors";
 import {
@@ -30,39 +23,40 @@ describe("settings", () => {
       process.env = originalEnv;
     });
 
-    it("fails with SettingsValidationError when required variables are missing", async () => {
-      // Clear all env vars
-      process.env = {};
+    it.effect(
+      "fails with SettingsValidationError when required variables are missing",
+      () => {
+        // Clear all env vars
+        process.env = {};
 
-      const result = await Effect.runPromise(
-        validateSettings().pipe(Effect.either),
-      );
+        return Effect.gen(function* () {
+          const result = yield* validateSettings().pipe(Effect.either);
+          assert(Either.isLeft(result));
+          expect(result.left).toBeInstanceOf(SettingsValidationError);
+          expect(result.left.missingVariables).toContain("ENVIRONMENT");
+          expect(result.left.missingVariables).toContain("DATABASE_URL");
+        });
+      },
+    );
 
-      assert(Either.isLeft(result));
-      expect(result.left).toBeInstanceOf(SettingsValidationError);
-      expect(result.left.missingVariables).toContain("ENVIRONMENT");
-      expect(result.left.missingVariables).toContain("DATABASE_URL");
-    });
-
-    it("succeeds with all required variables set", async () => {
+    it.effect("succeeds with all required variables set", () => {
       // Set all required env vars
       const mockEnv = createMockEnv();
       for (const [key, value] of Object.entries(mockEnv)) {
         process.env[key] = value;
       }
 
-      const result = await Effect.runPromise(
-        validateSettings().pipe(Effect.either),
-      );
-
-      assert(Either.isRight(result));
-      expect(result.right.env).toBe("test");
-      expect(result.right.databaseUrl).toBe(
-        "postgres://test:test@localhost:5432/test",
-      );
+      return Effect.gen(function* () {
+        const result = yield* validateSettings().pipe(Effect.either);
+        assert(Either.isRight(result));
+        expect(result.right.env).toBe("test");
+        expect(result.right.databaseUrl).toBe(
+          "postgres://test:test@localhost:5432/test",
+        );
+      });
     });
 
-    it("parses boolean TLS settings correctly", async () => {
+    it.effect("parses boolean TLS settings correctly", () => {
       const mockEnv = createMockEnv({
         CLICKHOUSE_TLS_ENABLED: "false",
         CLICKHOUSE_TLS_SKIP_VERIFY: "false",
@@ -72,17 +66,16 @@ describe("settings", () => {
         process.env[key] = value;
       }
 
-      const result = await Effect.runPromise(
-        validateSettings().pipe(Effect.either),
-      );
-
-      assert(Either.isRight(result));
-      expect(result.right.clickhouse.tls.enabled).toBe(false);
-      expect(result.right.clickhouse.tls.skipVerify).toBe(false);
-      expect(result.right.clickhouse.tls.hostnameVerify).toBe(true);
+      return Effect.gen(function* () {
+        const result = yield* validateSettings().pipe(Effect.either);
+        assert(Either.isRight(result));
+        expect(result.right.clickhouse.tls.enabled).toBe(false);
+        expect(result.right.clickhouse.tls.skipVerify).toBe(false);
+        expect(result.right.clickhouse.tls.hostnameVerify).toBe(true);
+      });
     });
 
-    it("fails in production when CLICKHOUSE_URL is not https", async () => {
+    it.effect("fails in production when CLICKHOUSE_URL is not https", () => {
       const mockEnv = createMockEnv({
         ENVIRONMENT: "production",
         CLICKHOUSE_URL: "http://clickhouse.example.com",
@@ -96,93 +89,103 @@ describe("settings", () => {
         process.env[key] = value;
       }
 
-      const result = await Effect.runPromise(
-        validateSettings().pipe(Effect.either),
-      );
-
-      assert(Either.isLeft(result));
-      expect(result.left).toBeInstanceOf(SettingsValidationError);
-      expect(result.left.message).toContain("must use https://");
-    });
-
-    it("fails when TLS_SKIP_VERIFY is true (not supported by web client)", async () => {
-      const mockEnv = createMockEnv({
-        CLICKHOUSE_TLS_ENABLED: "true",
-        CLICKHOUSE_TLS_SKIP_VERIFY: "true",
-        CLICKHOUSE_TLS_HOSTNAME_VERIFY: "true",
-        CLICKHOUSE_TLS_CA: "", // Must be empty - CA not supported by web client
-        CLICKHOUSE_TLS_MIN_VERSION: "1.2",
+      return Effect.gen(function* () {
+        const result = yield* validateSettings().pipe(Effect.either);
+        assert(Either.isLeft(result));
+        expect(result.left).toBeInstanceOf(SettingsValidationError);
+        expect(result.left.message).toContain("must use https://");
       });
-      for (const [key, value] of Object.entries(mockEnv)) {
-        process.env[key] = value;
-      }
-
-      const result = await Effect.runPromise(
-        validateSettings().pipe(Effect.either),
-      );
-
-      assert(Either.isLeft(result));
-      expect(result.left).toBeInstanceOf(SettingsValidationError);
-      expect(result.left.message).toContain("CLICKHOUSE_TLS_SKIP_VERIFY=true");
     });
 
-    it("fails when TLS_HOSTNAME_VERIFY is false (not supported by web client)", async () => {
-      const mockEnv = createMockEnv({
-        CLICKHOUSE_TLS_ENABLED: "true",
-        CLICKHOUSE_TLS_SKIP_VERIFY: "false",
-        CLICKHOUSE_TLS_HOSTNAME_VERIFY: "false",
-        CLICKHOUSE_TLS_CA: "", // Must be empty - CA not supported by web client
-        CLICKHOUSE_TLS_MIN_VERSION: "1.2",
-      });
-      for (const [key, value] of Object.entries(mockEnv)) {
-        process.env[key] = value;
-      }
+    it.effect(
+      "fails when TLS_SKIP_VERIFY is true (not supported by web client)",
+      () => {
+        const mockEnv = createMockEnv({
+          CLICKHOUSE_TLS_ENABLED: "true",
+          CLICKHOUSE_TLS_SKIP_VERIFY: "true",
+          CLICKHOUSE_TLS_HOSTNAME_VERIFY: "true",
+          CLICKHOUSE_TLS_CA: "", // Must be empty - CA not supported by web client
+          CLICKHOUSE_TLS_MIN_VERSION: "1.2",
+        });
+        for (const [key, value] of Object.entries(mockEnv)) {
+          process.env[key] = value;
+        }
 
-      const result = await Effect.runPromise(
-        validateSettings().pipe(Effect.either),
-      );
+        return Effect.gen(function* () {
+          const result = yield* validateSettings().pipe(Effect.either);
+          assert(Either.isLeft(result));
+          expect(result.left).toBeInstanceOf(SettingsValidationError);
+          expect(result.left.message).toContain(
+            "CLICKHOUSE_TLS_SKIP_VERIFY=true",
+          );
+        });
+      },
+    );
 
-      assert(Either.isLeft(result));
-      expect(result.left).toBeInstanceOf(SettingsValidationError);
-      expect(result.left.message).toContain(
-        "CLICKHOUSE_TLS_HOSTNAME_VERIFY=false",
-      );
-    });
+    it.effect(
+      "fails when TLS_HOSTNAME_VERIFY is false (not supported by web client)",
+      () => {
+        const mockEnv = createMockEnv({
+          CLICKHOUSE_TLS_ENABLED: "true",
+          CLICKHOUSE_TLS_SKIP_VERIFY: "false",
+          CLICKHOUSE_TLS_HOSTNAME_VERIFY: "false",
+          CLICKHOUSE_TLS_CA: "", // Must be empty - CA not supported by web client
+          CLICKHOUSE_TLS_MIN_VERSION: "1.2",
+        });
+        for (const [key, value] of Object.entries(mockEnv)) {
+          process.env[key] = value;
+        }
+
+        return Effect.gen(function* () {
+          const result = yield* validateSettings().pipe(Effect.either);
+          assert(Either.isLeft(result));
+          expect(result.left).toBeInstanceOf(SettingsValidationError);
+          expect(result.left.message).toContain(
+            "CLICKHOUSE_TLS_HOSTNAME_VERIFY=false",
+          );
+        });
+      },
+    );
   });
 
   describe("validateSettingsFromEnvironment", () => {
-    it("fails when HYPERDRIVE binding is missing", async () => {
+    it.effect("fails when HYPERDRIVE binding is missing", () => {
       const env: CloudflareEnvironment = {};
 
-      const result = await Effect.runPromise(
-        validateSettingsFromEnvironment(env).pipe(Effect.either),
-      );
-
-      assert(Either.isLeft(result));
-      expect(result.left).toBeInstanceOf(SettingsValidationError);
-      expect(result.left.missingVariables).toContain("HYPERDRIVE");
-      expect(result.left.message).toContain(
-        "HYPERDRIVE binding not configured",
-      );
+      return Effect.gen(function* () {
+        const result = yield* validateSettingsFromEnvironment(env).pipe(
+          Effect.either,
+        );
+        assert(Either.isLeft(result));
+        expect(result.left).toBeInstanceOf(SettingsValidationError);
+        expect(result.left.missingVariables).toContain("HYPERDRIVE");
+        expect(result.left.message).toContain(
+          "HYPERDRIVE binding not configured",
+        );
+      });
     });
 
-    it("fails when required env vars are missing (after HYPERDRIVE)", async () => {
-      const env: CloudflareEnvironment = {
-        HYPERDRIVE: {
-          connectionString: "postgres://test:test@localhost:5432/test",
-        },
-      };
+    it.effect(
+      "fails when required env vars are missing (after HYPERDRIVE)",
+      () => {
+        const env: CloudflareEnvironment = {
+          HYPERDRIVE: {
+            connectionString: "postgres://test:test@localhost:5432/test",
+          },
+        };
 
-      const result = await Effect.runPromise(
-        validateSettingsFromEnvironment(env).pipe(Effect.either),
-      );
+        return Effect.gen(function* () {
+          const result = yield* validateSettingsFromEnvironment(env).pipe(
+            Effect.either,
+          );
+          assert(Either.isLeft(result));
+          expect(result.left).toBeInstanceOf(SettingsValidationError);
+          expect(result.left.missingVariables).toContain("ENVIRONMENT");
+        });
+      },
+    );
 
-      assert(Either.isLeft(result));
-      expect(result.left).toBeInstanceOf(SettingsValidationError);
-      expect(result.left.missingVariables).toContain("ENVIRONMENT");
-    });
-
-    it("succeeds with all required env bindings", async () => {
+    it.effect("succeeds with all required env bindings", () => {
       const env: CloudflareEnvironment = {
         ...createMockEnv(),
         HYPERDRIVE: {
@@ -190,18 +193,19 @@ describe("settings", () => {
         },
       };
 
-      const result = await Effect.runPromise(
-        validateSettingsFromEnvironment(env).pipe(Effect.either),
-      );
-
-      assert(Either.isRight(result));
-      expect(result.right.env).toBe("test");
-      expect(result.right.clickhouse.url).toBe("http://localhost:8123");
-      expect(result.right.clickhouse.user).toBe("default");
-      expect(result.right.clickhouse.database).toBe("test_db");
+      return Effect.gen(function* () {
+        const result = yield* validateSettingsFromEnvironment(env).pipe(
+          Effect.either,
+        );
+        assert(Either.isRight(result));
+        expect(result.right.env).toBe("test");
+        expect(result.right.clickhouse.url).toBe("http://localhost:8123");
+        expect(result.right.clickhouse.user).toBe("default");
+        expect(result.right.clickhouse.database).toBe("test_db");
+      });
     });
 
-    it("maps all ClickHouse settings from env", async () => {
+    it.effect("maps all ClickHouse settings from env", () => {
       const env: CloudflareEnvironment = {
         ...createMockEnv(),
         HYPERDRIVE: {
@@ -213,18 +217,19 @@ describe("settings", () => {
         CLICKHOUSE_DATABASE: "analytics",
       };
 
-      const result = await Effect.runPromise(
-        validateSettingsFromEnvironment(env).pipe(Effect.either),
-      );
-
-      assert(Either.isRight(result));
-      expect(result.right.clickhouse.url).toBe("https://ch.example.com");
-      expect(result.right.clickhouse.user).toBe("user");
-      expect(result.right.clickhouse.password).toBe("pass");
-      expect(result.right.clickhouse.database).toBe("analytics");
+      return Effect.gen(function* () {
+        const result = yield* validateSettingsFromEnvironment(env).pipe(
+          Effect.either,
+        );
+        assert(Either.isRight(result));
+        expect(result.right.clickhouse.url).toBe("https://ch.example.com");
+        expect(result.right.clickhouse.user).toBe("user");
+        expect(result.right.clickhouse.password).toBe("pass");
+        expect(result.right.clickhouse.database).toBe("analytics");
+      });
     });
 
-    it("maps TLS settings from env", async () => {
+    it.effect("maps TLS settings from env", () => {
       const env: CloudflareEnvironment = {
         ...createMockEnv(),
         HYPERDRIVE: {
@@ -237,15 +242,16 @@ describe("settings", () => {
         CLICKHOUSE_TLS_MIN_VERSION: "1.2",
       };
 
-      const result = await Effect.runPromise(
-        validateSettingsFromEnvironment(env).pipe(Effect.either),
-      );
-
-      assert(Either.isRight(result));
-      expect(result.right.clickhouse.tls.enabled).toBe(false);
-      expect(result.right.clickhouse.tls.ca).toBe("test-ca");
-      expect(result.right.clickhouse.tls.skipVerify).toBe(false);
-      expect(result.right.clickhouse.tls.hostnameVerify).toBe(true);
+      return Effect.gen(function* () {
+        const result = yield* validateSettingsFromEnvironment(env).pipe(
+          Effect.either,
+        );
+        assert(Either.isRight(result));
+        expect(result.right.clickhouse.tls.enabled).toBe(false);
+        expect(result.right.clickhouse.tls.ca).toBe("test-ca");
+        expect(result.right.clickhouse.tls.skipVerify).toBe(false);
+        expect(result.right.clickhouse.tls.hostnameVerify).toBe(true);
+      });
     });
   });
 });

--- a/cloud/workers/billingReconciliationCron.test.ts
+++ b/cloud/workers/billingReconciliationCron.test.ts
@@ -1,5 +1,6 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, vi } from "vitest";
+import { vi } from "vitest";
 
 import type { CronTriggerEnv } from "@/workers/billingReconciliationCron";
 

--- a/cloud/workers/dataRetentionCron.test.ts
+++ b/cloud/workers/dataRetentionCron.test.ts
@@ -1,5 +1,6 @@
+import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, it, expect, vi } from "vitest";
+import { vi } from "vitest";
 
 import type { CronTriggerEnv } from "@/workers/dataRetentionCron";
 

--- a/cloud/workers/realtimeSpans/client.test.ts
+++ b/cloud/workers/realtimeSpans/client.test.ts
@@ -4,8 +4,9 @@
 
 import type { DurableObjectNamespace } from "@cloudflare/workers-types";
 
+import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { describe, expect, it, vi } from "vitest";
+import { vi } from "vitest";
 
 import {
   RealtimeSpans,

--- a/cloud/workers/realtimeSpans/durableObject.test.ts
+++ b/cloud/workers/realtimeSpans/durableObject.test.ts
@@ -2,8 +2,9 @@
  * @fileoverview Tests for RealtimeSpansDurableObject realtime cache behavior.
  */
 
+import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach } from "vitest";
 
 import type { SpansBatchRequest } from "@/db/clickhouse/types";
 


### PR DESCRIPTION
Convert all 15 test cases from `await Effect.runPromise()` to
`it.effect()` from @effect/vitest. Moves assertions inside the
Effect generator and uses `Effect.flip` for error tests.

Co-authored-by: Verse <verse@mirascope.com>