### PR TITLE
feat: org-scoped API keys with discriminated union type hierarchy

### DIFF
--- a/cloud/api/annotations.handlers.ts
+++ b/cloud/api/annotations.handlers.ts
@@ -35,7 +35,7 @@ export const listAnnotationsHandler = (params: {
 }) =>
   Effect.gen(function* () {
     const db = yield* Database;
-    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+    const { user, apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
 
     const results =
       yield* db.organizations.projects.environments.traces.annotations.findAll({
@@ -65,7 +65,7 @@ export const listAnnotationsHandler = (params: {
 export const createAnnotationHandler = (payload: CreateAnnotationRequest) =>
   Effect.gen(function* () {
     const db = yield* Database;
-    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+    const { user, apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
 
     const tags =
       payload.tags === null ? null : payload.tags ? [...payload.tags] : null;
@@ -96,7 +96,7 @@ export const createAnnotationHandler = (payload: CreateAnnotationRequest) =>
 export const getAnnotationHandler = (id: string) =>
   Effect.gen(function* () {
     const db = yield* Database;
-    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+    const { user, apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
 
     const result =
       yield* db.organizations.projects.environments.traces.annotations.findById(
@@ -122,7 +122,7 @@ export const updateAnnotationHandler = (
 ) =>
   Effect.gen(function* () {
     const db = yield* Database;
-    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+    const { user, apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
 
     const tags =
       payload.tags === null
@@ -156,7 +156,7 @@ export const updateAnnotationHandler = (
 export const deleteAnnotationHandler = (id: string) =>
   Effect.gen(function* () {
     const db = yield* Database;
-    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+    const { user, apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
 
     yield* db.organizations.projects.environments.traces.annotations.delete({
       userId: user.id,

--- a/cloud/api/api-keys.handlers.ts
+++ b/cloud/api/api-keys.handlers.ts
@@ -2,9 +2,9 @@ import { Effect } from "effect";
 
 import type { CreateApiKeyRequest } from "@/api/api-keys.schemas";
 import type {
-  EnvironmentPublicApiKey,
-  EnvironmentApiKeyCreateResponse,
-  EnvironmentApiKeyWithContext,
+  PublicApiKey,
+  ApiKeyCreateResponse,
+  ApiKeyWithContext,
 } from "@/db/schema";
 
 import { Analytics } from "@/analytics";
@@ -14,21 +14,19 @@ import { Database } from "@/db/database";
 export * from "@/api/api-keys.schemas";
 
 // Helper to convert Date to ISO string for API response
-export const toApiKey = (apiKey: EnvironmentPublicApiKey) => ({
+export const toApiKey = (apiKey: PublicApiKey) => ({
   ...apiKey,
   createdAt: apiKey.createdAt?.toISOString() ?? null,
   lastUsedAt: apiKey.lastUsedAt?.toISOString() ?? null,
 });
 
-export const toApiKeyCreateResponse = (
-  apiKey: EnvironmentApiKeyCreateResponse,
-) => ({
+export const toApiKeyCreateResponse = (apiKey: ApiKeyCreateResponse) => ({
   ...apiKey,
   createdAt: apiKey.createdAt?.toISOString() ?? null,
   lastUsedAt: apiKey.lastUsedAt?.toISOString() ?? null,
 });
 
-export const toApiKeyWithContext = (apiKey: EnvironmentApiKeyWithContext) => ({
+export const toApiKeyWithContext = (apiKey: ApiKeyWithContext) => ({
   ...apiKey,
   createdAt: apiKey.createdAt?.toISOString() ?? null,
   lastUsedAt: apiKey.lastUsedAt?.toISOString() ?? null,

--- a/cloud/api/api-keys.handlers.ts
+++ b/cloud/api/api-keys.handlers.ts
@@ -2,8 +2,8 @@ import { Effect } from "effect";
 
 import type { CreateApiKeyRequest } from "@/api/api-keys.schemas";
 import type {
-  PublicApiKey,
-  ApiKeyCreateResponse,
+  EnvironmentPublicApiKey,
+  EnvironmentApiKeyCreateResponse,
   ApiKeyWithContext,
 } from "@/db/schema";
 
@@ -13,14 +13,17 @@ import { Database } from "@/db/database";
 
 export * from "@/api/api-keys.schemas";
 
-// Helper to convert Date to ISO string for API response
-export const toApiKey = (apiKey: PublicApiKey) => ({
+// Helpers to convert Date to ISO string for API responses.
+// Environment-scoped helpers for env-specific endpoints.
+export const toApiKey = (apiKey: EnvironmentPublicApiKey) => ({
   ...apiKey,
   createdAt: apiKey.createdAt?.toISOString() ?? null,
   lastUsedAt: apiKey.lastUsedAt?.toISOString() ?? null,
 });
 
-export const toApiKeyCreateResponse = (apiKey: ApiKeyCreateResponse) => ({
+export const toApiKeyCreateResponse = (
+  apiKey: EnvironmentApiKeyCreateResponse,
+) => ({
   ...apiKey,
   createdAt: apiKey.createdAt?.toISOString() ?? null,
   lastUsedAt: apiKey.lastUsedAt?.toISOString() ?? null,

--- a/cloud/api/api-keys.handlers.ts
+++ b/cloud/api/api-keys.handlers.ts
@@ -2,9 +2,9 @@ import { Effect } from "effect";
 
 import type { CreateApiKeyRequest } from "@/api/api-keys.schemas";
 import type {
-  PublicApiKey,
-  ApiKeyCreateResponse,
-  ApiKeyWithContext,
+  EnvironmentPublicApiKey,
+  EnvironmentApiKeyCreateResponse,
+  EnvironmentApiKeyWithContext,
 } from "@/db/schema";
 
 import { Analytics } from "@/analytics";
@@ -14,19 +14,21 @@ import { Database } from "@/db/database";
 export * from "@/api/api-keys.schemas";
 
 // Helper to convert Date to ISO string for API response
-export const toApiKey = (apiKey: PublicApiKey) => ({
+export const toApiKey = (apiKey: EnvironmentPublicApiKey) => ({
   ...apiKey,
   createdAt: apiKey.createdAt?.toISOString() ?? null,
   lastUsedAt: apiKey.lastUsedAt?.toISOString() ?? null,
 });
 
-export const toApiKeyCreateResponse = (apiKey: ApiKeyCreateResponse) => ({
+export const toApiKeyCreateResponse = (
+  apiKey: EnvironmentApiKeyCreateResponse,
+) => ({
   ...apiKey,
   createdAt: apiKey.createdAt?.toISOString() ?? null,
   lastUsedAt: apiKey.lastUsedAt?.toISOString() ?? null,
 });
 
-export const toApiKeyWithContext = (apiKey: ApiKeyWithContext) => ({
+export const toApiKeyWithContext = (apiKey: EnvironmentApiKeyWithContext) => ({
   ...apiKey,
   createdAt: apiKey.createdAt?.toISOString() ?? null,
   lastUsedAt: apiKey.lastUsedAt?.toISOString() ?? null,

--- a/cloud/api/api-keys.handlers.ts
+++ b/cloud/api/api-keys.handlers.ts
@@ -15,13 +15,13 @@ export * from "@/api/api-keys.schemas";
 
 // Helpers to convert Date to ISO string for API responses.
 // Environment-scoped helpers for env-specific endpoints.
-export const toApiKey = (apiKey: EnvironmentPublicApiKey) => ({
+export const toEnvironmentApiKey = (apiKey: EnvironmentPublicApiKey) => ({
   ...apiKey,
   createdAt: apiKey.createdAt?.toISOString() ?? null,
   lastUsedAt: apiKey.lastUsedAt?.toISOString() ?? null,
 });
 
-export const toApiKeyCreateResponse = (
+export const toEnvironmentApiKeyCreateResponse = (
   apiKey: EnvironmentApiKeyCreateResponse,
 ) => ({
   ...apiKey,
@@ -49,7 +49,7 @@ export const listAllApiKeysHandler = (organizationId: string) =>
     return apiKeys.map(toApiKeyWithContext);
   });
 
-export const listApiKeysHandler = (
+export const listEnvironmentApiKeysHandler = (
   organizationId: string,
   projectId: string,
   environmentId: string,
@@ -64,10 +64,10 @@ export const listApiKeysHandler = (
         projectId,
         environmentId,
       });
-    return apiKeys.map(toApiKey);
+    return apiKeys.map(toEnvironmentApiKey);
   });
 
-export const createApiKeyHandler = (
+export const createEnvironmentApiKeyHandler = (
   organizationId: string,
   projectId: string,
   environmentId: string,
@@ -100,10 +100,10 @@ export const createApiKeyHandler = (
       distinctId: user.id,
     });
 
-    return toApiKeyCreateResponse(apiKey);
+    return toEnvironmentApiKeyCreateResponse(apiKey);
   });
 
-export const getApiKeyHandler = (
+export const getEnvironmentApiKeyHandler = (
   organizationId: string,
   projectId: string,
   environmentId: string,
@@ -120,10 +120,10 @@ export const getApiKeyHandler = (
         environmentId,
         apiKeyId,
       });
-    return toApiKey(apiKey);
+    return toEnvironmentApiKey(apiKey);
   });
 
-export const deleteApiKeyHandler = (
+export const deleteEnvironmentApiKeyHandler = (
   organizationId: string,
   projectId: string,
   environmentId: string,

--- a/cloud/api/api-keys.schemas.ts
+++ b/cloud/api/api-keys.schemas.ts
@@ -31,18 +31,25 @@ export const ApiKeyCreateResponseSchema = Schema.Struct({
   key: Schema.String,
 });
 
-// Schema for API key with project and environment context
+// Schema for API key with display context.
+// Environment-scoped keys have environmentId/projectId/projectName/environmentName set.
+// Org-scoped keys have organizationId/organizationName set and environmentId null.
 export const ApiKeyWithContextSchema = Schema.Struct({
   id: Schema.String,
   name: Schema.String,
   keyPrefix: Schema.String,
-  environmentId: Schema.String,
+  environmentId: Schema.NullOr(Schema.String),
   ownerId: Schema.String,
   createdAt: Schema.NullOr(Schema.String),
   lastUsedAt: Schema.NullOr(Schema.String),
-  projectId: Schema.String,
-  projectName: Schema.String,
-  environmentName: Schema.String,
+  // Environment-scoped fields (null for org-scoped keys)
+  projectId: Schema.optional(Schema.String),
+  projectName: Schema.optional(Schema.String),
+  environmentName: Schema.optional(Schema.String),
+  // Org-scoped fields (null for environment-scoped keys)
+  organizationId: Schema.optional(Schema.String),
+  organizationName: Schema.optional(Schema.String),
+  // Owner context
   ownerName: Schema.NullOr(Schema.String),
   ownerAccountType: Schema.Literal("user", "claw"),
 });

--- a/cloud/api/api-keys.schemas.ts
+++ b/cloud/api/api-keys.schemas.ts
@@ -43,6 +43,8 @@ export const ApiKeyWithContextSchema = Schema.Struct({
   projectId: Schema.String,
   projectName: Schema.String,
   environmentName: Schema.String,
+  ownerName: Schema.NullOr(Schema.String),
+  ownerAccountType: Schema.Literal("user", "claw"),
 });
 
 // API key name must be 1-100 characters

--- a/cloud/api/api-keys.test.ts
+++ b/cloud/api/api-keys.test.ts
@@ -1,9 +1,9 @@
 import { Effect, Schema } from "effect";
 
 import type {
-  PublicApiKey,
-  ApiKeyCreateResponse,
-  ApiKeyWithContext,
+  EnvironmentPublicApiKey,
+  EnvironmentApiKeyCreateResponse,
+  EnvironmentApiKeyWithContext,
   PublicProject,
   PublicEnvironment,
 } from "@/db/schema";
@@ -19,7 +19,7 @@ import { describe, it, expect, TestApiContext } from "@/tests/api";
 describe("toApiKey helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
-    const apiKey: PublicApiKey = {
+    const apiKey: EnvironmentPublicApiKey = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -38,7 +38,7 @@ describe("toApiKey helper", () => {
   });
 
   it("should handle null dates", () => {
-    const apiKey: PublicApiKey = {
+    const apiKey: EnvironmentPublicApiKey = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -59,7 +59,7 @@ describe("toApiKey helper", () => {
 describe("toApiKeyCreateResponse helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
-    const apiKey: ApiKeyCreateResponse = {
+    const apiKey: EnvironmentApiKeyCreateResponse = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -80,7 +80,7 @@ describe("toApiKeyCreateResponse helper", () => {
   });
 
   it("should handle null dates", () => {
-    const apiKey: ApiKeyCreateResponse = {
+    const apiKey: EnvironmentApiKeyCreateResponse = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -103,7 +103,7 @@ describe("toApiKeyCreateResponse helper", () => {
 describe("toApiKeyWithContext helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
-    const apiKey: ApiKeyWithContext = {
+    const apiKey: EnvironmentApiKeyWithContext = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -123,13 +123,17 @@ describe("toApiKeyWithContext helper", () => {
 
     expect(result.createdAt).toBe("2025-01-01T00:00:00.000Z");
     expect(result.lastUsedAt).toBe("2025-01-01T00:00:00.000Z");
-    expect(result.projectId).toBe("project-id");
-    expect(result.projectName).toBe("My Project");
-    expect(result.environmentName).toBe("production");
+    // Env-scoped fields accessible after narrowing on environmentId
+    expect(result.environmentId).toBe("env-id");
+    expect("projectId" in result && result.projectId).toBe("project-id");
+    expect("projectName" in result && result.projectName).toBe("My Project");
+    expect("environmentName" in result && result.environmentName).toBe(
+      "production",
+    );
   });
 
   it("should handle null dates", () => {
-    const apiKey: ApiKeyWithContext = {
+    const apiKey: EnvironmentApiKeyWithContext = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",

--- a/cloud/api/api-keys.test.ts
+++ b/cloud/api/api-keys.test.ts
@@ -9,14 +9,14 @@ import type {
 } from "@/db/schema";
 
 import {
-  toApiKey,
-  toApiKeyCreateResponse,
+  toEnvironmentApiKey,
+  toEnvironmentApiKeyCreateResponse,
   toApiKeyWithContext,
 } from "@/api/api-keys.handlers";
 import { CreateApiKeyRequestSchema } from "@/api/api-keys.schemas";
 import { describe, it, expect, TestApiContext } from "@/tests/api";
 
-describe("toApiKey helper", () => {
+describe("toEnvironmentApiKey helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
     const apiKey: EnvironmentPublicApiKey = {
@@ -30,7 +30,7 @@ describe("toApiKey helper", () => {
       deletedAt: null,
     };
 
-    const result = toApiKey(apiKey);
+    const result = toEnvironmentApiKey(apiKey);
 
     expect(result.createdAt).toBe("2025-01-01T00:00:00.000Z");
     expect(result.lastUsedAt).toBe("2025-01-01T00:00:00.000Z");
@@ -49,14 +49,14 @@ describe("toApiKey helper", () => {
       deletedAt: null,
     };
 
-    const result = toApiKey(apiKey);
+    const result = toEnvironmentApiKey(apiKey);
 
     expect(result.createdAt).toBeNull();
     expect(result.lastUsedAt).toBeNull();
   });
 });
 
-describe("toApiKeyCreateResponse helper", () => {
+describe("toEnvironmentApiKeyCreateResponse helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
     const apiKey: EnvironmentApiKeyCreateResponse = {
@@ -71,7 +71,7 @@ describe("toApiKeyCreateResponse helper", () => {
       key: "mk_secret_key",
     };
 
-    const result = toApiKeyCreateResponse(apiKey);
+    const result = toEnvironmentApiKeyCreateResponse(apiKey);
 
     expect(result.createdAt).toBe("2025-01-01T00:00:00.000Z");
     expect(result.lastUsedAt).toBe("2025-01-01T00:00:00.000Z");
@@ -92,7 +92,7 @@ describe("toApiKeyCreateResponse helper", () => {
       key: "mk_secret_key",
     };
 
-    const result = toApiKeyCreateResponse(apiKey);
+    const result = toEnvironmentApiKeyCreateResponse(apiKey);
 
     expect(result.createdAt).toBeNull();
     expect(result.lastUsedAt).toBeNull();
@@ -100,7 +100,7 @@ describe("toApiKeyCreateResponse helper", () => {
   });
 });
 
-describe("toApiKeyWithContext helper", () => {
+describe("toEnvironmentApiKeyWithContext helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
     const apiKey: EnvironmentApiKeyWithContext = {

--- a/cloud/api/api-keys.test.ts
+++ b/cloud/api/api-keys.test.ts
@@ -1,9 +1,9 @@
 import { Effect, Schema } from "effect";
 
 import type {
-  EnvironmentPublicApiKey,
-  EnvironmentApiKeyCreateResponse,
-  EnvironmentApiKeyWithContext,
+  PublicApiKey,
+  ApiKeyCreateResponse,
+  ApiKeyWithContext,
   PublicProject,
   PublicEnvironment,
 } from "@/db/schema";
@@ -19,7 +19,7 @@ import { describe, it, expect, TestApiContext } from "@/tests/api";
 describe("toApiKey helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
-    const apiKey: EnvironmentPublicApiKey = {
+    const apiKey: PublicApiKey = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -38,7 +38,7 @@ describe("toApiKey helper", () => {
   });
 
   it("should handle null dates", () => {
-    const apiKey: EnvironmentPublicApiKey = {
+    const apiKey: PublicApiKey = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -59,7 +59,7 @@ describe("toApiKey helper", () => {
 describe("toApiKeyCreateResponse helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
-    const apiKey: EnvironmentApiKeyCreateResponse = {
+    const apiKey: ApiKeyCreateResponse = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -80,7 +80,7 @@ describe("toApiKeyCreateResponse helper", () => {
   });
 
   it("should handle null dates", () => {
-    const apiKey: EnvironmentApiKeyCreateResponse = {
+    const apiKey: ApiKeyCreateResponse = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -103,7 +103,7 @@ describe("toApiKeyCreateResponse helper", () => {
 describe("toApiKeyWithContext helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
-    const apiKey: EnvironmentApiKeyWithContext = {
+    const apiKey: ApiKeyWithContext = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -129,7 +129,7 @@ describe("toApiKeyWithContext helper", () => {
   });
 
   it("should handle null dates", () => {
-    const apiKey: EnvironmentApiKeyWithContext = {
+    const apiKey: ApiKeyWithContext = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",

--- a/cloud/api/api-keys.test.ts
+++ b/cloud/api/api-keys.test.ts
@@ -1,9 +1,9 @@
 import { Effect, Schema } from "effect";
 
 import type {
-  PublicApiKey,
-  ApiKeyCreateResponse,
-  ApiKeyWithContext,
+  EnvironmentPublicApiKey,
+  EnvironmentApiKeyCreateResponse,
+  EnvironmentApiKeyWithContext,
   PublicProject,
   PublicEnvironment,
 } from "@/db/schema";
@@ -19,7 +19,7 @@ import { describe, it, expect, TestApiContext } from "@/tests/api";
 describe("toApiKey helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
-    const apiKey: PublicApiKey = {
+    const apiKey: EnvironmentPublicApiKey = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -38,7 +38,7 @@ describe("toApiKey helper", () => {
   });
 
   it("should handle null dates", () => {
-    const apiKey: PublicApiKey = {
+    const apiKey: EnvironmentPublicApiKey = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -59,7 +59,7 @@ describe("toApiKey helper", () => {
 describe("toApiKeyCreateResponse helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
-    const apiKey: ApiKeyCreateResponse = {
+    const apiKey: EnvironmentApiKeyCreateResponse = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -80,7 +80,7 @@ describe("toApiKeyCreateResponse helper", () => {
   });
 
   it("should handle null dates", () => {
-    const apiKey: ApiKeyCreateResponse = {
+    const apiKey: EnvironmentApiKeyCreateResponse = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -103,7 +103,7 @@ describe("toApiKeyCreateResponse helper", () => {
 describe("toApiKeyWithContext helper", () => {
   it("should convert dates to ISO strings", () => {
     const date = new Date("2025-01-01T00:00:00.000Z");
-    const apiKey: ApiKeyWithContext = {
+    const apiKey: EnvironmentApiKeyWithContext = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -115,6 +115,8 @@ describe("toApiKeyWithContext helper", () => {
       projectId: "project-id",
       projectName: "My Project",
       environmentName: "production",
+      ownerName: "Test User",
+      ownerAccountType: "user" as const,
     };
 
     const result = toApiKeyWithContext(apiKey);
@@ -127,7 +129,7 @@ describe("toApiKeyWithContext helper", () => {
   });
 
   it("should handle null dates", () => {
-    const apiKey: ApiKeyWithContext = {
+    const apiKey: EnvironmentApiKeyWithContext = {
       id: "test-id",
       name: "test-key",
       keyPrefix: "mk_abc...",
@@ -139,6 +141,8 @@ describe("toApiKeyWithContext helper", () => {
       projectId: "project-id",
       projectName: "My Project",
       environmentName: "production",
+      ownerName: "Test User",
+      ownerAccountType: "user" as const,
     };
 
     const result = toApiKeyWithContext(apiKey);

--- a/cloud/api/functions.handlers.ts
+++ b/cloud/api/functions.handlers.ts
@@ -49,7 +49,7 @@ export const listFunctionsHandler = (
 export const createFunctionHandler = (payload: CreateFunctionRequest) =>
   Effect.gen(function* () {
     const db = yield* Database;
-    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+    const { user, apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
 
     const tags = payload.tags ? [...payload.tags] : null;
     const metadata = payload.metadata ? { ...payload.metadata } : null;

--- a/cloud/api/handler.ts
+++ b/cloud/api/handler.ts
@@ -1,7 +1,7 @@
 import { HttpApiBuilder, HttpServer } from "@effect/platform";
 import { Context, Effect, Layer } from "effect";
 
-import type { PublicUser, ApiKeyInfo } from "@/db/schema";
+import type { PublicUser, ApiKeyAuth } from "@/db/schema";
 
 import { Analytics } from "@/analytics";
 import { ApiLive } from "@/api/router";
@@ -20,7 +20,7 @@ import { SpansIngestQueue } from "@/workers/spanIngestQueue";
 export type HandleRequestOptions = {
   prefix?: string;
   user: PublicUser;
-  apiKeyInfo?: ApiKeyInfo;
+  apiKeyInfo?: ApiKeyAuth;
   settings: SettingsConfig;
   drizzle: Context.Tag.Service<DrizzleORM>;
   analytics: Context.Tag.Service<Analytics>;
@@ -42,7 +42,7 @@ type WebHandlerOptions = {
   spansIngestQueue: Context.Tag.Service<SpansIngestQueue>;
   clawDeployment: Context.Tag.Service<ClawDeploymentService>;
   user: PublicUser;
-  apiKeyInfo?: ApiKeyInfo;
+  apiKeyInfo?: ApiKeyAuth;
   settings: SettingsConfig;
 };
 

--- a/cloud/api/router.ts
+++ b/cloud/api/router.ts
@@ -134,7 +134,7 @@ const TracesHandlersLive = HttpApiBuilder.group(
       // API key route - extracts environmentId from apiKeyInfo
       .handle("search", ({ payload }) =>
         Effect.gen(function* () {
-          const { apiKeyInfo } = yield* Authentication.ApiKey;
+          const { apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
           return yield* searchHandler(apiKeyInfo.environmentId, payload);
         }),
       )
@@ -145,7 +145,7 @@ const TracesHandlersLive = HttpApiBuilder.group(
       // API key route - extracts environmentId from apiKeyInfo
       .handle("getTraceDetail", ({ path }) =>
         Effect.gen(function* () {
-          const { apiKeyInfo } = yield* Authentication.ApiKey;
+          const { apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
           return yield* getTraceDetailHandler(
             apiKeyInfo.environmentId,
             path.traceId,
@@ -397,7 +397,7 @@ const FunctionsHandlersLive = HttpApiBuilder.group(
       // API key route - extracts IDs from apiKeyInfo
       .handle("list", () =>
         Effect.gen(function* () {
-          const { apiKeyInfo } = yield* Authentication.ApiKey;
+          const { apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
           return yield* listFunctionsHandler(
             apiKeyInfo.organizationId,
             apiKeyInfo.projectId,
@@ -409,7 +409,7 @@ const FunctionsHandlersLive = HttpApiBuilder.group(
       // API key route - extracts IDs from apiKeyInfo
       .handle("get", ({ path }) =>
         Effect.gen(function* () {
-          const { apiKeyInfo } = yield* Authentication.ApiKey;
+          const { apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
           return yield* getFunctionHandler(
             apiKeyInfo.organizationId,
             apiKeyInfo.projectId,
@@ -421,7 +421,7 @@ const FunctionsHandlersLive = HttpApiBuilder.group(
       // API key route - extracts IDs from apiKeyInfo
       .handle("delete", ({ path }) =>
         Effect.gen(function* () {
-          const { apiKeyInfo } = yield* Authentication.ApiKey;
+          const { apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
           return yield* deleteFunctionHandler(
             apiKeyInfo.organizationId,
             apiKeyInfo.projectId,
@@ -433,7 +433,7 @@ const FunctionsHandlersLive = HttpApiBuilder.group(
       // API key route - extracts IDs from apiKeyInfo
       .handle("findByHash", ({ path }) =>
         Effect.gen(function* () {
-          const { apiKeyInfo } = yield* Authentication.ApiKey;
+          const { apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
           return yield* findByHashHandler(
             apiKeyInfo.organizationId,
             apiKeyInfo.projectId,

--- a/cloud/api/router.ts
+++ b/cloud/api/router.ts
@@ -11,10 +11,10 @@ import {
 import { MirascopeCloudApi } from "@/api/api";
 import {
   listAllApiKeysHandler,
-  listApiKeysHandler,
-  createApiKeyHandler,
-  getApiKeyHandler,
-  deleteApiKeyHandler,
+  listEnvironmentApiKeysHandler,
+  createEnvironmentApiKeyHandler,
+  getEnvironmentApiKeyHandler,
+  deleteEnvironmentApiKeyHandler,
 } from "@/api/api-keys.handlers";
 import {
   listClawMembersHandler,
@@ -357,14 +357,14 @@ const ApiKeysHandlersLive = HttpApiBuilder.group(
         listAllApiKeysHandler(path.organizationId),
       )
       .handle("list", ({ path }) =>
-        listApiKeysHandler(
+        listEnvironmentApiKeysHandler(
           path.organizationId,
           path.projectId,
           path.environmentId,
         ),
       )
       .handle("create", ({ path, payload }) =>
-        createApiKeyHandler(
+        createEnvironmentApiKeyHandler(
           path.organizationId,
           path.projectId,
           path.environmentId,
@@ -372,7 +372,7 @@ const ApiKeysHandlersLive = HttpApiBuilder.group(
         ),
       )
       .handle("get", ({ path }) =>
-        getApiKeyHandler(
+        getEnvironmentApiKeyHandler(
           path.organizationId,
           path.projectId,
           path.environmentId,
@@ -380,7 +380,7 @@ const ApiKeysHandlersLive = HttpApiBuilder.group(
         ),
       )
       .handle("delete", ({ path }) =>
-        deleteApiKeyHandler(
+        deleteEnvironmentApiKeyHandler(
           path.organizationId,
           path.projectId,
           path.environmentId,

--- a/cloud/api/router/non-streaming.test.ts
+++ b/cloud/api/router/non-streaming.test.ts
@@ -8,7 +8,7 @@ import type {
   RouterRequestContext,
   ValidatedRouterRequest,
 } from "@/api/router/utils";
-import type { PublicUser, ApiKeyInfo } from "@/db/schema";
+import type { PublicUser, EnvironmentApiKeyAuth } from "@/db/schema";
 
 import { handleNonStreamingResponse } from "@/api/router/non-streaming";
 import { RouterMeteringQueueService } from "@/workers/routerMeteringQueue";
@@ -79,7 +79,7 @@ describe("Non-Streaming", () => {
           ownerAccountType: "user",
           ownerDeletedAt: null,
           clawId: null,
-        } satisfies ApiKeyInfo,
+        } satisfies EnvironmentApiKeyAuth,
         provider: "openai",
         modelId: "gpt-4",
         parsedRequestBody: {},
@@ -146,7 +146,7 @@ describe("Non-Streaming", () => {
           ownerAccountType: "user",
           ownerDeletedAt: null,
           clawId: null,
-        } satisfies ApiKeyInfo,
+        } satisfies EnvironmentApiKeyAuth,
         provider: "openai",
         modelId: "gpt-4",
         parsedRequestBody: {},
@@ -224,7 +224,7 @@ describe("Non-Streaming", () => {
           ownerAccountType: "user",
           ownerDeletedAt: null,
           clawId: null,
-        } satisfies ApiKeyInfo,
+        } satisfies EnvironmentApiKeyAuth,
         provider: "openai",
         modelId: "gpt-4",
         parsedRequestBody: {},
@@ -301,7 +301,7 @@ describe("Non-Streaming", () => {
           ownerAccountType: "user",
           ownerDeletedAt: null,
           clawId: null,
-        } satisfies ApiKeyInfo,
+        } satisfies EnvironmentApiKeyAuth,
         provider: "openai",
         modelId: "gpt-4",
         parsedRequestBody: {},

--- a/cloud/api/router/utils.ts
+++ b/cloud/api/router/utils.ts
@@ -115,6 +115,14 @@ export function validateRouterRequest(
       });
     }
 
+    // Router requires environment-scoped keys
+    if (apiKeyInfo.environmentId === null) {
+      return yield* new UnauthorizedError({
+        message:
+          "Environment-scoped API key required for router access. Org-scoped keys cannot route requests.",
+      });
+    }
+
     // Parse request body
     const requestBodyText = yield* Effect.tryPromise({
       try: () => request.clone().text(),

--- a/cloud/api/router/utils.ts
+++ b/cloud/api/router/utils.ts
@@ -8,7 +8,7 @@
 import { Effect } from "effect";
 
 import type { TokenUsage, ModelPricing } from "@/api/router/pricing";
-import type { PublicUser, ApiKeyInfo } from "@/db/schema";
+import type { PublicUser, EnvironmentApiKeyAuth } from "@/db/schema";
 
 import { estimateCost } from "@/api/router/cost-estimator";
 import {
@@ -45,6 +45,7 @@ export interface RouterRequestIdentifiers {
   environmentId: string;
   apiKeyId: string;
   routerRequestId: string;
+  /** Populated when the request is made via a claw's bot-user API key. */
   clawId: string | null;
 }
 
@@ -53,7 +54,7 @@ export interface RouterRequestIdentifiers {
  */
 export interface ValidatedRouterRequest {
   user: PublicUser;
-  apiKeyInfo: ApiKeyInfo;
+  apiKeyInfo: EnvironmentApiKeyAuth;
   provider: ProviderName;
   modelId: string;
   parsedRequestBody: unknown;

--- a/cloud/api/traces-search.handlers.ts
+++ b/cloud/api/traces-search.handlers.ts
@@ -169,7 +169,7 @@ export const getTraceDetailHandler = (environmentId: string, traceId: string) =>
  */
 export const getAnalyticsSummaryHandler = (params: AnalyticsSummaryRequest) =>
   Effect.gen(function* () {
-    const { apiKeyInfo } = yield* Authentication.ApiKey;
+    const { apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
     const searchService = yield* ClickHouseSearch;
 
     const input: AnalyticsSummaryInput = {

--- a/cloud/api/traces-search.test.ts
+++ b/cloud/api/traces-search.test.ts
@@ -8,7 +8,7 @@ import type {
   AnalyticsSummaryResponse,
 } from "@/api/traces-search.schemas";
 import type {
-  ApiKeyInfo,
+  EnvironmentApiKeyAuth,
   PublicEnvironment,
   PublicProject,
   PublicUser,
@@ -48,7 +48,7 @@ describe.sequential("Search API", (it) => {
   let environment: PublicEnvironment;
   let apiKeyClient: Awaited<ReturnType<typeof createApiClient>>["client"];
   let disposeApiKeyClient: (() => Promise<void>) | null = null;
-  let apiKeyInfo: ApiKeyInfo | null = null;
+  let apiKeyInfo: EnvironmentApiKeyAuth | null = null;
   let ownerFromContext: PublicUser | null = null;
 
   it.effect(
@@ -83,7 +83,7 @@ describe.sequential("Search API", (it) => {
   it.effect("Create API key client for search tests", () =>
     Effect.gen(function* () {
       const { org, owner } = yield* TestApiContext;
-      const apiKeyContext: ApiKeyInfo = {
+      const apiKeyContext: EnvironmentApiKeyAuth = {
         apiKeyId: "test-search-api-key-id",
         organizationId: org.id,
         projectId: project.id,
@@ -2328,7 +2328,7 @@ describe("Realtime span merge", () => {
   const createMockSpan = buildSearchSpan;
   const createMockTraceSpan = buildTraceDetailSpan;
 
-  const mockApiKeyInfo: ApiKeyInfo = {
+  const mockEnvironmentApiKeyAuth: EnvironmentApiKeyAuth = {
     apiKeyId: "test-api-key",
     organizationId: "org-1",
     projectId: "proj-1",
@@ -2337,8 +2337,8 @@ describe("Realtime span merge", () => {
     ownerEmail: "test@example.com",
     ownerName: "Test User",
     ownerDeletedAt: null,
-    ownerAccountType: "user" as const,
     clawId: null,
+    ownerAccountType: "user" as const,
   };
 
   const mockUser: PublicUser = {
@@ -2351,7 +2351,7 @@ describe("Realtime span merge", () => {
 
   const authenticationLayer = Layer.succeed(Authentication, {
     user: mockUser,
-    apiKeyInfo: mockApiKeyInfo,
+    apiKeyInfo: mockEnvironmentApiKeyAuth,
   });
 
   const createClickHouseSearchLayer = (
@@ -2443,10 +2443,13 @@ describe("Realtime span merge", () => {
             hasMore: false,
           };
 
-          const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-            startTime: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
-            endTime: now.toISOString(),
-          }).pipe(
+          const result = yield* searchHandler(
+            mockEnvironmentApiKeyAuth.environmentId,
+            {
+              startTime: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
+              endTime: now.toISOString(),
+            },
+          ).pipe(
             Effect.provide(
               Layer.mergeAll(
                 authenticationLayer,
@@ -2479,11 +2482,14 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
-          endTime: now.toISOString(),
-          offset: 10,
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
+            endTime: now.toISOString(),
+            offset: 10,
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2524,10 +2530,13 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
-          endTime: now.toISOString(),
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
+            endTime: now.toISOString(),
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2554,10 +2563,13 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
-          endTime: now.toISOString(),
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now.getTime() - 5 * 60 * 1000).toISOString(),
+            endTime: now.toISOString(),
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2589,10 +2601,13 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: oldDate.toISOString(),
-          endTime: new Date(oldDate.getTime() + 60 * 1000).toISOString(),
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: oldDate.toISOString(),
+            endTime: new Date(oldDate.getTime() + 60 * 1000).toISOString(),
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2631,12 +2646,15 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          sortBy: "start_time",
-          sortOrder: "desc",
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            sortBy: "start_time",
+            sortOrder: "desc",
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2675,12 +2693,15 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          sortBy: "duration_ms",
-          sortOrder: "asc",
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            sortBy: "duration_ms",
+            sortOrder: "asc",
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2719,12 +2740,15 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          sortBy: "duration_ms",
-          sortOrder: "asc",
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            sortBy: "duration_ms",
+            sortOrder: "asc",
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2764,12 +2788,15 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          sortBy: "total_tokens",
-          sortOrder: "desc",
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            sortBy: "total_tokens",
+            sortOrder: "desc",
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2806,11 +2833,14 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          limit: 3,
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            limit: 3,
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2847,12 +2877,15 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          sortBy: "duration_ms",
-          sortOrder: "desc",
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            sortBy: "duration_ms",
+            sortOrder: "desc",
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2892,12 +2925,15 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          sortBy: "total_tokens",
-          sortOrder: "asc",
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            sortBy: "total_tokens",
+            sortOrder: "asc",
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2937,12 +2973,15 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          sortBy: "total_tokens",
-          sortOrder: "desc",
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            sortBy: "total_tokens",
+            sortOrder: "desc",
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -2982,12 +3021,15 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          sortBy: "start_time",
-          sortOrder: "asc",
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            sortBy: "start_time",
+            sortOrder: "asc",
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -3027,12 +3069,15 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-          sortBy: "start_time",
-          sortOrder: "desc",
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+            sortBy: "start_time",
+            sortOrder: "desc",
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -3066,10 +3111,13 @@ describe("Realtime span merge", () => {
           hasMore: false,
         };
 
-        const result = yield* searchHandler(mockApiKeyInfo.environmentId, {
-          startTime: new Date(now - 5 * 60 * 1000).toISOString(),
-          endTime: new Date(now).toISOString(),
-        }).pipe(
+        const result = yield* searchHandler(
+          mockEnvironmentApiKeyAuth.environmentId,
+          {
+            startTime: new Date(now - 5 * 60 * 1000).toISOString(),
+            endTime: new Date(now).toISOString(),
+          },
+        ).pipe(
           Effect.provide(
             Layer.mergeAll(
               authenticationLayer,
@@ -3111,7 +3159,7 @@ describe("Realtime span merge", () => {
         };
 
         const result = yield* getTraceDetailHandler(
-          mockApiKeyInfo.environmentId,
+          mockEnvironmentApiKeyAuth.environmentId,
           "trace-1",
         ).pipe(
           Effect.provide(
@@ -3158,7 +3206,7 @@ describe("Realtime span merge", () => {
         };
 
         const result = yield* getTraceDetailHandler(
-          mockApiKeyInfo.environmentId,
+          mockEnvironmentApiKeyAuth.environmentId,
           "trace-1",
         ).pipe(
           Effect.provide(
@@ -3211,7 +3259,7 @@ describe("Realtime span merge", () => {
         };
 
         const result = yield* getTraceDetailHandler(
-          mockApiKeyInfo.environmentId,
+          mockEnvironmentApiKeyAuth.environmentId,
           "trace-1",
         ).pipe(
           Effect.provide(
@@ -3244,7 +3292,7 @@ describe("Realtime span merge", () => {
         };
 
         const result = yield* getTraceDetailHandler(
-          mockApiKeyInfo.environmentId,
+          mockEnvironmentApiKeyAuth.environmentId,
           "trace-1",
         ).pipe(
           Effect.provide(
@@ -3280,7 +3328,7 @@ describe("Realtime span merge", () => {
         };
 
         const result = yield* getTraceDetailHandler(
-          mockApiKeyInfo.environmentId,
+          mockEnvironmentApiKeyAuth.environmentId,
           "trace-1",
         ).pipe(
           Effect.provide(
@@ -3330,7 +3378,7 @@ describe("Realtime span merge", () => {
         };
 
         const result = yield* getTraceDetailHandler(
-          mockApiKeyInfo.environmentId,
+          mockEnvironmentApiKeyAuth.environmentId,
           "trace-1",
         ).pipe(
           Effect.provide(
@@ -3374,7 +3422,7 @@ describe("Realtime span merge", () => {
         };
 
         const result = yield* getTraceDetailHandler(
-          mockApiKeyInfo.environmentId,
+          mockEnvironmentApiKeyAuth.environmentId,
           "trace-1",
         ).pipe(
           Effect.provide(

--- a/cloud/api/traces.handlers.ts
+++ b/cloud/api/traces.handlers.ts
@@ -37,7 +37,7 @@ export const DEFAULT_TIME_RANGE_MS =
 export const createTraceHandler = (payload: CreateTraceRequest) =>
   Effect.gen(function* () {
     const db = yield* Database;
-    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+    const { user, apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
 
     const result = yield* db.organizations.projects.environments.traces.create({
       userId: user.id,
@@ -76,7 +76,7 @@ export const listByFunctionHashHandler = (
 ) =>
   Effect.gen(function* () {
     const db = yield* Database;
-    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+    const { user, apiKeyInfo } = yield* Authentication.EnvironmentApiKey;
     const clickHouseSearch = yield* ClickHouseSearch;
 
     // First, find the function by hash

--- a/cloud/app/components/delete-api-key-modal.tsx
+++ b/cloud/app/components/delete-api-key-modal.tsx
@@ -51,14 +51,14 @@ export function DeleteApiKeyModal({
     try {
       await deleteApiKey.mutateAsync({
         organizationId,
-        projectId: apiKey.projectId,
-        environmentId: apiKey.environmentId,
+        projectId: apiKey.projectId ?? "",
+        environmentId: apiKey.environmentId ?? "",
         apiKeyId: apiKey.id,
       });
       analytics.trackEvent("api_key_deleted", {
         api_key_id: apiKey.id,
-        environment_id: apiKey.environmentId,
-        project_id: apiKey.projectId,
+        environment_id: apiKey.environmentId ?? "",
+        project_id: apiKey.projectId ?? "",
         organization_id: organizationId,
       });
 

--- a/cloud/auth/context.test.ts
+++ b/cloud/auth/context.test.ts
@@ -1,64 +1,146 @@
 import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 
-import type { PublicUser, EnvironmentApiKeyAuth } from "@/db/schema";
+import type {
+  PublicUser,
+  EnvironmentApiKeyAuth,
+  OrgApiKeyAuth,
+} from "@/db/schema";
 
 import { Authentication, type AuthResult } from "@/auth/context";
 import { UnauthorizedError } from "@/errors";
 
-describe("Authentication", () => {
-  const mockUser: PublicUser = {
-    id: "test-user-id",
-    email: "test@example.com",
-    name: "Test User",
-    accountType: "user" as const,
-    deletedAt: null,
-  };
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
 
-  const mockApiKeyInfo: EnvironmentApiKeyAuth = {
-    apiKeyId: "test-api-key-id",
-    organizationId: "test-org-id",
-    projectId: "test-project-id",
-    environmentId: "test-env-id",
-    ownerId: mockUser.id,
-    ownerEmail: mockUser.email,
-    ownerName: mockUser.name,
-    ownerAccountType: "user" as const,
-    ownerDeletedAt: mockUser.deletedAt,
-    clawId: null,
-  };
+const mockUser: PublicUser = {
+  id: "test-user-id",
+  email: "test@example.com",
+  name: "Test User",
+  accountType: "user" as const,
+  deletedAt: null,
+};
 
-  describe("ApiKey", () => {
-    it.effect("should return auth result when apiKeyInfo is present", () => {
-      const authWithApiKey: AuthResult = {
-        user: mockUser,
-        apiKeyInfo: mockApiKeyInfo,
-      };
+const sharedOwnerFields = {
+  ownerId: mockUser.id,
+  ownerEmail: mockUser.email,
+  ownerName: mockUser.name,
+  ownerAccountType: "user" as const,
+  ownerDeletedAt: mockUser.deletedAt,
+  clawId: null,
+};
 
-      const layer = Layer.succeed(Authentication, authWithApiKey);
-      return Effect.gen(function* () {
-        const result = yield* Authentication.ApiKey;
-        expect(result.user).toEqual(mockUser);
-        expect(result.apiKeyInfo).toEqual(mockApiKeyInfo);
-      }).pipe(Effect.provide(layer));
-    });
+const envApiKeyInfo: EnvironmentApiKeyAuth = {
+  apiKeyId: "test-env-key-id",
+  organizationId: "test-org-id",
+  projectId: "test-project-id",
+  environmentId: "test-env-id",
+  ...sharedOwnerFields,
+};
 
-    it.effect(
-      "should fail with UnauthorizedError when apiKeyInfo is not present",
-      () => {
-        const authWithoutApiKey: AuthResult = {
-          user: mockUser,
-        };
+const orgApiKeyInfo: OrgApiKeyAuth = {
+  apiKeyId: "test-org-key-id",
+  organizationId: "test-org-id",
+  environmentId: null,
+  ...sharedOwnerFields,
+};
 
-        const layer = Layer.succeed(Authentication, authWithoutApiKey);
-        return Effect.gen(function* () {
-          const error = yield* Authentication.ApiKey.pipe(Effect.flip);
-          expect(error).toBeInstanceOf(UnauthorizedError);
-          expect(error.message).toBe(
-            "API key required. Provide X-API-Key header or Bearer token.",
-          );
-        }).pipe(Effect.provide(layer));
-      },
-    );
+// ---------------------------------------------------------------------------
+// Authentication.ApiKey — accepts both scopes
+// ---------------------------------------------------------------------------
+
+describe("Authentication.ApiKey", () => {
+  it.effect("should return auth result for environment-scoped key", () => {
+    const auth: AuthResult = { user: mockUser, apiKeyInfo: envApiKeyInfo };
+    return Effect.gen(function* () {
+      const result = yield* Authentication.ApiKey;
+      expect(result.apiKeyInfo.apiKeyId).toBe("test-env-key-id");
+      expect(result.apiKeyInfo.organizationId).toBe("test-org-id");
+    }).pipe(Effect.provide(Layer.succeed(Authentication, auth)));
+  });
+
+  it.effect("should return auth result for org-scoped key", () => {
+    const auth: AuthResult = { user: mockUser, apiKeyInfo: orgApiKeyInfo };
+    return Effect.gen(function* () {
+      const result = yield* Authentication.ApiKey;
+      expect(result.apiKeyInfo.apiKeyId).toBe("test-org-key-id");
+      expect(result.apiKeyInfo.environmentId).toBeNull();
+    }).pipe(Effect.provide(Layer.succeed(Authentication, auth)));
+  });
+
+  it.effect("should fail with UnauthorizedError when no apiKeyInfo", () => {
+    const auth: AuthResult = { user: mockUser };
+    return Effect.gen(function* () {
+      const error = yield* Authentication.ApiKey.pipe(Effect.flip);
+      expect(error).toBeInstanceOf(UnauthorizedError);
+      expect(error.message).toBe(
+        "API key required. Provide X-API-Key header or Bearer token.",
+      );
+    }).pipe(Effect.provide(Layer.succeed(Authentication, auth)));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authentication.EnvironmentApiKey — narrows to env-scoped only
+// ---------------------------------------------------------------------------
+
+describe("Authentication.EnvironmentApiKey", () => {
+  it.effect("should succeed for environment-scoped key", () => {
+    const auth: AuthResult = { user: mockUser, apiKeyInfo: envApiKeyInfo };
+    return Effect.gen(function* () {
+      const result = yield* Authentication.EnvironmentApiKey;
+      expect(result.apiKeyInfo.environmentId).toBe("test-env-id");
+      expect(result.apiKeyInfo.projectId).toBe("test-project-id");
+    }).pipe(Effect.provide(Layer.succeed(Authentication, auth)));
+  });
+
+  it.effect("should reject org-scoped key", () => {
+    const auth: AuthResult = { user: mockUser, apiKeyInfo: orgApiKeyInfo };
+    return Effect.gen(function* () {
+      const error = yield* Authentication.EnvironmentApiKey.pipe(Effect.flip);
+      expect(error).toBeInstanceOf(UnauthorizedError);
+      expect(error.message).toContain("Environment-scoped API key required");
+    }).pipe(Effect.provide(Layer.succeed(Authentication, auth)));
+  });
+
+  it.effect("should fail when no apiKeyInfo", () => {
+    const auth: AuthResult = { user: mockUser };
+    return Effect.gen(function* () {
+      const error = yield* Authentication.EnvironmentApiKey.pipe(Effect.flip);
+      expect(error).toBeInstanceOf(UnauthorizedError);
+    }).pipe(Effect.provide(Layer.succeed(Authentication, auth)));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authentication.OrgApiKey — narrows to org-scoped only
+// ---------------------------------------------------------------------------
+
+describe("Authentication.OrgApiKey", () => {
+  it.effect("should succeed for org-scoped key", () => {
+    const auth: AuthResult = { user: mockUser, apiKeyInfo: orgApiKeyInfo };
+    return Effect.gen(function* () {
+      const result = yield* Authentication.OrgApiKey;
+      expect(result.apiKeyInfo.environmentId).toBeNull();
+      expect(result.apiKeyInfo.organizationId).toBe("test-org-id");
+    }).pipe(Effect.provide(Layer.succeed(Authentication, auth)));
+  });
+
+  it.effect("should reject environment-scoped key", () => {
+    const auth: AuthResult = { user: mockUser, apiKeyInfo: envApiKeyInfo };
+    return Effect.gen(function* () {
+      const error = yield* Authentication.OrgApiKey.pipe(Effect.flip);
+      expect(error).toBeInstanceOf(UnauthorizedError);
+      expect(error.message).toContain("Org-scoped API key required");
+    }).pipe(Effect.provide(Layer.succeed(Authentication, auth)));
+  });
+
+  it.effect("should fail when no apiKeyInfo", () => {
+    const auth: AuthResult = { user: mockUser };
+    return Effect.gen(function* () {
+      const error = yield* Authentication.OrgApiKey.pipe(Effect.flip);
+      expect(error).toBeInstanceOf(UnauthorizedError);
+    }).pipe(Effect.provide(Layer.succeed(Authentication, auth)));
   });
 });

--- a/cloud/auth/context.test.ts
+++ b/cloud/auth/context.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 
-import type { PublicUser, ApiKeyInfo } from "@/db/schema";
+import type { PublicUser, EnvironmentApiKeyAuth } from "@/db/schema";
 
 import { Authentication, type AuthResult } from "@/auth/context";
 import { UnauthorizedError } from "@/errors";
@@ -15,7 +15,7 @@ describe("Authentication", () => {
     deletedAt: null,
   };
 
-  const mockApiKeyInfo: ApiKeyInfo = {
+  const mockApiKeyInfo: EnvironmentApiKeyAuth = {
     apiKeyId: "test-api-key-id",
     organizationId: "test-org-id",
     projectId: "test-project-id",

--- a/cloud/auth/utils.ts
+++ b/cloud/auth/utils.ts
@@ -157,29 +157,33 @@ export const validateApiKey = (
     // If path parameters are provided, validate that the API key matches them
     if (pathParams) {
       // Validate environmentId if provided
-      if (
-        pathParams.environmentId &&
-        pathParams.environmentId !== apiKeyInfo.environmentId
-      ) {
-        return yield* Effect.fail(
-          new UnauthorizedError({
-            message:
-              "The environment ID in the request path does not match the environment associated with this API key",
-          }),
-        );
+      if (pathParams.environmentId) {
+        if (
+          apiKeyInfo.environmentId === null ||
+          pathParams.environmentId !== apiKeyInfo.environmentId
+        ) {
+          return yield* Effect.fail(
+            new UnauthorizedError({
+              message:
+                "The environment ID in the request path does not match the environment associated with this API key",
+            }),
+          );
+        }
       }
 
       // Validate projectId if provided
-      if (
-        pathParams.projectId &&
-        pathParams.projectId !== apiKeyInfo.projectId
-      ) {
-        return yield* Effect.fail(
-          new UnauthorizedError({
-            message:
-              "The project ID in the request path does not match the project associated with this API key",
-          }),
-        );
+      if (pathParams.projectId) {
+        if (
+          apiKeyInfo.environmentId === null ||
+          pathParams.projectId !== apiKeyInfo.projectId
+        ) {
+          return yield* Effect.fail(
+            new UnauthorizedError({
+              message:
+                "The project ID in the request path does not match the project associated with this API key",
+            }),
+          );
+        }
       }
 
       // Validate organizationId if provided

--- a/cloud/auth/utils.ts
+++ b/cloud/auth/utils.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 
 import type { AuthResult } from "@/auth/context";
-import type { ApiKeyInfo } from "@/db/schema";
+import type { ApiKeyAuth } from "@/db/schema";
 import type { SettingsConfig } from "@/settings";
 
 import { getApiKeyFromRequest } from "@/auth/api-key";
@@ -137,7 +137,7 @@ export type PathParameters = {
 export const validateApiKey = (
   apiKey: string,
   pathParams?: PathParameters,
-): Effect.Effect<ApiKeyInfo, UnauthorizedError, Database> =>
+): Effect.Effect<ApiKeyAuth, UnauthorizedError, Database> =>
   Effect.gen(function* () {
     const db = yield* Database;
 

--- a/cloud/auth/utils.ts
+++ b/cloud/auth/utils.ts
@@ -142,17 +142,15 @@ export const validateApiKey = (
     const db = yield* Database;
 
     // Get the API key info (verifies key and ensures owner exists)
-    const apiKeyInfo = yield* db.organizations.projects.environments.apiKeys
-      .getApiKeyInfo(apiKey)
-      .pipe(
-        Effect.catchAll(() =>
-          Effect.fail(
-            new UnauthorizedError({
-              message: "Invalid API key",
-            }),
-          ),
+    const apiKeyInfo = yield* db.authenticateApiKey(apiKey).pipe(
+      Effect.catchAll(() =>
+        Effect.fail(
+          new UnauthorizedError({
+            message: "Invalid API key",
+          }),
         ),
-      );
+      ),
+    );
 
     // If path parameters are provided, validate that the API key matches them
     if (pathParams) {

--- a/cloud/db/api-keys.test.ts
+++ b/cloud/db/api-keys.test.ts
@@ -1269,6 +1269,9 @@ describe("ApiKeys", () => {
 
         expect(result.apiKeyId).toBe(created.id);
         expect(result.environmentId).toBe(environment.id);
+        // Narrow to env-scoped key
+        expect(result.environmentId).not.toBeNull();
+        if (result.environmentId === null) throw new Error("unreachable");
         expect(result.projectId).toBe(project.id);
         expect(result.organizationId).toBe(org.id);
         expect(result.ownerId).toBe(owner.id);
@@ -1505,10 +1508,14 @@ describe("ApiKeys", () => {
 
           expect(apiKeys).toHaveLength(2);
           expect(apiKeys.map((k) => k.name).sort()).toEqual(["key-1", "key-2"]);
-          // Should include project and environment context
-          expect(apiKeys[0].projectName).toBeDefined();
-          expect(apiKeys[0].environmentName).toBeDefined();
-          expect(apiKeys[0].projectId).toBeDefined();
+          // Should include project and environment context (env-scoped keys)
+          const envKey = apiKeys[0];
+          expect(envKey.environmentId).not.toBeNull();
+          if (envKey.environmentId !== null) {
+            expect(envKey.projectName).toBeDefined();
+            expect(envKey.environmentName).toBeDefined();
+            expect(envKey.projectId).toBeDefined();
+          }
         }),
     );
 

--- a/cloud/db/api-keys.ts
+++ b/cloud/db/api-keys.ts
@@ -62,16 +62,20 @@ import { ProjectMemberships } from "@/db/project-memberships";
 import {
   apiKeys,
   claws,
+  organizations,
   users,
   environments,
   projects,
   projectMemberships,
   organizationMemberships,
   type NewApiKey,
-  type PublicApiKey,
-  type ApiKeyCreateResponse,
+  type EnvironmentPublicApiKey,
+  type EnvironmentApiKeyCreateResponse,
   type ApiKeyAuth,
+  type EnvironmentApiKeyAuth,
+  type OrgApiKeyAuth,
   type ApiKeyWithContext,
+  type EnvironmentApiKeyWithContext,
   type ProjectRole,
 } from "@/db/schema";
 import { isUniqueConstraintError } from "@/db/utils";
@@ -171,7 +175,7 @@ const publicFields = {
  * - Keys are hashed with SHA-256 before storage
  */
 export class ApiKeys extends BaseAuthenticatedEffectService<
-  PublicApiKey,
+  EnvironmentPublicApiKey,
   "organizations/:organizationId/projects/:projectId/environments/:environmentId/apiKeys/:apiKeyId",
   Pick<NewApiKey, "name">,
   Partial<Pick<NewApiKey, "name">>,
@@ -270,7 +274,7 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
     environmentId: string;
     data: Pick<NewApiKey, "name">;
   }): Effect.Effect<
-    ApiKeyCreateResponse,
+    EnvironmentApiKeyCreateResponse,
     AlreadyExistsError | NotFoundError | PermissionDeniedError | DatabaseError,
     DrizzleORM
   > {
@@ -320,7 +324,7 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
       return {
         ...apiKey,
         key: plaintextKey,
-      } as ApiKeyCreateResponse;
+      } as EnvironmentApiKeyCreateResponse;
     });
   }
 
@@ -349,7 +353,7 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
     projectId: string;
     environmentId: string;
   }): Effect.Effect<
-    PublicApiKey[],
+    EnvironmentPublicApiKey[],
     NotFoundError | PermissionDeniedError | DatabaseError,
     DrizzleORM
   > {
@@ -366,7 +370,8 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
         apiKeyId: "", // Not used for findAll
       });
 
-      const results: PublicApiKey[] = yield* client
+      // Filtered by environmentId — result always has environmentId set
+      const results = (yield* client
         .select(publicFields)
         .from(apiKeys)
         .where(
@@ -383,7 +388,7 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
                 cause: e,
               }),
           ),
-        );
+        )) as EnvironmentPublicApiKey[];
 
       return results;
     });
@@ -417,7 +422,7 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
     environmentId: string;
     apiKeyId: string;
   }): Effect.Effect<
-    PublicApiKey,
+    EnvironmentPublicApiKey,
     NotFoundError | PermissionDeniedError | DatabaseError,
     DrizzleORM
   > {
@@ -464,7 +469,8 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
         );
       }
 
-      return apiKey;
+      // Filtered by environmentId — result always has environmentId set
+      return apiKey as unknown as EnvironmentPublicApiKey;
     });
   }
 
@@ -501,7 +507,7 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
     apiKeyId: string;
     data: Partial<Pick<NewApiKey, "name">>;
   }): Effect.Effect<
-    PublicApiKey,
+    EnvironmentPublicApiKey,
     NotFoundError | PermissionDeniedError | AlreadyExistsError | DatabaseError,
     DrizzleORM
   > {
@@ -552,7 +558,8 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
         );
       }
 
-      return updated;
+      // Filtered by environmentId — result always has environmentId set
+      return updated as unknown as EnvironmentPublicApiKey;
     });
   }
 
@@ -711,15 +718,16 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
       const client = yield* DrizzleORM;
       const keyHash = hashApiKey(key);
 
-      // Look up the API key by hash and resolve the full hierarchy + owner info.
-      // Only include API keys whose owner has not been deleted.
-      // LEFT JOIN to claws to detect claw-owned keys.
-      const [apiKeyInfo] = yield* client
+      // Look up the API key by hash and resolve owner info.
+      // LEFT JOINs to environments/projects (null for org-scoped keys)
+      // and to claws to detect claw-owned keys.
+      const [row] = yield* client
         .select({
           apiKeyId: apiKeys.id,
           environmentId: apiKeys.environmentId,
+          organizationId: apiKeys.organizationId,
           projectId: environments.projectId,
-          organizationId: projects.organizationId,
+          projectOrgId: projects.organizationId,
           clawId: claws.id,
           ownerId: users.id,
           ownerEmail: users.email,
@@ -728,8 +736,8 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
           ownerDeletedAt: users.deletedAt,
         })
         .from(apiKeys)
-        .innerJoin(environments, eq(apiKeys.environmentId, environments.id))
-        .innerJoin(projects, eq(environments.projectId, projects.id))
+        .leftJoin(environments, eq(apiKeys.environmentId, environments.id))
+        .leftJoin(projects, eq(environments.projectId, projects.id))
         .innerJoin(users, eq(apiKeys.ownerId, users.id))
         .leftJoin(claws, eq(claws.botUserId, users.id))
         .where(
@@ -750,10 +758,47 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
           ),
         );
 
-      if (!apiKeyInfo) {
+      if (!row) {
         return yield* Effect.fail(
           new NotFoundError({
             message: "Invalid API key or owner not found",
+            resource: this.getResourceName(),
+          }),
+        );
+      }
+
+      // Build the typed ApiKeyAuth based on scope
+      const base = {
+        apiKeyId: row.apiKeyId,
+        clawId: row.clawId,
+        ownerId: row.ownerId,
+        ownerEmail: row.ownerEmail,
+        ownerName: row.ownerName,
+        ownerAccountType: row.ownerAccountType,
+        ownerDeletedAt: row.ownerDeletedAt,
+      };
+
+      let apiKeyInfo: ApiKeyAuth;
+      if (row.environmentId && row.projectId && row.projectOrgId) {
+        // Environment-scoped key
+        apiKeyInfo = {
+          ...base,
+          organizationId: row.projectOrgId,
+          environmentId: row.environmentId,
+          projectId: row.projectId,
+        } satisfies EnvironmentApiKeyAuth;
+      } else if (row.organizationId) {
+        // Org-scoped key
+        apiKeyInfo = {
+          ...base,
+          organizationId: row.organizationId,
+          environmentId: null,
+        } satisfies OrgApiKeyAuth;
+      } else {
+        // Should not happen — CHECK constraint enforces one scope
+        return yield* Effect.fail(
+          new NotFoundError({
+            message: "API key has invalid scope — neither env nor org",
             resource: this.getResourceName(),
           }),
         );
@@ -763,7 +808,7 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
       yield* client
         .update(apiKeys)
         .set({ lastUsedAt: new Date() })
-        .where(eq(apiKeys.id, apiKeyInfo.apiKeyId))
+        .where(eq(apiKeys.id, row.apiKeyId))
         .pipe(
           Effect.mapError(
             (e) =>
@@ -839,8 +884,8 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
       const isOrgAdmin =
         orgMembership.role === "OWNER" || orgMembership.role === "ADMIN";
 
-      // Build the query for API keys with context
-      const baseQuery = client
+      // Query environment-scoped keys with project/environment context
+      const envKeysQuery = client
         .select({
           id: apiKeys.id,
           name: apiKeys.name,
@@ -861,11 +906,32 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
         .innerJoin(projects, eq(environments.projectId, projects.id))
         .innerJoin(users, eq(apiKeys.ownerId, users.id));
 
-      let results: ApiKeyWithContext[];
+      // Query org-scoped keys (only visible to org admins)
+      const orgKeysQuery = client
+        .select({
+          id: apiKeys.id,
+          name: apiKeys.name,
+          keyPrefix: apiKeys.keyPrefix,
+          environmentId: apiKeys.environmentId,
+          organizationId: apiKeys.organizationId,
+          ownerId: apiKeys.ownerId,
+          createdAt: apiKeys.createdAt,
+          lastUsedAt: apiKeys.lastUsedAt,
+          deletedAt: apiKeys.deletedAt,
+          organizationName: organizations.name,
+          ownerName: users.name,
+          ownerAccountType: users.accountType,
+        })
+        .from(apiKeys)
+        .innerJoin(organizations, eq(apiKeys.organizationId, organizations.id))
+        .innerJoin(users, eq(apiKeys.ownerId, users.id));
+
+      const results: ApiKeyWithContext[] = [];
 
       if (isOrgAdmin) {
         // Org OWNER/ADMIN can see all API keys in the organization
-        results = yield* baseQuery
+        // INNER JOIN on environments guarantees environmentId is non-null
+        const envKeys = yield* envKeysQuery
           .where(
             and(
               eq(projects.organizationId, organizationId),
@@ -876,11 +942,40 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
             Effect.mapError(
               (e) =>
                 new DatabaseError({
-                  message: "Failed to find API keys for organization",
+                  message: "Failed to find env API keys for organization",
                   cause: e,
                 }),
             ),
           );
+        results.push(...(envKeys as unknown as EnvironmentApiKeyWithContext[]));
+
+        // Org-scoped keys
+        const orgKeys = yield* orgKeysQuery
+          .where(
+            and(
+              eq(apiKeys.organizationId, organizationId),
+              isNull(apiKeys.deletedAt),
+            ),
+          )
+          .pipe(
+            Effect.mapError(
+              (e) =>
+                new DatabaseError({
+                  message: "Failed to find org API keys for organization",
+                  cause: e,
+                }),
+            ),
+          );
+        results.push(
+          ...orgKeys.map(
+            (k) =>
+              ({
+                ...k,
+                organizationId: k.organizationId!,
+                environmentId: k.environmentId as null,
+              }) satisfies ApiKeyWithContext,
+          ),
+        );
       } else {
         // Get projects where the user has ADMIN or DEVELOPER role
         const userProjectMemberships = yield* client
@@ -910,28 +1005,31 @@ export class ApiKeys extends BaseAuthenticatedEffectService<
           (m) => m.projectId,
         );
 
-        if (accessibleProjectIds.length === 0) {
-          return [];
-        }
-
-        // Get API keys for accessible projects only
-        results = yield* baseQuery
-          .where(
-            and(
-              eq(projects.organizationId, organizationId),
-              inArray(projects.id, accessibleProjectIds),
-              isNull(apiKeys.deletedAt),
-            ),
-          )
-          .pipe(
-            Effect.mapError(
-              (e) =>
-                new DatabaseError({
-                  message: "Failed to find API keys for organization",
-                  cause: e,
-                }),
-            ),
+        if (accessibleProjectIds.length > 0) {
+          // Get env-scoped API keys for accessible projects only
+          // INNER JOIN on environments guarantees environmentId is non-null
+          const envKeys = yield* envKeysQuery
+            .where(
+              and(
+                eq(projects.organizationId, organizationId),
+                inArray(projects.id, accessibleProjectIds),
+                isNull(apiKeys.deletedAt),
+              ),
+            )
+            .pipe(
+              Effect.mapError(
+                (e) =>
+                  new DatabaseError({
+                    message: "Failed to find API keys for organization",
+                    cause: e,
+                  }),
+              ),
+            );
+          results.push(
+            ...(envKeys as unknown as EnvironmentApiKeyWithContext[]),
           );
+        }
+        // Non-admin members cannot see org-scoped keys
       }
 
       return results;

--- a/cloud/db/migrations/0010_org_scoped_api_keys.sql
+++ b/cloud/db/migrations/0010_org_scoped_api_keys.sql
@@ -1,0 +1,13 @@
+-- Add organization_id column for org-scoped API keys.
+-- Environment-scoped keys have environment_id set (existing behavior).
+-- Org-scoped keys have organization_id set and environment_id NULL.
+-- Exactly one of environment_id or organization_id must be set.
+
+ALTER TABLE "api_keys" ALTER COLUMN "environment_id" DROP NOT NULL;
+ALTER TABLE "api_keys" ADD COLUMN "organization_id" uuid REFERENCES "organizations"("id") ON DELETE CASCADE;
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_scope_check" CHECK (
+  (environment_id IS NOT NULL AND organization_id IS NULL) OR
+  (environment_id IS NULL AND organization_id IS NOT NULL)
+);
+-- Unique name within org for org-scoped keys (mirrors env-scoped unique constraint)
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_organization_id_name_unique" UNIQUE ("organization_id", "name");

--- a/cloud/db/migrations/meta/_journal.json
+++ b/cloud/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1770861548027,
       "tag": "0009_living_doctor_strange",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1739404800000,
+      "tag": "0010_org_scoped_api_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/cloud/db/schema/index.ts
+++ b/cloud/db/schema/index.ts
@@ -51,6 +51,7 @@ export type {
   OrgPublicApiKey,
   PublicApiKey,
   EnvironmentApiKeyCreateResponse,
+  OrgApiKeyCreateResponse,
   ApiKeyCreateResponse,
   ApiKeyOwner,
   BaseApiKeyAuth,

--- a/cloud/db/schema/index.ts
+++ b/cloud/db/schema/index.ts
@@ -46,8 +46,22 @@ export type {
 } from "@/db/schema/environments";
 export type { PublicTag } from "@/db/schema/tags";
 export type {
+  BasePublicApiKey,
+  EnvironmentPublicApiKey,
+  OrgPublicApiKey,
   PublicApiKey,
+  EnvironmentApiKeyCreateResponse,
   ApiKeyCreateResponse,
+  ApiKeyOwner,
+  BaseApiKeyAuth,
+  EnvironmentApiKeyAuth,
+  OrgApiKeyAuth,
+  ApiKeyAuth,
+  EnvironmentApiKeyInfo,
+  ApiKeyInfo,
+  BaseApiKeyContext,
+  EnvironmentApiKeyWithContext,
+  OrgApiKeyWithContext,
   ApiKeyWithContext,
 } from "@/db/schema/api-keys";
 export type { PublicFunction } from "@/db/schema/functions";

--- a/cloud/tests/api.ts
+++ b/cloud/tests/api.ts
@@ -21,7 +21,11 @@ import type { ModelPricing } from "@/api/router/pricing";
 import type { ProviderName } from "@/api/router/providers";
 import type { StreamMeteringContext } from "@/api/router/streaming";
 import type { AuthResult } from "@/auth/context";
-import type { PublicUser, PublicOrganization, ApiKeyInfo } from "@/db/schema";
+import type {
+  PublicUser,
+  PublicOrganization,
+  EnvironmentApiKeyAuth,
+} from "@/db/schema";
 
 import { Analytics } from "@/analytics";
 import { MirascopeCloudApi, ApiLive } from "@/api/router";
@@ -209,7 +213,7 @@ type ApiClient = Effect.Effect.Success<typeof makeClient>;
 function createTestWebHandler(
   databaseUrl: string,
   user: PublicUser,
-  apiKeyInfo: ApiKeyInfo,
+  apiKeyInfo: EnvironmentApiKeyAuth,
   queueSend: (message: SpansIngestMessage) => Effect.Effect<void, Error>,
   realtimeLayer: Layer.Layer<RealtimeSpans> = DefaultRealtimeLayer,
 ) {
@@ -291,7 +295,7 @@ function createHandlerHttpClient(
 export async function createApiClient(
   databaseUrl: string,
   user: PublicUser,
-  apiKeyInfo: ApiKeyInfo,
+  apiKeyInfo: EnvironmentApiKeyAuth,
   queueSend: (message: SpansIngestMessage) => Effect.Effect<void, Error>,
   realtimeLayer: Layer.Layer<RealtimeSpans> = DefaultRealtimeLayer,
 ): Promise<{ client: ApiClient; dispose: () => Promise<void> }> {
@@ -417,7 +421,7 @@ function createSequentialDescribe(
             },
           });
 
-          const apiKeyInfo: ApiKeyInfo = {
+          const apiKeyInfo: EnvironmentApiKeyAuth = {
             apiKeyId: "00000000-0000-0000-0000-000000000001",
             organizationId: org.id,
             projectId: "00000000-0000-0000-0000-000000000002",

--- a/fern/openapi.json
+++ b/fern/openapi.json
@@ -9026,9 +9026,6 @@
                       "ownerId",
                       "createdAt",
                       "lastUsedAt",
-                      "projectId",
-                      "projectName",
-                      "environmentName",
                       "ownerName",
                       "ownerAccountType"
                     ],
@@ -9043,7 +9040,14 @@
                         "type": "string"
                       },
                       "environmentId": {
-                        "type": "string"
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       },
                       "ownerId": {
                         "type": "string"
@@ -9075,6 +9079,12 @@
                         "type": "string"
                       },
                       "environmentName": {
+                        "type": "string"
+                      },
+                      "organizationId": {
+                        "type": "string"
+                      },
+                      "organizationName": {
                         "type": "string"
                       },
                       "ownerName": {

--- a/fern/openapi.json
+++ b/fern/openapi.json
@@ -9028,7 +9028,9 @@
                       "lastUsedAt",
                       "projectId",
                       "projectName",
-                      "environmentName"
+                      "environmentName",
+                      "ownerName",
+                      "ownerAccountType"
                     ],
                     "properties": {
                       "id": {
@@ -9074,6 +9076,23 @@
                       },
                       "environmentName": {
                         "type": "string"
+                      },
+                      "ownerName": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "ownerAccountType": {
+                        "type": "string",
+                        "enum": [
+                          "user",
+                          "claw"
+                        ]
                       }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
## BLUF
Org-scoped API keys + comprehensive type hierarchy with real discriminated unions. Extracts authentication into a standalone `db.authenticateApiKey()` and renames env-specific code with `Environment` prefix throughout.

## Schema Changes
- **Migration `0010_org_scoped_api_keys.sql`**: `environment_id` nullable, new `organization_id` column
- **CHECK constraint**: exactly one of `environment_id`/`organization_id` must be set
- **Unique constraint**: `(organization_id, name)` for org-scoped key naming

## Type Hierarchy (discriminated on `environmentId`)
- `ApiKeyAuth = EnvironmentApiKeyAuth | OrgApiKeyAuth`
- `PublicApiKey = EnvironmentPublicApiKey | OrgPublicApiKey`
- `ApiKeyWithContext = EnvironmentApiKeyWithContext | OrgApiKeyWithContext`
- `ApiKeyCreateResponse = EnvironmentApiKeyCreateResponse | OrgApiKeyCreateResponse`

## Architecture
- **`db.authenticateApiKey(key)`** — standalone function, not on any CRUD class. Returns the correct union variant.
- **`EnvironmentApiKeys`** class — env-scoped CRUD only (`create`, `findAll`, `findById`, `update`, `delete`)
- **`Authentication.EnvironmentApiKey`** / **`Authentication.OrgApiKey`** — runtime narrowing via `environmentId`

## Naming Convention
All env-specific code uses `Environment` prefix:
- `EnvironmentApiKeys` class, `EnvironmentApiKeysService` interface
- `listEnvironmentApiKeysHandler`, `createEnvironmentApiKeyHandler`, etc.
- `toEnvironmentApiKey`, `toEnvironmentApiKeyCreateResponse`
- Generic code (`listAllApiKeysHandler`, `toApiKeyWithContext`) stays unscoped

## Testing
- **`auth/context.test.ts`**: 9 tests — 3 per accessor (`ApiKey`, `EnvironmentApiKey`, `OrgApiKey`), each testing success, wrong-scope rejection, and no-key
- **`db/api-keys.test.ts`**: `authenticateApiKey` tests updated

Part 1 of 3 in the CLI stack: #2699 → #2695 → #2698