### PR TITLE
fix(cloud): add CloudLayout + Protected to org layout

### DIFF
--- a/cloud/app/routes/$orgSlug.tsx
+++ b/cloud/app/routes/$orgSlug.tsx
@@ -2,6 +2,8 @@ import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import { useEffect } from "react";
 
+import { CloudLayout } from "@/app/components/cloud-layout";
+import { Protected } from "@/app/components/protected";
 import { ClawProvider } from "@/app/contexts/claw";
 import { EnvironmentProvider } from "@/app/contexts/environment";
 import { useOrganization } from "@/app/contexts/organization";
@@ -42,13 +44,17 @@ function OrgLayout() {
   }
 
   return (
-    <ProjectProvider>
-      <EnvironmentProvider>
-        <ClawProvider>
-          <Outlet />
-        </ClawProvider>
-      </EnvironmentProvider>
-    </ProjectProvider>
+    <Protected>
+      <CloudLayout>
+        <ProjectProvider>
+          <EnvironmentProvider>
+            <ClawProvider>
+              <Outlet />
+            </ClawProvider>
+          </EnvironmentProvider>
+        </ProjectProvider>
+      </CloudLayout>
+    </Protected>
   );
 }
 


### PR DESCRIPTION
## Problem
The route restructure (42f892f5) moved from `/cloud/...` to `/$orgSlug/...` but removed `CloudLayout` from leaf pages without adding it to the `$orgSlug.tsx` layout. This caused:
- **No sidebar** on any org route (dashboard, projects, claws)
- **No auth guard** on org routes
- Footer still showing (fixed by f7e3424c but this completes the fix)

## Fix
Wrap the org layout's `<Outlet />` with `<Protected><CloudLayout>` so all org routes inherit sidebar + auth automatically.

## Screenshots
See William's screenshots in #maintenance — dashboard showing footer + marketing nav instead of cloud nav.