### PR TITLE
fix(cloud): move CloudLayout inside context providers

### DIFF
--- a/cloud/app/routes/$orgSlug.tsx
+++ b/cloud/app/routes/$orgSlug.tsx
@@ -45,15 +45,15 @@ function OrgLayout() {
 
   return (
     <Protected>
-      <CloudLayout>
-        <ProjectProvider>
-          <EnvironmentProvider>
-            <ClawProvider>
+      <ProjectProvider>
+        <EnvironmentProvider>
+          <ClawProvider>
+            <CloudLayout>
               <Outlet />
-            </ClawProvider>
-          </EnvironmentProvider>
-        </ProjectProvider>
-      </CloudLayout>
+            </CloudLayout>
+          </ClawProvider>
+        </EnvironmentProvider>
+      </ProjectProvider>
     </Protected>
   );
 }

--- a/cloud/app/routes/$orgSlug/claws/$clawSlug/chat.tsx
+++ b/cloud/app/routes/$orgSlug/claws/$clawSlug/chat.tsx
@@ -39,8 +39,6 @@ import {
   ToolOutput,
 } from "@/app/components/ai-elements/tool";
 import { ClawHeader } from "@/app/components/claw-header";
-import { CloudLayout } from "@/app/components/cloud-layout";
-import { Protected } from "@/app/components/protected";
 import { useClaw } from "@/app/contexts/claw";
 import { useMockChat } from "@/app/hooks/use-mock-chat";
 
@@ -140,62 +138,58 @@ function ClawsChatPage() {
   const { messages, status, sendMessage } = useMockChat();
 
   return (
-    <Protected>
-      <CloudLayout>
-        <div className="flex h-full flex-col overflow-hidden">
-          <div className="shrink-0 p-6 pb-0">
-            <ClawHeader />
-          </div>
-          <div className="relative min-h-0 flex-1">
-            <Conversation className="absolute inset-0">
-              <ConversationContent>
-                {messages.length === 0 ? (
-                  <ConversationEmptyState />
-                ) : (
-                  messages.map((msg, msgIndex) => (
-                    <Message from={msg.role} key={msg.id}>
-                      <MessageContent>
-                        <MessageParts
-                          chatStatus={status}
-                          isLastMessage={msgIndex === messages.length - 1}
-                          message={msg}
-                        />
-                      </MessageContent>
-                    </Message>
-                  ))
-                )}
-              </ConversationContent>
-              <ConversationScrollButton />
-            </Conversation>
-          </div>
-          <div className="shrink-0 px-6 pb-6">
-            <PromptInput
-              onSubmit={(message) => {
-                if (message.text.trim()) {
-                  sendMessage(message.text);
-                }
-              }}
-            >
-              <PromptInputTextarea
-                className="min-h-0 pr-14 font-sans"
-                disabled={!selectedClaw}
-                placeholder={
-                  selectedClaw
-                    ? "What would you like to know?"
-                    : "Select a claw to start chatting"
-                }
-              />
-              <PromptInputFooter className="absolute right-1.5 bottom-1.5 w-auto px-0 pb-0">
-                <PromptInputSubmit
-                  disabled={!selectedClaw || status !== "ready"}
-                  status={status}
-                />
-              </PromptInputFooter>
-            </PromptInput>
-          </div>
-        </div>
-      </CloudLayout>
-    </Protected>
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="shrink-0 p-6 pb-0">
+        <ClawHeader />
+      </div>
+      <div className="relative min-h-0 flex-1">
+        <Conversation className="absolute inset-0">
+          <ConversationContent>
+            {messages.length === 0 ? (
+              <ConversationEmptyState />
+            ) : (
+              messages.map((msg, msgIndex) => (
+                <Message from={msg.role} key={msg.id}>
+                  <MessageContent>
+                    <MessageParts
+                      chatStatus={status}
+                      isLastMessage={msgIndex === messages.length - 1}
+                      message={msg}
+                    />
+                  </MessageContent>
+                </Message>
+              ))
+            )}
+          </ConversationContent>
+          <ConversationScrollButton />
+        </Conversation>
+      </div>
+      <div className="shrink-0 px-6 pb-6">
+        <PromptInput
+          onSubmit={(message) => {
+            if (message.text.trim()) {
+              sendMessage(message.text);
+            }
+          }}
+        >
+          <PromptInputTextarea
+            className="min-h-0 pr-14 font-sans"
+            disabled={!selectedClaw}
+            placeholder={
+              selectedClaw
+                ? "What would you like to know?"
+                : "Select a claw to start chatting"
+            }
+          />
+          <PromptInputFooter className="absolute right-1.5 bottom-1.5 w-auto px-0 pb-0">
+            <PromptInputSubmit
+              disabled={!selectedClaw || status !== "ready"}
+              status={status}
+            />
+          </PromptInputFooter>
+        </PromptInput>
+      </div>
+    </div>
   );
 }
 

--- a/cloud/app/routes/$orgSlug/claws/$clawSlug/secrets.tsx
+++ b/cloud/app/routes/$orgSlug/claws/$clawSlug/secrets.tsx
@@ -15,8 +15,6 @@ import {
   useUpdateClawSecrets,
 } from "@/app/api/claws";
 import { ClawHeader } from "@/app/components/claw-header";
-import { CloudLayout } from "@/app/components/cloud-layout";
-import { Protected } from "@/app/components/protected";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -159,157 +157,145 @@ function ClawsSecretsPage() {
 
   if (!selectedClaw) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <ClawHeader />
-            <div className="flex items-center justify-center rounded-lg border border-dashed py-12 text-center text-muted-foreground">
-              <p>Select a claw to manage its secrets.</p>
-            </div>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <ClawHeader />
+        <div className="flex items-center justify-center rounded-lg border border-dashed py-12 text-center text-muted-foreground">
+          <p>Select a claw to manage its secrets.</p>
+        </div>
+      </div>
     );
   }
 
   if (isLoading) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <ClawHeader />
-            <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <ClawHeader />
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      </div>
     );
   }
 
   return (
-    <Protected>
-      <CloudLayout>
-        <div className="p-6">
-          <ClawHeader />
-          <Tabs
-            defaultValue="table"
-            onValueChange={(value) => {
-              if (value === "raw") {
-                setRawJson(JSON.stringify(secrets, null, 2));
-                setRawError(null);
-              }
-            }}
-          >
-            <div className="flex items-center justify-between">
-              <TabsList>
-                <TabsTrigger value="table">Table</TabsTrigger>
-                <TabsTrigger value="raw">Raw</TabsTrigger>
-              </TabsList>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  onClick={() => setRestartDialogOpen(true)}
-                  disabled={restartClaw.isPending}
-                >
-                  {restartClaw.isPending ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <RefreshCw className="mr-2 h-4 w-4" />
-                  )}
-                  Restart claw
-                </Button>
-                <Button onClick={() => setAddDialogOpen(true)}>
-                  <Plus className="mr-2 h-4 w-4" />
-                  Add variable
-                </Button>
+    <>
+      <div className="p-6">
+        <ClawHeader />
+        <Tabs
+          defaultValue="table"
+          onValueChange={(value) => {
+            if (value === "raw") {
+              setRawJson(JSON.stringify(secrets, null, 2));
+              setRawError(null);
+            }
+          }}
+        >
+          <div className="flex items-center justify-between">
+            <TabsList>
+              <TabsTrigger value="table">Table</TabsTrigger>
+              <TabsTrigger value="raw">Raw</TabsTrigger>
+            </TabsList>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setRestartDialogOpen(true)}
+                disabled={restartClaw.isPending}
+              >
+                {restartClaw.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                )}
+                Restart claw
+              </Button>
+              <Button onClick={() => setAddDialogOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Add variable
+              </Button>
+            </div>
+          </div>
+
+          <TabsContent value="table">
+            <div className="space-y-4">
+              {entries.length === 0 ? (
+                <div className="flex items-center justify-center rounded-lg border border-dashed py-12 text-center text-muted-foreground">
+                  <p>No environment variables yet. Add one to get started.</p>
+                </div>
+              ) : (
+                <div className="rounded-lg border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Value</TableHead>
+                        <TableHead className="w-[50px]" />
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {entries.map(([key]) => (
+                        <TableRow key={key}>
+                          <TableCell className="font-mono text-sm">
+                            {key}
+                          </TableCell>
+                          <TableCell className="font-mono text-sm text-muted-foreground">
+                            {"\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022"}
+                          </TableCell>
+                          <TableCell>
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button variant="ghost" size="icon">
+                                  <MoreHorizontal className="h-4 w-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                  onClick={() => {
+                                    setEditKey(key);
+                                    setEditDialogOpen(true);
+                                  }}
+                                >
+                                  <Pencil className="mr-2 h-4 w-4" />
+                                  Edit
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onClick={() => setDeleteKey(key)}
+                                  className="text-destructive focus:text-destructive"
+                                >
+                                  <Trash className="mr-2 h-4 w-4" />
+                                  Delete
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="raw">
+            <div className="space-y-4">
+              <Textarea
+                value={rawJson}
+                onChange={(e) => {
+                  setRawJson(e.target.value);
+                  setRawError(null);
+                }}
+                className="min-h-[300px] font-mono text-sm"
+              />
+              {rawError && (
+                <p className="text-sm text-destructive">{rawError}</p>
+              )}
+              <div className="flex justify-end">
+                <Button onClick={handleSaveRaw}>Save</Button>
               </div>
             </div>
-
-            <TabsContent value="table">
-              <div className="space-y-4">
-                {entries.length === 0 ? (
-                  <div className="flex items-center justify-center rounded-lg border border-dashed py-12 text-center text-muted-foreground">
-                    <p>No environment variables yet. Add one to get started.</p>
-                  </div>
-                ) : (
-                  <div className="rounded-lg border">
-                    <Table>
-                      <TableHeader>
-                        <TableRow>
-                          <TableHead>Name</TableHead>
-                          <TableHead>Value</TableHead>
-                          <TableHead className="w-[50px]" />
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {entries.map(([key]) => (
-                          <TableRow key={key}>
-                            <TableCell className="font-mono text-sm">
-                              {key}
-                            </TableCell>
-                            <TableCell className="font-mono text-sm text-muted-foreground">
-                              {
-                                "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022"
-                              }
-                            </TableCell>
-                            <TableCell>
-                              <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                  <Button variant="ghost" size="icon">
-                                    <MoreHorizontal className="h-4 w-4" />
-                                  </Button>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent align="end">
-                                  <DropdownMenuItem
-                                    onClick={() => {
-                                      setEditKey(key);
-                                      setEditDialogOpen(true);
-                                    }}
-                                  >
-                                    <Pencil className="mr-2 h-4 w-4" />
-                                    Edit
-                                  </DropdownMenuItem>
-                                  <DropdownMenuItem
-                                    onClick={() => setDeleteKey(key)}
-                                    className="text-destructive focus:text-destructive"
-                                  >
-                                    <Trash className="mr-2 h-4 w-4" />
-                                    Delete
-                                  </DropdownMenuItem>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </div>
-                )}
-              </div>
-            </TabsContent>
-
-            <TabsContent value="raw">
-              <div className="space-y-4">
-                <Textarea
-                  value={rawJson}
-                  onChange={(e) => {
-                    setRawJson(e.target.value);
-                    setRawError(null);
-                  }}
-                  className="min-h-[300px] font-mono text-sm"
-                />
-                {rawError && (
-                  <p className="text-sm text-destructive">{rawError}</p>
-                )}
-                <div className="flex justify-end">
-                  <Button onClick={handleSaveRaw}>Save</Button>
-                </div>
-              </div>
-            </TabsContent>
-          </Tabs>
-        </div>
-      </CloudLayout>
+          </TabsContent>
+        </Tabs>
+      </div>
 
       <AddVariableDialog
         open={addDialogOpen}
@@ -378,7 +364,7 @@ function ClawsSecretsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Protected>
+    </>
   );
 }
 

--- a/cloud/app/routes/$orgSlug/index.tsx
+++ b/cloud/app/routes/$orgSlug/index.tsx
@@ -11,11 +11,9 @@ import {
   UsageMeter,
   statusBarColor,
 } from "@/app/components/claw-card";
-import { CloudLayout } from "@/app/components/cloud-layout";
 import { CreateClawModal } from "@/app/components/create-claw-modal";
 import { CreateProjectModal } from "@/app/components/create-project-modal";
 import { ClawIcon } from "@/app/components/icons/claw-icon";
-import { Protected } from "@/app/components/protected";
 import { Button } from "@/app/components/ui/button";
 import {
   Card,
@@ -64,137 +62,126 @@ function CloudIndexPage() {
 
   if (orgsLoading) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="flex h-64 items-center justify-center">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="flex h-64 items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
     );
   }
 
   return (
-    <Protected>
-      <CloudLayout>
-        <div className="p-6 space-y-6">
-          <div>
-            <h1 className="text-2xl font-semibold">
-              {selectedOrganization?.name ?? "Dashboard"}
-            </h1>
-            <p className="text-muted-foreground">
-              Manage your claws and projects
-            </p>
-          </div>
+    <>
+      <div className="p-6 space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold">
+            {selectedOrganization?.name ?? "Dashboard"}
+          </h1>
+          <p className="text-muted-foreground">
+            Manage your claws and projects
+          </p>
+        </div>
 
-          <div className="grid gap-x-6 gap-y-0 grid-cols-1 md:grid-cols-2 md:grid-rows-[auto_auto_1fr]">
-            {/* Claws Section */}
-            <div className="row-span-1 md:row-span-3 grid grid-rows-subgrid items-start gap-y-0">
-              <div className="flex items-center gap-3 mb-2">
-                <ClawIcon className="h-5 w-5 text-muted-foreground" />
-                <h2 className="text-lg font-semibold">Claws</h2>
-                <Button size="sm" onClick={() => setShowCreateClaw(true)}>
-                  <Plus className="h-4 w-4" />
-                </Button>
-              </div>
-              <p className="text-sm text-muted-foreground mb-4">
-                Deploy and manage AI-powered claws for your organization
-              </p>
-              {clawsLoading ? (
-                <div className="flex h-24 items-center justify-center">
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-                </div>
-              ) : claws.length === 0 ? (
-                <Card className="border-dashed bg-muted/30">
-                  <CardHeader className="p-4 flex items-center justify-center">
-                    <p className="text-sm text-muted-foreground">
-                      No claws yet
-                    </p>
-                  </CardHeader>
-                </Card>
-              ) : (
-                <div className="space-y-3">
-                  {weeklyUsage > 0 && (
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs text-muted-foreground shrink-0">
-                        Weekly
-                      </span>
-                      <UsageMeter
-                        usage={weeklyUsage}
-                        limit={limits.includedCreditsCenticents}
-                        barColor={statusBarColor[claws[0].status]}
-                        className="flex-1"
-                      />
-                    </div>
-                  )}
-                  <div className="grid gap-3 grid-cols-1 lg:grid-cols-2">
-                    {claws.slice(0, 3).map((claw) => (
-                      <ClawCard
-                        key={claw.id}
-                        claw={claw}
-                        onClick={() => handleClawClick(claw)}
-                        burstLimitCenticents={limits.burstCreditsCenticents}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
+        <div className="grid gap-x-6 gap-y-0 grid-cols-1 md:grid-cols-2 md:grid-rows-[auto_auto_1fr]">
+          {/* Claws Section */}
+          <div className="row-span-1 md:row-span-3 grid grid-rows-subgrid items-start gap-y-0">
+            <div className="flex items-center gap-3 mb-2">
+              <ClawIcon className="h-5 w-5 text-muted-foreground" />
+              <h2 className="text-lg font-semibold">Claws</h2>
+              <Button size="sm" onClick={() => setShowCreateClaw(true)}>
+                <Plus className="h-4 w-4" />
+              </Button>
             </div>
-
-            {/* Projects Section */}
-            <div className="row-span-1 md:row-span-3 grid grid-rows-subgrid items-start gap-y-0 mt-6 md:mt-0">
-              <div className="flex items-center gap-3 mb-2">
-                <FolderKanban className="h-5 w-5 text-muted-foreground" />
-                <h2 className="text-lg font-semibold">Projects</h2>
-                <Button size="sm" onClick={() => setShowCreateProject(true)}>
-                  <Plus className="h-4 w-4" />
-                </Button>
+            <p className="text-sm text-muted-foreground mb-4">
+              Deploy and manage AI-powered claws for your organization
+            </p>
+            {clawsLoading ? (
+              <div className="flex h-24 items-center justify-center">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
               </div>
-              <p className="text-sm text-muted-foreground mb-4">
-                Monitor traces, functions, and analytics for your LLM
-                applications
-              </p>
-              {projectsLoading ? (
-                <div className="flex h-24 items-center justify-center">
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-                </div>
-              ) : projects.length === 0 ? (
-                <div className="flex h-24 items-center justify-center rounded-lg border border-dashed bg-muted/30">
-                  <p className="text-sm text-muted-foreground">
-                    No projects yet
-                  </p>
-                </div>
-              ) : (
+            ) : claws.length === 0 ? (
+              <Card className="border-dashed bg-muted/30">
+                <CardHeader className="p-4 flex items-center justify-center">
+                  <p className="text-sm text-muted-foreground">No claws yet</p>
+                </CardHeader>
+              </Card>
+            ) : (
+              <div className="space-y-3">
+                {weeklyUsage > 0 && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      Weekly
+                    </span>
+                    <UsageMeter
+                      usage={weeklyUsage}
+                      limit={limits.includedCreditsCenticents}
+                      barColor={statusBarColor[claws[0].status]}
+                      className="flex-1"
+                    />
+                  </div>
+                )}
                 <div className="grid gap-3 grid-cols-1 lg:grid-cols-2">
-                  {projects.map((project) => (
-                    <Card
-                      key={project.id}
-                      className="cursor-pointer transition-colors hover:bg-muted/50 min-h-[5.5rem]"
-                      onClick={() => handleProjectClick(project)}
-                    >
-                      <CardHeader className="p-4">
-                        <CardTitle className="text-base">
-                          {project.name}
-                        </CardTitle>
-                        <CardDescription className="text-sm">
-                          {project.slug}
-                        </CardDescription>
-                      </CardHeader>
-                    </Card>
+                  {claws.slice(0, 3).map((claw) => (
+                    <ClawCard
+                      key={claw.id}
+                      claw={claw}
+                      onClick={() => handleClawClick(claw)}
+                      burstLimitCenticents={limits.burstCreditsCenticents}
+                    />
                   ))}
                 </div>
-              )}
+              </div>
+            )}
+          </div>
+
+          {/* Projects Section */}
+          <div className="row-span-1 md:row-span-3 grid grid-rows-subgrid items-start gap-y-0 mt-6 md:mt-0">
+            <div className="flex items-center gap-3 mb-2">
+              <FolderKanban className="h-5 w-5 text-muted-foreground" />
+              <h2 className="text-lg font-semibold">Projects</h2>
+              <Button size="sm" onClick={() => setShowCreateProject(true)}>
+                <Plus className="h-4 w-4" />
+              </Button>
             </div>
+            <p className="text-sm text-muted-foreground mb-4">
+              Monitor traces, functions, and analytics for your LLM applications
+            </p>
+            {projectsLoading ? (
+              <div className="flex h-24 items-center justify-center">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : projects.length === 0 ? (
+              <div className="flex h-24 items-center justify-center rounded-lg border border-dashed bg-muted/30">
+                <p className="text-sm text-muted-foreground">No projects yet</p>
+              </div>
+            ) : (
+              <div className="grid gap-3 grid-cols-1 lg:grid-cols-2">
+                {projects.map((project) => (
+                  <Card
+                    key={project.id}
+                    className="cursor-pointer transition-colors hover:bg-muted/50 min-h-[5.5rem]"
+                    onClick={() => handleProjectClick(project)}
+                  >
+                    <CardHeader className="p-4">
+                      <CardTitle className="text-base">
+                        {project.name}
+                      </CardTitle>
+                      <CardDescription className="text-sm">
+                        {project.slug}
+                      </CardDescription>
+                    </CardHeader>
+                  </Card>
+                ))}
+              </div>
+            )}
           </div>
         </div>
-      </CloudLayout>
+      </div>
 
       <CreateClawModal open={showCreateClaw} onOpenChange={setShowCreateClaw} />
       <CreateProjectModal
         open={showCreateProject}
         onOpenChange={setShowCreateProject}
       />
-    </Protected>
+    </>
   );
 }
 

--- a/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/annotation-queue.tsx
+++ b/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/annotation-queue.tsx
@@ -1,8 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { CodeBlock } from "@/app/components/blocks/code-block/code-block";
-import { CloudLayout } from "@/app/components/cloud-layout";
-import { Protected } from "@/app/components/protected";
 
 const CODE_EXAMPLE = `import marimo as mo
 from datetime import datetime, timedelta
@@ -44,36 +42,32 @@ client.annotations.create(
 
 function AnnotationQueuePage() {
   return (
-    <Protected>
-      <CloudLayout>
-        <div className="p-6 max-w-4xl">
-          <h1 className="text-2xl font-semibold mb-2">Annotation Queue</h1>
-          <div className="bg-muted/50 border rounded-lg px-4 pt-4 pb-2 mb-6">
-            <p className="text-muted-foreground mb-4">
-              While we build the annotation queue UI, you can annotate traces
-              programmatically using our Python SDK. We recommend using{" "}
-              <a
-                href="https://marimo.io"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                Marimo notebooks
-              </a>{" "}
-              for interactive annotation and evaluation workflows.
-            </p>
+    <div className="p-6 max-w-4xl">
+      <h1 className="text-2xl font-semibold mb-2">Annotation Queue</h1>
+      <div className="bg-muted/50 border rounded-lg px-4 pt-4 pb-2 mb-6">
+        <p className="text-muted-foreground mb-4">
+          While we build the annotation queue UI, you can annotate traces
+          programmatically using our Python SDK. We recommend using{" "}
+          <a
+            href="https://marimo.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            Marimo notebooks
+          </a>{" "}
+          for interactive annotation and evaluation workflows.
+        </p>
 
-            <h3 className="text-base font-medium mb-2">
-              1. Fetch and display traces for a function
-            </h3>
-            <CodeBlock code={CODE_EXAMPLE} language="python" className="mb-6" />
+        <h3 className="text-base font-medium mb-2">
+          1. Fetch and display traces for a function
+        </h3>
+        <CodeBlock code={CODE_EXAMPLE} language="python" className="mb-6" />
 
-            <h3 className="text-base font-medium mb-2">2. Annotate a trace</h3>
-            <CodeBlock code={ANNOTATION_EXAMPLE} language="python" />
-          </div>
-        </div>
-      </CloudLayout>
-    </Protected>
+        <h3 className="text-base font-medium mb-2">2. Annotate a trace</h3>
+        <CodeBlock code={ANNOTATION_EXAMPLE} language="python" />
+      </div>
+    </div>
   );
 }
 

--- a/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/functions.$functionName.tsx
+++ b/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/functions.$functionName.tsx
@@ -18,8 +18,6 @@ import { useFunctionsList } from "@/app/api/functions";
 import { useTracesSearch, useTraceDetail } from "@/app/api/traces";
 import { CodeBlock } from "@/app/components/blocks/code-block/code-block";
 import { DiffTool } from "@/app/components/blocks/diff-tool";
-import { CloudLayout } from "@/app/components/cloud-layout";
-import { Protected } from "@/app/components/protected";
 import { SpanDetailPanel } from "@/app/components/traces/span-detail-panel";
 import { TracesTable } from "@/app/components/traces/traces-table";
 import { Badge } from "@/app/components/ui/badge";
@@ -224,293 +222,268 @@ function FunctionDetailPage() {
 
   if (!selectedEnvironment) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <div className="flex h-64 items-center justify-center">
-              <p className="text-muted-foreground text-lg">
-                Select an environment to view function details.
-              </p>
-            </div>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <div className="flex h-64 items-center justify-center">
+          <p className="text-muted-foreground text-lg">
+            Select an environment to view function details.
+          </p>
+        </div>
+      </div>
     );
   }
 
   if (isLoadingFunctions) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <div className="flex h-64 items-center justify-center">
-              <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
-            </div>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <div className="flex h-64 items-center justify-center">
+          <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+        </div>
+      </div>
     );
   }
 
   if (!fn) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <div className="flex h-64 items-center justify-center">
-              <div className="text-center">
-                <p className="text-muted-foreground mb-2 text-lg">
-                  Function not found.
-                </p>
-                <Link
-                  to="/$orgSlug/projects/$projectSlug/$envSlug/functions"
-                  params={{ orgSlug, projectSlug, envSlug }}
-                >
-                  <Button variant="outline" size="sm">
-                    <ArrowLeft className="mr-2 h-4 w-4" />
-                    Back to Functions
-                  </Button>
-                </Link>
-              </div>
-            </div>
+      <div className="p-6">
+        <div className="flex h-64 items-center justify-center">
+          <div className="text-center">
+            <p className="text-muted-foreground mb-2 text-lg">
+              Function not found.
+            </p>
+            <Link
+              to="/$orgSlug/projects/$projectSlug/$envSlug/functions"
+              params={{ orgSlug, projectSlug, envSlug }}
+            >
+              <Button variant="outline" size="sm">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to Functions
+              </Button>
+            </Link>
           </div>
-        </CloudLayout>
-      </Protected>
+        </div>
+      </div>
     );
   }
 
   return (
-    <Protected>
-      <CloudLayout>
-        <div className="flex h-full flex-col overflow-hidden">
-          {/* Header */}
-          <div className="shrink-0 p-6 pb-4">
-            <div className="mb-2 flex items-center gap-2">
-              <Link
-                to="/$orgSlug/projects/$projectSlug/$envSlug/functions"
-                params={{ orgSlug, projectSlug, envSlug }}
-              >
-                <Button variant="ghost" size="sm">
-                  <ArrowLeft className="mr-1 h-4 w-4" />
-                  Functions
-                </Button>
-              </Link>
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <h1 className="font-mono text-2xl font-semibold">{fn.name}</h1>
-                {isCompareMode && compareVersion ? (
-                  <>
-                    {/* Compare mode: [v1.1 ▼] → [v1.2 ▼] */}
-                    <Select
-                      value={compareVersion.id}
-                      onValueChange={handleCompareVersionChange}
-                    >
-                      <SelectTrigger className="h-auto w-auto gap-1 rounded-md border-transparent bg-muted px-2.5 py-0.5 text-xs font-semibold shadow hover:bg-muted/80">
-                        <SelectValue>v{compareVersion.version}</SelectValue>
-                      </SelectTrigger>
-                      <SelectContent>
-                        {allVersions
-                          .filter((v) => v.id !== fn.id)
-                          .map((version) => (
-                            <SelectItem key={version.id} value={version.id}>
-                              <span className="flex items-center gap-2">
-                                v{version.version}
-                                {version.id === allVersions[0].id && (
-                                  <span className="text-xs text-muted-foreground">
-                                    (latest)
-                                  </span>
-                                )}
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header */}
+      <div className="shrink-0 p-6 pb-4">
+        <div className="mb-2 flex items-center gap-2">
+          <Link
+            to="/$orgSlug/projects/$projectSlug/$envSlug/functions"
+            params={{ orgSlug, projectSlug, envSlug }}
+          >
+            <Button variant="ghost" size="sm">
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              Functions
+            </Button>
+          </Link>
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <h1 className="font-mono text-2xl font-semibold">{fn.name}</h1>
+            {isCompareMode && compareVersion ? (
+              <>
+                {/* Compare mode: [v1.1 ▼] → [v1.2 ▼] */}
+                <Select
+                  value={compareVersion.id}
+                  onValueChange={handleCompareVersionChange}
+                >
+                  <SelectTrigger className="h-auto w-auto gap-1 rounded-md border-transparent bg-muted px-2.5 py-0.5 text-xs font-semibold shadow hover:bg-muted/80">
+                    <SelectValue>v{compareVersion.version}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {allVersions
+                      .filter((v) => v.id !== fn.id)
+                      .map((version) => (
+                        <SelectItem key={version.id} value={version.id}>
+                          <span className="flex items-center gap-2">
+                            v{version.version}
+                            {version.id === allVersions[0].id && (
+                              <span className="text-xs text-muted-foreground">
+                                (latest)
                               </span>
-                            </SelectItem>
-                          ))}
-                      </SelectContent>
-                    </Select>
-                    <ArrowRight className="text-muted-foreground h-4 w-4" />
-                    <Select value={fn.id} onValueChange={handleVersionChange}>
-                      <SelectTrigger className="h-auto w-auto gap-1 rounded-md border-transparent bg-primary px-2.5 py-0.5 text-xs font-semibold text-primary-foreground shadow hover:bg-primary/80">
-                        <SelectValue>v{fn.version}</SelectValue>
-                      </SelectTrigger>
-                      <SelectContent>
-                        {allVersions
-                          .filter((v) => v.id !== compareVersionId)
-                          .map((version) => (
-                            <SelectItem key={version.id} value={version.id}>
-                              <span className="flex items-center gap-2">
-                                v{version.version}
-                                {version.id === allVersions[0].id && (
-                                  <span className="text-xs text-muted-foreground">
-                                    (latest)
-                                  </span>
-                                )}
+                            )}
+                          </span>
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+                <ArrowRight className="text-muted-foreground h-4 w-4" />
+                <Select value={fn.id} onValueChange={handleVersionChange}>
+                  <SelectTrigger className="h-auto w-auto gap-1 rounded-md border-transparent bg-primary px-2.5 py-0.5 text-xs font-semibold text-primary-foreground shadow hover:bg-primary/80">
+                    <SelectValue>v{fn.version}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {allVersions
+                      .filter((v) => v.id !== compareVersionId)
+                      .map((version) => (
+                        <SelectItem key={version.id} value={version.id}>
+                          <span className="flex items-center gap-2">
+                            v{version.version}
+                            {version.id === allVersions[0].id && (
+                              <span className="text-xs text-muted-foreground">
+                                (latest)
                               </span>
-                            </SelectItem>
-                          ))}
-                      </SelectContent>
-                    </Select>
-                  </>
+                            )}
+                          </span>
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+              </>
+            ) : (
+              <>
+                {/* Normal mode: [v1.2 ▼] */}
+                {allVersions.length > 1 ? (
+                  <Select value={fn.id} onValueChange={handleVersionChange}>
+                    <SelectTrigger className="h-auto w-auto gap-1 rounded-md border-transparent bg-primary px-2.5 py-0.5 text-xs font-semibold text-primary-foreground shadow hover:bg-primary/80">
+                      <SelectValue>v{fn.version}</SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {allVersions.map((version) => (
+                        <SelectItem key={version.id} value={version.id}>
+                          <span className="flex items-center gap-2">
+                            v{version.version}
+                            {version.id === allVersions[0].id && (
+                              <span className="text-xs text-muted-foreground">
+                                (latest)
+                              </span>
+                            )}
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 ) : (
-                  <>
-                    {/* Normal mode: [v1.2 ▼] */}
-                    {allVersions.length > 1 ? (
-                      <Select value={fn.id} onValueChange={handleVersionChange}>
-                        <SelectTrigger className="h-auto w-auto gap-1 rounded-md border-transparent bg-primary px-2.5 py-0.5 text-xs font-semibold text-primary-foreground shadow hover:bg-primary/80">
-                          <SelectValue>v{fn.version}</SelectValue>
-                        </SelectTrigger>
-                        <SelectContent>
-                          {allVersions.map((version) => (
-                            <SelectItem key={version.id} value={version.id}>
-                              <span className="flex items-center gap-2">
-                                v{version.version}
-                                {version.id === allVersions[0].id && (
-                                  <span className="text-xs text-muted-foreground">
-                                    (latest)
-                                  </span>
-                                )}
-                              </span>
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Badge variant="default">v{fn.version}</Badge>
-                    )}
-                  </>
+                  <Badge variant="default">v{fn.version}</Badge>
+                )}
+              </>
+            )}
+          </div>
+          {/* Right side: Compare or Exit Compare button */}
+          {isCompareMode ? (
+            <Button variant="outline" size="sm" onClick={exitCompareMode}>
+              <X className="mr-1 h-4 w-4" />
+              Exit Compare
+            </Button>
+          ) : (
+            allVersions.length > 1 &&
+            activeTab === "code" && (
+              <Button variant="outline" size="sm" onClick={enterCompareMode}>
+                <GitCompare className="mr-1 h-4 w-4" />
+                Compare
+              </Button>
+            )
+          )}
+        </div>
+        {fn.description && (
+          <p className="text-muted-foreground mt-1">{fn.description}</p>
+        )}
+      </div>
+
+      {/* Content area with tabs overlay */}
+      <div className="relative min-h-0 flex-1">
+        {/* Tab buttons - absolutely positioned */}
+        <Tabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          className="absolute left-6 top-0 z-10"
+        >
+          <TabsList>
+            <TabsTrigger value="code">Code</TabsTrigger>
+            <TabsTrigger value="traces" disabled={isCompareMode}>
+              Traces
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        {/* Code content */}
+        {activeTab === "code" && (
+          <div className="h-full overflow-hidden">
+            <div className="flex h-full gap-4 px-6 pt-12 pb-6">
+              <div className="min-w-0 flex-1 overflow-auto">
+                {isCompareMode && compareVersion ? (
+                  <DiffTool
+                    baseCode={compareVersion.code}
+                    newCode={fn.code}
+                    language={(fn.language ?? "python") as SupportedLanguages}
+                    baseName={`v${compareVersion.version}`}
+                    newName={`v${fn.version}`}
+                  />
+                ) : (
+                  <CodeBlock
+                    code={fn.code}
+                    language={fn.language ?? "python"}
+                    showLineNumbers={true}
+                    className="app-bg-code"
+                  />
                 )}
               </div>
-              {/* Right side: Compare or Exit Compare button */}
-              {isCompareMode ? (
-                <Button variant="outline" size="sm" onClick={exitCompareMode}>
-                  <X className="mr-1 h-4 w-4" />
-                  Exit Compare
-                </Button>
-              ) : (
-                allVersions.length > 1 &&
-                activeTab === "code" && (
+            </div>
+          </div>
+        )}
+
+        {/* Traces content */}
+        {activeTab === "traces" && (
+          <ResizablePanelGroup direction="horizontal" className="h-full">
+            <ResizablePanel defaultSize={selectedSpan ? 70 : 100} minSize={30}>
+              <div className="h-full overflow-auto px-6 pb-6">
+                <div className="mb-4 flex justify-end">
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={enterCompareMode}
+                    onClick={() => setRefreshKey((k) => k + 1)}
+                    disabled={isFetchingTraces}
                   >
-                    <GitCompare className="mr-1 h-4 w-4" />
-                    Compare
+                    <RefreshCw
+                      className={`mr-2 h-4 w-4 ${isFetchingTraces ? "animate-spin" : ""}`}
+                    />
+                    Refresh
                   </Button>
-                )
-              )}
-            </div>
-            {fn.description && (
-              <p className="text-muted-foreground mt-1">{fn.description}</p>
-            )}
-          </div>
-
-          {/* Content area with tabs overlay */}
-          <div className="relative min-h-0 flex-1">
-            {/* Tab buttons - absolutely positioned */}
-            <Tabs
-              value={activeTab}
-              onValueChange={setActiveTab}
-              className="absolute left-6 top-0 z-10"
-            >
-              <TabsList>
-                <TabsTrigger value="code">Code</TabsTrigger>
-                <TabsTrigger value="traces" disabled={isCompareMode}>
-                  Traces
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-
-            {/* Code content */}
-            {activeTab === "code" && (
-              <div className="h-full overflow-hidden">
-                <div className="flex h-full gap-4 px-6 pt-12 pb-6">
-                  <div className="min-w-0 flex-1 overflow-auto">
-                    {isCompareMode && compareVersion ? (
-                      <DiffTool
-                        baseCode={compareVersion.code}
-                        newCode={fn.code}
-                        language={
-                          (fn.language ?? "python") as SupportedLanguages
-                        }
-                        baseName={`v${compareVersion.version}`}
-                        newName={`v${fn.version}`}
-                      />
-                    ) : (
-                      <CodeBlock
-                        code={fn.code}
-                        language={fn.language ?? "python"}
-                        showLineNumbers={true}
-                        className="app-bg-code"
-                      />
-                    )}
-                  </div>
                 </div>
+                <TracesTable
+                  spans={tracesData?.spans ?? []}
+                  isLoading={isLoadingTraces}
+                  onTraceSelect={setSelectedTraceId}
+                  traceDetail={traceDetail ?? null}
+                  isLoadingDetail={isLoadingDetail}
+                  onSpanClick={(span) => {
+                    analytics.trackEvent("span_selected", {
+                      span_id: span?.spanId,
+                      trace_id: selectedTraceId,
+                      environment_id: selectedEnvironment?.id,
+                    });
+                    setSelectedSpan(span);
+                  }}
+                  selectedSpanId={selectedSpan?.spanId}
+                />
               </div>
-            )}
+            </ResizablePanel>
 
-            {/* Traces content */}
-            {activeTab === "traces" && (
-              <ResizablePanelGroup direction="horizontal" className="h-full">
-                <ResizablePanel
-                  defaultSize={selectedSpan ? 70 : 100}
-                  minSize={30}
-                >
-                  <div className="h-full overflow-auto px-6 pb-6">
-                    <div className="mb-4 flex justify-end">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setRefreshKey((k) => k + 1)}
-                        disabled={isFetchingTraces}
-                      >
-                        <RefreshCw
-                          className={`mr-2 h-4 w-4 ${isFetchingTraces ? "animate-spin" : ""}`}
-                        />
-                        Refresh
-                      </Button>
-                    </div>
-                    <TracesTable
-                      spans={tracesData?.spans ?? []}
-                      isLoading={isLoadingTraces}
-                      onTraceSelect={setSelectedTraceId}
-                      traceDetail={traceDetail ?? null}
-                      isLoadingDetail={isLoadingDetail}
-                      onSpanClick={(span) => {
-                        analytics.trackEvent("span_selected", {
-                          span_id: span?.spanId,
-                          trace_id: selectedTraceId,
-                          environment_id: selectedEnvironment?.id,
-                        });
-                        setSelectedSpan(span);
-                      }}
-                      selectedSpanId={selectedSpan?.spanId}
+            {selectedSpan && (
+              <>
+                <ResizableHandle className="cursor-col-resize">
+                  <div className="z-10 flex h-8 w-4 translate-x-0.5 items-center justify-center rounded-sm border bg-background">
+                    <DragHandleDots2Icon className="h-4 w-4" />
+                  </div>
+                </ResizableHandle>
+                <ResizablePanel defaultSize={30} minSize={20} maxSize={50}>
+                  <div className="h-full overflow-hidden pb-6 pr-6">
+                    <SpanDetailPanel
+                      span={selectedSpan}
+                      functionData={fn}
+                      onClose={() => setSelectedSpan(null)}
                     />
                   </div>
                 </ResizablePanel>
-
-                {selectedSpan && (
-                  <>
-                    <ResizableHandle className="cursor-col-resize">
-                      <div className="z-10 flex h-8 w-4 translate-x-0.5 items-center justify-center rounded-sm border bg-background">
-                        <DragHandleDots2Icon className="h-4 w-4" />
-                      </div>
-                    </ResizableHandle>
-                    <ResizablePanel defaultSize={30} minSize={20} maxSize={50}>
-                      <div className="h-full overflow-hidden pb-6 pr-6">
-                        <SpanDetailPanel
-                          span={selectedSpan}
-                          functionData={fn}
-                          onClose={() => setSelectedSpan(null)}
-                        />
-                      </div>
-                    </ResizablePanel>
-                  </>
-                )}
-              </ResizablePanelGroup>
+              </>
             )}
-          </div>
-        </div>
-      </CloudLayout>
-    </Protected>
+          </ResizablePanelGroup>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/functions.index.tsx
+++ b/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/functions.index.tsx
@@ -5,9 +5,7 @@ import { useMemo } from "react";
 import type { FunctionResponse } from "@/api/functions.schemas";
 
 import { useFunctionsList } from "@/app/api/functions";
-import { CloudLayout } from "@/app/components/cloud-layout";
 import { FunctionCard } from "@/app/components/function-card";
-import { Protected } from "@/app/components/protected";
 import { Button } from "@/app/components/ui/button";
 import { useEnvironment } from "@/app/contexts/environment";
 import { useOrganization } from "@/app/contexts/organization";
@@ -61,69 +59,60 @@ function FunctionsPage() {
 
   if (!selectedEnvironment) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <div className="flex h-64 items-center justify-center">
-              <p className="text-muted-foreground text-lg">
-                Select an environment to view functions.
-              </p>
-            </div>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <div className="flex h-64 items-center justify-center">
+          <p className="text-muted-foreground text-lg">
+            Select an environment to view functions.
+          </p>
+        </div>
+      </div>
     );
   }
 
   return (
-    <Protected>
-      <CloudLayout>
-        <div className="p-6">
-          <div className="mb-6 flex items-center justify-between">
-            <h1 className="text-2xl font-semibold">Functions</h1>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => void refetch()}
-              disabled={isFetching}
-            >
-              <RefreshCw
-                className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
-              />
-              Refresh
-            </Button>
-          </div>
+    <div className="p-6">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Functions</h1>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => void refetch()}
+          disabled={isFetching}
+        >
+          <RefreshCw
+            className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+          />
+          Refresh
+        </Button>
+      </div>
 
-          {isLoading && (
-            <div className="flex h-64 items-center justify-center">
-              <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
-            </div>
-          )}
-
-          {!isLoading && uniqueFunctions.length === 0 && (
-            <div className="flex h-64 items-center justify-center">
-              <div className="text-center">
-                <p className="text-muted-foreground mb-2 text-lg">
-                  No functions found in this environment.
-                </p>
-                <p className="text-muted-foreground text-sm">
-                  Functions will appear here when they are registered via the
-                  SDK.
-                </p>
-              </div>
-            </div>
-          )}
-
-          {!isLoading && uniqueFunctions.length > 0 && (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {uniqueFunctions.map((fn) => (
-                <FunctionCard key={fn.id} fn={fn} />
-              ))}
-            </div>
-          )}
+      {isLoading && (
+        <div className="flex h-64 items-center justify-center">
+          <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
         </div>
-      </CloudLayout>
-    </Protected>
+      )}
+
+      {!isLoading && uniqueFunctions.length === 0 && (
+        <div className="flex h-64 items-center justify-center">
+          <div className="text-center">
+            <p className="text-muted-foreground mb-2 text-lg">
+              No functions found in this environment.
+            </p>
+            <p className="text-muted-foreground text-sm">
+              Functions will appear here when they are registered via the SDK.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {!isLoading && uniqueFunctions.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {uniqueFunctions.map((fn) => (
+            <FunctionCard key={fn.id} fn={fn} />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/index.tsx
+++ b/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/index.tsx
@@ -2,7 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useState, useMemo } from "react";
 
 import { useEnvironmentAnalytics } from "@/app/api/environments";
-import { CloudLayout } from "@/app/components/cloud-layout";
 import { StatCard } from "@/app/components/dashboard/stat-card";
 import {
   TimePeriodSelector,
@@ -10,7 +9,6 @@ import {
   type TimePeriod,
 } from "@/app/components/dashboard/time-period-selector";
 import { TopItemsList } from "@/app/components/dashboard/top-items-list";
-import { Protected } from "@/app/components/protected";
 import { useEnvironment } from "@/app/contexts/environment";
 import { useOrganization } from "@/app/contexts/organization";
 import { useProject } from "@/app/contexts/project";
@@ -40,95 +38,91 @@ function CloudDashboardPage() {
     ms !== null ? `${ms.toFixed(0)}ms` : "N/A";
 
   return (
-    <Protected>
-      <CloudLayout>
-        <div className="p-6 space-y-6">
-          {/* Header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold">Dashboard</h1>
-              <p className="text-muted-foreground">
-                Analytics for {selectedEnvironment?.name ?? "your environment"}
-              </p>
-            </div>
-            <TimePeriodSelector value={timePeriod} onChange={setTimePeriod} />
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Dashboard</h1>
+          <p className="text-muted-foreground">
+            Analytics for {selectedEnvironment?.name ?? "your environment"}
+          </p>
+        </div>
+        <TimePeriodSelector value={timePeriod} onChange={setTimePeriod} />
+      </div>
+
+      {/* Environment not selected state */}
+      {!selectedEnvironment ? (
+        <div className="flex items-center justify-center h-64">
+          <p className="text-muted-foreground">
+            Please select an organization, project, and environment to view
+            analytics.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Stat Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <StatCard
+              title="Total Spans"
+              value={analytics?.totalSpans.toLocaleString() ?? "0"}
+              isLoading={isLoading}
+            />
+            <StatCard
+              title="Total Cost"
+              value={formatCost(analytics?.totalCostUsd ?? 0)}
+              isLoading={isLoading}
+            />
+            <StatCard
+              title="Error Rate"
+              value={formatErrorRate(analytics?.errorRate ?? 0)}
+              isLoading={isLoading}
+            />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <StatCard
+              title="Input Tokens"
+              value={(analytics?.totalInputTokens ?? 0).toLocaleString()}
+              isLoading={isLoading}
+            />
+            <StatCard
+              title="Output Tokens"
+              value={(analytics?.totalOutputTokens ?? 0).toLocaleString()}
+              isLoading={isLoading}
+            />
+            <StatCard
+              title="Avg Duration"
+              value={formatDuration(analytics?.avgDurationMs ?? null)}
+              subtitle={
+                analytics?.p95DurationMs != null
+                  ? `p95: ${formatDuration(analytics.p95DurationMs)}`
+                  : undefined
+              }
+              isLoading={isLoading}
+            />
           </div>
 
-          {/* Environment not selected state */}
-          {!selectedEnvironment ? (
-            <div className="flex items-center justify-center h-64">
-              <p className="text-muted-foreground">
-                Please select an organization, project, and environment to view
-                analytics.
-              </p>
-            </div>
-          ) : (
-            <>
-              {/* Stat Cards */}
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                <StatCard
-                  title="Total Spans"
-                  value={analytics?.totalSpans.toLocaleString() ?? "0"}
-                  isLoading={isLoading}
-                />
-                <StatCard
-                  title="Total Cost"
-                  value={formatCost(analytics?.totalCostUsd ?? 0)}
-                  isLoading={isLoading}
-                />
-                <StatCard
-                  title="Error Rate"
-                  value={formatErrorRate(analytics?.errorRate ?? 0)}
-                  isLoading={isLoading}
-                />
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                <StatCard
-                  title="Input Tokens"
-                  value={(analytics?.totalInputTokens ?? 0).toLocaleString()}
-                  isLoading={isLoading}
-                />
-                <StatCard
-                  title="Output Tokens"
-                  value={(analytics?.totalOutputTokens ?? 0).toLocaleString()}
-                  isLoading={isLoading}
-                />
-                <StatCard
-                  title="Avg Duration"
-                  value={formatDuration(analytics?.avgDurationMs ?? null)}
-                  subtitle={
-                    analytics?.p95DurationMs != null
-                      ? `p95: ${formatDuration(analytics.p95DurationMs)}`
-                      : undefined
-                  }
-                  isLoading={isLoading}
-                />
-              </div>
-
-              {/* Top Items */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <TopItemsList
-                  title="Top 5 Models"
-                  items={(analytics?.topModels ?? []).map((m) => ({
-                    name: m.model,
-                    count: m.count,
-                  }))}
-                  isLoading={isLoading}
-                />
-                <TopItemsList
-                  title="Top 5 Functions"
-                  items={(analytics?.topFunctions ?? []).map((f) => ({
-                    name: f.functionName,
-                    count: f.count,
-                  }))}
-                  isLoading={isLoading}
-                />
-              </div>
-            </>
-          )}
-        </div>
-      </CloudLayout>
-    </Protected>
+          {/* Top Items */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <TopItemsList
+              title="Top 5 Models"
+              items={(analytics?.topModels ?? []).map((m) => ({
+                name: m.model,
+                count: m.count,
+              }))}
+              isLoading={isLoading}
+            />
+            <TopItemsList
+              title="Top 5 Functions"
+              items={(analytics?.topFunctions ?? []).map((f) => ({
+                name: f.functionName,
+                count: f.count,
+              }))}
+              isLoading={isLoading}
+            />
+          </div>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/trace-view.$traceId.$spanId.tsx
+++ b/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/trace-view.$traceId.$spanId.tsx
@@ -7,8 +7,6 @@ import type { SpanDetail } from "@/api/traces-search.schemas";
 
 import { useFunctionDetail } from "@/app/api/functions";
 import { useTraceDetail } from "@/app/api/traces";
-import { CloudLayout } from "@/app/components/cloud-layout";
-import { Protected } from "@/app/components/protected";
 import { SpanDetailPanel } from "@/app/components/traces/span-detail-panel";
 import { TraceTree } from "@/app/components/traces/trace-tree";
 import { Alert, AlertDescription, AlertTitle } from "@/app/components/ui/alert";
@@ -87,121 +85,98 @@ function FullTraceViewPage() {
   // No environment selected
   if (!selectedEnvironment) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <div className="flex h-64 items-center justify-center">
-              <p className="text-lg text-muted-foreground">
-                Select an environment to view trace details.
-              </p>
-            </div>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <div className="flex h-64 items-center justify-center">
+          <p className="text-lg text-muted-foreground">
+            Select an environment to view trace details.
+          </p>
+        </div>
+      </div>
     );
   }
 
   // Loading state
   if (isLoading) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <div className="flex h-64 items-center justify-center">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <div className="flex h-64 items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      </div>
     );
   }
 
   // Trace not found
   if (!traceDetail || traceDetail.spans.length === 0) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Trace not found</AlertTitle>
-              <AlertDescription>
-                The trace with ID &quot;{traceId}&quot; could not be found.
-              </AlertDescription>
-            </Alert>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Trace not found</AlertTitle>
+          <AlertDescription>
+            The trace with ID &quot;{traceId}&quot; could not be found.
+          </AlertDescription>
+        </Alert>
+      </div>
     );
   }
 
   // Span not found in trace
   if (!selectedSpan) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Span not found</AlertTitle>
-              <AlertDescription>
-                The span with ID &quot;{spanId}&quot; could not be found in this
-                trace.
-              </AlertDescription>
-            </Alert>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Span not found</AlertTitle>
+          <AlertDescription>
+            The span with ID &quot;{spanId}&quot; could not be found in this
+            trace.
+          </AlertDescription>
+        </Alert>
+      </div>
     );
   }
 
   return (
-    <Protected>
-      <CloudLayout>
-        <div className="flex h-full flex-col overflow-hidden">
-          {/* Header */}
-          <div className="shrink-0 px-6 py-4">
-            <h1 className="truncate text-xl font-semibold">
-              {rootSpan?.name ?? "Trace"}
-            </h1>
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header */}
+      <div className="shrink-0 px-6 py-4">
+        <h1 className="truncate text-xl font-semibold">
+          {rootSpan?.name ?? "Trace"}
+        </h1>
+      </div>
+
+      {/* Main content */}
+      <ResizablePanelGroup direction="horizontal" className="min-h-0 flex-1">
+        {/* Left panel - Trace tree */}
+        <ResizablePanel defaultSize={40} minSize={20} maxSize={60}>
+          <div className="h-full overflow-auto p-4">
+            <TraceTree
+              spans={traceDetail.spans}
+              selectedSpanId={spanId}
+              onSpanSelect={handleSpanSelect}
+            />
           </div>
+        </ResizablePanel>
 
-          {/* Main content */}
-          <ResizablePanelGroup
-            direction="horizontal"
-            className="min-h-0 flex-1"
-          >
-            {/* Left panel - Trace tree */}
-            <ResizablePanel defaultSize={40} minSize={20} maxSize={60}>
-              <div className="h-full overflow-auto p-4">
-                <TraceTree
-                  spans={traceDetail.spans}
-                  selectedSpanId={spanId}
-                  onSpanSelect={handleSpanSelect}
-                />
-              </div>
-            </ResizablePanel>
+        <ResizableHandle className="cursor-col-resize">
+          <div className="z-10 flex h-8 w-4 items-center justify-center rounded-sm border bg-background">
+            <DragHandleDots2Icon className="h-4 w-4" />
+          </div>
+        </ResizableHandle>
 
-            <ResizableHandle className="cursor-col-resize">
-              <div className="z-10 flex h-8 w-4 items-center justify-center rounded-sm border bg-background">
-                <DragHandleDots2Icon className="h-4 w-4" />
-              </div>
-            </ResizableHandle>
-
-            {/* Right panel - Span detail */}
-            <ResizablePanel defaultSize={60} minSize={30}>
-              <div className="h-full py-4 pr-4">
-                <SpanDetailPanel
-                  span={selectedSpan}
-                  functionData={functionDetail ?? null}
-                  mode="full-view"
-                />
-              </div>
-            </ResizablePanel>
-          </ResizablePanelGroup>
-        </div>
-      </CloudLayout>
-    </Protected>
+        {/* Right panel - Span detail */}
+        <ResizablePanel defaultSize={60} minSize={30}>
+          <div className="h-full py-4 pr-4">
+            <SpanDetailPanel
+              span={selectedSpan}
+              functionData={functionDetail ?? null}
+              mode="full-view"
+            />
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
   );
 }
 

--- a/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/traces.tsx
+++ b/cloud/app/routes/$orgSlug/projects/$projectSlug/$envSlug/traces.tsx
@@ -7,8 +7,6 @@ import type { SpanDetail, SpanSearchResult } from "@/api/traces-search.schemas";
 
 import { useFunctionDetail } from "@/app/api/functions";
 import { useTracesSearch, useTraceDetail } from "@/app/api/traces";
-import { CloudLayout } from "@/app/components/cloud-layout";
-import { Protected } from "@/app/components/protected";
 import { SpanDetailPanel } from "@/app/components/traces/span-detail-panel";
 import { TracesTable } from "@/app/components/traces/traces-table";
 import { Button } from "@/app/components/ui/button";
@@ -104,93 +102,85 @@ function TracesPage() {
 
   if (!selectedEnvironment) {
     return (
-      <Protected>
-        <CloudLayout>
-          <div className="p-6">
-            <div className="flex items-center justify-center h-64">
-              <p className="text-muted-foreground text-lg">
-                Select an environment to view traces.
-              </p>
-            </div>
-          </div>
-        </CloudLayout>
-      </Protected>
+      <div className="p-6">
+        <div className="flex items-center justify-center h-64">
+          <p className="text-muted-foreground text-lg">
+            Select an environment to view traces.
+          </p>
+        </div>
+      </div>
     );
   }
 
   return (
-    <Protected>
-      <CloudLayout>
-        <ResizablePanelGroup direction="horizontal" className="h-full">
-          {/* Main content area */}
-          <ResizablePanel defaultSize={selectedSpan ? 70 : 100} minSize={30}>
-            <div className="overflow-auto p-6">
-              <div className="mb-4 flex items-center justify-between">
-                <h1 className="text-2xl font-semibold">Traces</h1>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    analytics.trackEvent("traces_refreshed", {
-                      environment_id: selectedEnvironment?.id,
-                    });
-                    setRefreshKey((k) => k + 1);
-                  }}
-                  disabled={isFetching}
-                >
-                  <RefreshCw
-                    className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
-                  />
-                  Refresh
-                </Button>
-              </div>
-              <TracesTable
-                spans={data?.spans ?? []}
-                isLoading={isLoading}
-                onTraceSelect={(traceId) => {
-                  analytics.trackEvent("trace_selected", {
-                    trace_id: traceId,
-                    environment_id: selectedEnvironment?.id,
-                  });
-                  setSelectedTraceId(traceId);
-                }}
-                traceDetail={traceDetail ?? null}
-                isLoadingDetail={isLoadingDetail}
-                onSpanClick={(span) => {
-                  analytics.trackEvent("span_selected", {
-                    span_id: span?.spanId,
-                    trace_id: selectedTraceId,
-                    environment_id: selectedEnvironment?.id,
-                  });
-                  setSelectedSpan(span);
-                }}
-                selectedSpanId={selectedSpan?.spanId}
+    <ResizablePanelGroup direction="horizontal" className="h-full">
+      {/* Main content area */}
+      <ResizablePanel defaultSize={selectedSpan ? 70 : 100} minSize={30}>
+        <div className="overflow-auto p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h1 className="text-2xl font-semibold">Traces</h1>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                analytics.trackEvent("traces_refreshed", {
+                  environment_id: selectedEnvironment?.id,
+                });
+                setRefreshKey((k) => k + 1);
+              }}
+              disabled={isFetching}
+            >
+              <RefreshCw
+                className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+              />
+              Refresh
+            </Button>
+          </div>
+          <TracesTable
+            spans={data?.spans ?? []}
+            isLoading={isLoading}
+            onTraceSelect={(traceId) => {
+              analytics.trackEvent("trace_selected", {
+                trace_id: traceId,
+                environment_id: selectedEnvironment?.id,
+              });
+              setSelectedTraceId(traceId);
+            }}
+            traceDetail={traceDetail ?? null}
+            isLoadingDetail={isLoadingDetail}
+            onSpanClick={(span) => {
+              analytics.trackEvent("span_selected", {
+                span_id: span?.spanId,
+                trace_id: selectedTraceId,
+                environment_id: selectedEnvironment?.id,
+              });
+              setSelectedSpan(span);
+            }}
+            selectedSpanId={selectedSpan?.spanId}
+          />
+        </div>
+      </ResizablePanel>
+
+      {/* Detail panel - resizable */}
+      {selectedSpan && (
+        <>
+          <ResizableHandle className="cursor-col-resize">
+            <div className="z-10 flex h-8 w-4 translate-x-0.5 items-center justify-center rounded-sm border bg-background">
+              <DragHandleDots2Icon className="h-4 w-4" />
+            </div>
+          </ResizableHandle>
+          <ResizablePanel defaultSize={30} minSize={20} maxSize={50}>
+            <div className="h-full py-6 pr-6">
+              <SpanDetailPanel
+                span={selectedSpan}
+                functionData={functionDetail ?? null}
+                onClose={() => setSelectedSpan(null)}
               />
             </div>
           </ResizablePanel>
-
-          {/* Detail panel - resizable */}
-          {selectedSpan && (
-            <>
-              <ResizableHandle className="cursor-col-resize">
-                <div className="z-10 flex h-8 w-4 translate-x-0.5 items-center justify-center rounded-sm border bg-background">
-                  <DragHandleDots2Icon className="h-4 w-4" />
-                </div>
-              </ResizableHandle>
-              <ResizablePanel defaultSize={30} minSize={20} maxSize={50}>
-                <div className="h-full py-6 pr-6">
-                  <SpanDetailPanel
-                    span={selectedSpan}
-                    functionData={functionDetail ?? null}
-                    onClose={() => setSelectedSpan(null)}
-                  />
-                </div>
-              </ResizablePanel>
-            </>
-          )}
-        </ResizablePanelGroup>
-      </CloudLayout>
-    </Protected>
+        </>
+      )}
+    </ResizablePanelGroup>
   );
 }
 


### PR DESCRIPTION
Fixes the context errors from #2617. CloudLayout renders Sidebar which uses `useClaw()` and `useProject()`, so it must be inside the provider tree.

**Error:** `useClaw must be used within a ClawProvider` on /claws route

**Fix:** Reorder so providers wrap CloudLayout:
```
Protected → ProjectProvider → EnvironmentProvider → ClawProvider → CloudLayout → Outlet
```