### PR TITLE
fix: add missing cache invalidation and redirect guards

### DIFF
--- a/cloud/app/api/claws.ts
+++ b/cloud/app/api/claws.ts
@@ -283,6 +283,8 @@ export const useUpdateClawSecrets = () => {
 };
 
 export const useRestartClaw = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     ...eq.mutationOptions({
       mutationKey: ["claws", "restart"],
@@ -297,5 +299,11 @@ export const useRestartClaw = () => {
           });
         }),
     }),
+    onSuccess: (_, variables) => {
+      // Refetch claws to pick up status changes (e.g. provisioning)
+      void queryClient.invalidateQueries({
+        queryKey: ["claws", variables.organizationId],
+      });
+    },
   });
 };

--- a/cloud/app/routes/settings/organizations/$orgSlug/projects/$projectSlug.tsx
+++ b/cloud/app/routes/settings/organizations/$orgSlug/projects/$projectSlug.tsx
@@ -41,6 +41,17 @@ function ProjectSettingsPage() {
 
   const project = projects.find((p) => p.slug === projectSlug);
 
+  // If project was deleted (optimistic removal), redirect to projects list
+  useEffect(() => {
+    if (!isLoading && !project) {
+      setShowDeleteModal(false);
+      void navigate({
+        to: "/settings/organizations/$orgSlug/projects",
+        params: { orgSlug },
+      });
+    }
+  }, [project, isLoading, navigate, orgSlug]);
+
   // Sync URL project to context
   useEffect(() => {
     if (project && selectedProject?.id !== project.id) {
@@ -140,27 +151,10 @@ function ProjectSettingsPage() {
     );
   }
 
+  // Don't render settings for a project that no longer exists
+  // (redirect effect above will navigate away)
   if (!project) {
-    return (
-      <div className="max-w-2xl">
-        {header}
-        <div className="flex justify-center pt-12">
-          <div className="text-muted-foreground">
-            Project not found: {projectSlug}
-          </div>
-        </div>
-        <CreateProjectModal
-          open={showCreateModal}
-          onOpenChange={setShowCreateModal}
-          onCreated={(p) => {
-            void navigate({
-              to: "/settings/organizations/$orgSlug/projects/$projectSlug",
-              params: { orgSlug, projectSlug: p.slug },
-            });
-          }}
-        />
-      </div>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
Follow-up from the delete claw modal loop fix. Audit found two remaining gaps:

1. **`$projectSlug.tsx`** — No redirect when project is removed from cache after deletion. Added `useEffect` that detects project removal and redirects to projects list (same pattern as `$clawSlug.tsx`). Replaced the stale "Project not found" UI with `return null` during the transition.

2. **`useRestartClaw`** — No cache invalidation after restart. Added `onSuccess` handler that invalidates the claws query so the UI reflects status changes (e.g. provisioning).