### PR TITLE
ci: add vitest JSON reporter for test timing metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,14 @@ jobs:
       - name: Run `vitest` with code coverage
         run: bun run test:coverage
 
+      - name: Upload test timing data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloud-test-results
+          path: cloud/test-results.json
+          retention-days: 30
+
   dispatch-worker-lint:
     name: Dispatch Worker Lint & Type Check
     needs: changes

--- a/cloud/vitest.config.ts
+++ b/cloud/vitest.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     globalSetup: "./tests/global-setup.ts",
     pool: "forks",
     maxWorkers: 1,
+    reporters: process.env.CI ? ["default", "json"] : ["default"],
+    outputFile: process.env.CI ? { json: "test-results.json" } : undefined,
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
Adds JSON test results output in CI for tracking per-test timing.
Uploaded as GitHub Actions artifact (30 day retention).

This provides baseline timing data before layer caching and
tiered layer optimizations in subsequent PRs.