### PR TITLE
feat: pass primary model from claw creation to container env

### DIFF
--- a/cloud/api/claws.handlers.ts
+++ b/cloud/api/claws.handlers.ts
@@ -63,11 +63,15 @@ export const createClawHandler = (
     // Build Mirascope Router base URL for Anthropic-compatible proxy
     const routerBaseUrl = `${settings.siteUrl}/router/v2/anthropic`;
 
+    // Derive the primary model from the request (defaults to haiku for free tier)
+    const primaryModel = payload.model ?? "claude-haiku-4-5";
+
     // Encrypt all container secrets before persisting
     const encrypted = yield* encryptSecrets({
       ANTHROPIC_API_KEY: claw.plaintextApiKey,
       ANTHROPIC_BASE_URL: routerBaseUrl,
       OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+      OPENCLAW_PRIMARY_MODEL: `anthropic/${primaryModel}`,
       OPENCLAW_SITE_URL: settings.siteUrl,
       R2_ACCESS_KEY_ID: status.r2Credentials?.accessKeyId ?? "",
       R2_SECRET_ACCESS_KEY: status.r2Credentials?.secretAccessKey ?? "",


### PR DESCRIPTION
- Add OPENCLAW_PRIMARY_MODEL to encrypted containerEnv at claw creation
- Startup script reads model from env instead of hardcoding
- Remove hardcoded timestamp-versioned model IDs and aliases
- Default to anthropic/claude-haiku-4-5 when no model specified
- Free→haiku, Pro→sonnet, Team→sonnet (set in create-claw-modal)