### PR TITLE
feat(claws): add verse-staging environment for autonomous deploy testing

### DIFF
--- a/cloud/claws/dispatch-worker/wrangler.jsonc
+++ b/cloud/claws/dispatch-worker/wrangler.jsonc
@@ -83,6 +83,37 @@
         },
       ],
     },
+    "verse-staging": {
+      "name": "claw-dispatch-worker-verse-staging",
+      "services": [{ "binding": "MIRASCOPE_CLOUD", "service": "staging" }],
+      "route": {
+        "pattern": "openclaw-verse.staging.mirascope.com",
+        "zone_name": "mirascope.com",
+        "custom_domain": true,
+      },
+      "containers": [
+        {
+          "class_name": "Sandbox",
+          "image": "./Dockerfile",
+          "instance_type": "standard-2",
+          "max_instances": 2,
+        },
+      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "class_name": "Sandbox",
+            "name": "Sandbox",
+          },
+        ],
+      },
+      "migrations": [
+        {
+          "new_sqlite_classes": ["Sandbox"],
+          "tag": "v1",
+        },
+      ],
+    },
     "production": {
       "name": "claw-dispatch-worker-production",
       "services": [{ "binding": "MIRASCOPE_CLOUD", "service": "production" }],


### PR DESCRIPTION
Adds a `verse-staging` environment to the dispatch worker for Verse to deploy and debug independently. Uses same cloud backend as staging, separate worker name and domain.

## What this does
- New wrangler env `verse-staging` with worker name `claw-dispatch-worker-verse-staging`
- Routes to `openclaw-verse.staging.mirascope.com` (auto-managed DNS via `custom_domain: true`)
- Service binding points to `staging` (same Mirascope Cloud backend)
- Max 2 container instances (just for testing)

## What William needs to do after merge

### 1. First deploy (one-time)
```bash
cd cloud/claws/dispatch-worker
wrangler deploy -e verse-staging --config wrangler.jsonc
```
This creates the worker, DO namespace, and DNS record. Subsequent deploys can be done by Verse with an API token.

### 2. Create a CF API token for Verse
Go to: https://dash.cloudflare.com/profile/api-tokens → Create Token

**Permissions needed:**
- Account → Workers Scripts → Edit
- Account → Workers R2 Storage → Edit
- Account → Cloudflare Containers → Edit
- Zone → DNS → Edit (for mirascope.com zone — needed for custom_domain deploys)

**Account scope:** Mirascope account only

### 3. Set secrets on the new worker
```bash
echo "https://staging.mirascope.com" | wrangler secret put SITE_URL -e verse-staging --config wrangler.jsonc
```

### 4. Share the token
Drop the API token at `~/verse/cloudflare-api-token.txt` — Verse will use it via `CLOUDFLARE_API_TOKEN` env var.

## After setup, Verse can independently:
- `wrangler deploy -e verse-staging` — deploy from any branch
- `wrangler tail -e verse-staging` — live request logs
- `wrangler secret put -e verse-staging` — set env vars
- Create/delete test claws via the staging cloud API
- Full debug cycle without going through a human