### PR TITLE
fix(cloud): optimistic cache for org create/delete and onboarding

### DIFF
--- a/cloud/app/api/claws.ts
+++ b/cloud/app/api/claws.ts
@@ -299,3 +299,4 @@ export const useRestartClaw = () => {
     }),
   });
 };
+// test

--- a/cloud/app/api/onboarding.ts
+++ b/cloud/app/api/onboarding.ts
@@ -112,6 +112,12 @@ export const useCompleteOnboarding = () => {
       return result.data;
     },
     onSuccess: (data) => {
+      // Cancel in-flight queries so they don't overwrite our optimistic insert
+      void queryClient.cancelQueries({ queryKey: ["organizations"] });
+      void queryClient.cancelQueries({
+        queryKey: ["claws", data.organization.id],
+      });
+
       // Optimistically insert into cache to prevent "not found" flash on navigation
       queryClient.setQueryData(
         ["organizations"],


### PR DESCRIPTION
- Cancel in-flight queries before optimistic cache inserts (prevents
  stale data from overwriting the insert)
- Add full optimistic update pattern to useDeleteOrganization
- Fix org creation 'not found' flash on navigation
- Fix onboarding claw creation cache race