### PR TITLE
feat(byok): add BYOK key management API endpoints

### DIFF
--- a/cloud/api/api.ts
+++ b/cloud/api/api.ts
@@ -11,6 +11,7 @@ import { HealthApi } from "@/api/health.schemas";
 import { OrganizationInvitationsApi } from "@/api/organization-invitations.schemas";
 import { OrganizationMembershipsApi } from "@/api/organization-memberships.schemas";
 import { OrganizationsApi } from "@/api/organizations.schemas";
+import { ProjectApiKeysApi } from "@/api/project-api-keys.schemas";
 import { ProjectMembershipsApi } from "@/api/project-memberships.schemas";
 import { ProjectsApi } from "@/api/projects.schemas";
 import { TagsApi } from "@/api/tags.schemas";
@@ -29,6 +30,7 @@ export * from "@/api/projects.schemas";
 export * from "@/api/project-memberships.schemas";
 export * from "@/api/environments.schemas";
 export * from "@/api/api-keys.schemas";
+export * from "@/api/project-api-keys.schemas";
 export * from "@/api/functions.schemas";
 export * from "@/api/annotations.schemas";
 export * from "@/api/claw-memberships.schemas";
@@ -48,6 +50,7 @@ export class MirascopeCloudApi extends HttpApi.make("MirascopeCloudApi")
   .add(ProjectMembershipsApi)
   .add(EnvironmentsApi)
   .add(ApiKeysApi)
+  .add(ProjectApiKeysApi)
   .add(FunctionsApi)
   .add(AnnotationsApi)
   .add(ClawsApi)

--- a/cloud/api/project-api-keys.handlers.ts
+++ b/cloud/api/project-api-keys.handlers.ts
@@ -1,0 +1,107 @@
+import { Effect } from "effect";
+
+import type { SetProjectApiKeyRequest } from "@/api/project-api-keys.schemas";
+import type { ProviderName } from "@/api/router/providers";
+
+import { AuthenticatedUser } from "@/auth";
+import { OrganizationMemberships } from "@/db/organization-memberships";
+import { ProjectApiKeys } from "@/db/project-api-keys";
+import { ProjectMemberships } from "@/db/project-memberships";
+import { PlanLimitExceededError } from "@/errors";
+import { Payments } from "@/payments";
+
+export * from "@/api/project-api-keys.schemas";
+
+/**
+ * Verify the organization is on a Pro or Team plan.
+ * Free tier users cannot manage BYOK keys.
+ */
+const requirePaidPlan = (organizationId: string) =>
+  Effect.gen(function* () {
+    const payments = yield* Payments;
+    const planTier =
+      yield* payments.customers.subscriptions.getPlan(organizationId);
+    if (planTier === "free") {
+      return yield* Effect.fail(
+        new PlanLimitExceededError({
+          message:
+            "BYOK (Bring Your Own Key) requires a Pro or Team plan. Upgrade to use your own API keys.",
+          resource: "project_api_keys",
+          limitType: "byok",
+          currentUsage: 0,
+          limit: 0,
+          planTier,
+        }),
+      );
+    }
+    return planTier;
+  });
+
+/**
+ * Create the ProjectApiKeys service instance.
+ * Instantiated per-request since it depends on membership services.
+ */
+const createService = () => {
+  const orgMemberships = new OrganizationMemberships();
+  const projectMemberships = new ProjectMemberships(orgMemberships);
+  return new ProjectApiKeys(projectMemberships);
+};
+
+export const listProjectApiKeysHandler = (
+  organizationId: string,
+  projectId: string,
+) =>
+  Effect.gen(function* () {
+    yield* requirePaidPlan(organizationId);
+    const user = yield* AuthenticatedUser;
+    const service = createService();
+    const keys = yield* service.list({
+      userId: user.id,
+      organizationId,
+      projectId,
+    });
+    return keys.map((k) => ({
+      ...k,
+      updatedAt: k.updatedAt?.toISOString() ?? new Date().toISOString(),
+    }));
+  });
+
+export const setProjectApiKeyHandler = (
+  organizationId: string,
+  projectId: string,
+  provider: string,
+  payload: SetProjectApiKeyRequest,
+) =>
+  Effect.gen(function* () {
+    yield* requirePaidPlan(organizationId);
+    const user = yield* AuthenticatedUser;
+    const service = createService();
+    const result = yield* service.set({
+      userId: user.id,
+      organizationId,
+      projectId,
+      provider: provider as ProviderName,
+      key: payload.key,
+    });
+    return {
+      ...result,
+      updatedAt: result.updatedAt?.toISOString() ?? new Date().toISOString(),
+    };
+  });
+
+export const deleteProjectApiKeyHandler = (
+  organizationId: string,
+  projectId: string,
+  provider: string,
+) =>
+  Effect.gen(function* () {
+    yield* requirePaidPlan(organizationId);
+    const user = yield* AuthenticatedUser;
+    const service = createService();
+    yield* service.delete({
+      userId: user.id,
+      organizationId,
+      projectId,
+      provider: provider as ProviderName,
+    });
+  });

--- a/cloud/api/project-api-keys.schemas.ts
+++ b/cloud/api/project-api-keys.schemas.ts
@@ -1,0 +1,92 @@
+import { HttpApiEndpoint, HttpApiGroup } from "@effect/platform";
+import { Schema } from "effect";
+
+import {
+  DatabaseError,
+  NotFoundError,
+  PermissionDeniedError,
+  PlanLimitExceededError,
+  StripeError,
+} from "@/errors";
+
+const ProviderSchema = Schema.Literal("anthropic", "openai", "google");
+
+export const ProjectApiKeySchema = Schema.Struct({
+  provider: Schema.String,
+  keySuffix: Schema.String,
+  updatedAt: Schema.String,
+});
+
+export const SetProjectApiKeyRequestSchema = Schema.Struct({
+  key: Schema.String.pipe(
+    Schema.minLength(1, { message: () => "API key is required" }),
+  ),
+});
+
+export type SetProjectApiKeyRequest = typeof SetProjectApiKeyRequestSchema.Type;
+
+export class ProjectApiKeysApi extends HttpApiGroup.make("projectApiKeys")
+  .add(
+    HttpApiEndpoint.get(
+      "list",
+      "/organizations/:organizationId/projects/:projectId/api-keys",
+    )
+      .setPath(
+        Schema.Struct({
+          organizationId: Schema.String,
+          projectId: Schema.String,
+        }),
+      )
+      .addSuccess(Schema.Array(ProjectApiKeySchema))
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(PlanLimitExceededError, {
+        status: PlanLimitExceededError.status,
+      })
+      .addError(StripeError, { status: StripeError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.put(
+      "set",
+      "/organizations/:organizationId/projects/:projectId/api-keys/:provider",
+    )
+      .setPath(
+        Schema.Struct({
+          organizationId: Schema.String,
+          projectId: Schema.String,
+          provider: ProviderSchema,
+        }),
+      )
+      .setPayload(SetProjectApiKeyRequestSchema)
+      .addSuccess(ProjectApiKeySchema)
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(PlanLimitExceededError, {
+        status: PlanLimitExceededError.status,
+      })
+      .addError(StripeError, { status: StripeError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.del(
+      "delete",
+      "/organizations/:organizationId/projects/:projectId/api-keys/:provider",
+    )
+      .setPath(
+        Schema.Struct({
+          organizationId: Schema.String,
+          projectId: Schema.String,
+          provider: ProviderSchema,
+        }),
+      )
+      .addSuccess(Schema.Void)
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(PlanLimitExceededError, {
+        status: PlanLimitExceededError.status,
+      })
+      .addError(StripeError, { status: StripeError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .prefix("/api/v2") {}

--- a/cloud/api/router.ts
+++ b/cloud/api/router.ts
@@ -83,6 +83,11 @@ import {
   updateAutoReloadSettingsHandler,
 } from "@/api/organizations.handlers";
 import {
+  listProjectApiKeysHandler,
+  setProjectApiKeyHandler,
+  deleteProjectApiKeyHandler,
+} from "@/api/project-api-keys.handlers";
+import {
   listProjectMembersHandler,
   addProjectMemberHandler,
   updateProjectMemberRoleHandler,
@@ -582,6 +587,31 @@ const TokenCostHandlersLive = HttpApiBuilder.group(
     ),
 );
 
+const ProjectApiKeysHandlersLive = HttpApiBuilder.group(
+  MirascopeCloudApi,
+  "projectApiKeys",
+  (handlers) =>
+    handlers
+      .handle("list", ({ path }) =>
+        listProjectApiKeysHandler(path.organizationId, path.projectId),
+      )
+      .handle("set", ({ path, payload }) =>
+        setProjectApiKeyHandler(
+          path.organizationId,
+          path.projectId,
+          path.provider,
+          payload,
+        ),
+      )
+      .handle("delete", ({ path }) =>
+        deleteProjectApiKeyHandler(
+          path.organizationId,
+          path.projectId,
+          path.provider,
+        ),
+      ),
+);
+
 export const ApiLive = HttpApiBuilder.api(MirascopeCloudApi).pipe(
   Layer.provide(HealthHandlersLive),
   Layer.provide(TracesHandlersLive),
@@ -593,6 +623,7 @@ export const ApiLive = HttpApiBuilder.api(MirascopeCloudApi).pipe(
   Layer.provide(ProjectMembershipsHandlersLive),
   Layer.provide(EnvironmentsHandlersLive),
   Layer.provide(ApiKeysHandlersLive),
+  Layer.provide(ProjectApiKeysHandlersLive),
   Layer.provide(FunctionsHandlersLive),
   Layer.provide(AnnotationsHandlersLive),
   Layer.provide(ClawsHandlersLive),


### PR DESCRIPTION
- PUT /api/v2/organizations/:orgId/projects/:projectId/api-keys/:provider
- DELETE /api/v2/organizations/:orgId/projects/:projectId/api-keys/:provider
- GET /api/v2/organizations/:orgId/projects/:projectId/api-keys
- All endpoints require Pro/Team plan + project ADMIN role
- Provider validated as anthropic | openai | google
- Never returns full key — only keySuffix (last 4 chars)