### PR TITLE
feat(dispatch-worker): add deploy fingerprint for stale deployment detection

### DIFF
--- a/cloud/claws/dispatch-worker/package.json
+++ b/cloud/claws/dispatch-worker/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --define __BUILD_TIMESTAMP__:\"\\\"$(date -u +%FT%TZ)\\\"\" --define __GIT_SHA__:\"\\\"$(git rev-parse --short HEAD)\\\"\"",
     "types": "wrangler types",
     "typecheck": "tsc --noEmit",
     "lint:oxlint": "oxlint .",

--- a/cloud/claws/dispatch-worker/src/fingerprint.ts
+++ b/cloud/claws/dispatch-worker/src/fingerprint.ts
@@ -1,0 +1,154 @@
+/**
+ * Deploy fingerprint — generates a human-readable label for each deployment.
+ *
+ * Uses build-time injected values (__BUILD_TIMESTAMP__, __GIT_SHA__) when
+ * available, falling back to runtime values for local development.
+ */
+
+const ADJECTIVES = [
+  "sparkling",
+  "crimson",
+  "silent",
+  "golden",
+  "swift",
+  "ancient",
+  "blazing",
+  "cosmic",
+  "dancing",
+  "eager",
+  "fierce",
+  "gentle",
+  "hidden",
+  "icy",
+  "jolly",
+  "keen",
+  "luminous",
+  "mystic",
+  "noble",
+  "opaque",
+  "patient",
+  "quiet",
+  "radiant",
+  "stellar",
+  "tender",
+  "umbral",
+  "vivid",
+  "wistful",
+  "xenial",
+  "yielding",
+  "zealous",
+  "amber",
+  "bold",
+  "calm",
+  "dusky",
+  "emerald",
+  "frosty",
+  "gusty",
+  "hazy",
+  "iron",
+  "jade",
+  "kindled",
+  "lunar",
+  "mellow",
+  "nimble",
+  "ochre",
+  "plucky",
+  "quartz",
+  "rustic",
+  "sapphire",
+] as const;
+
+const ANIMALS = [
+  "eagle",
+  "fox",
+  "otter",
+  "hawk",
+  "dingo",
+  "ibis",
+  "panda",
+  "lynx",
+  "raven",
+  "cobra",
+  "bison",
+  "crane",
+  "drake",
+  "finch",
+  "gecko",
+  "heron",
+  "impala",
+  "jackal",
+  "koala",
+  "lemur",
+  "marten",
+  "newt",
+  "osprey",
+  "puffin",
+  "quail",
+  "robin",
+  "shrike",
+  "toucan",
+  "urchin",
+  "viper",
+  "walrus",
+  "xerus",
+  "yak",
+  "zebu",
+  "axolotl",
+  "badger",
+  "condor",
+  "dugong",
+  "ermine",
+  "falcon",
+  "grouse",
+  "hoopoe",
+  "iguana",
+  "jaybird",
+  "kiwi",
+  "lark",
+  "myna",
+  "narwhal",
+  "ocelot",
+  "pelican",
+] as const;
+
+/** Simple hash: sum of char codes. */
+function simpleHash(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash += input.charCodeAt(i);
+  }
+  return hash;
+}
+
+declare const __BUILD_TIMESTAMP__: string | undefined;
+declare const __GIT_SHA__: string | undefined;
+
+interface DeployFingerprint {
+  label: string;
+  timestamp: string;
+  sha: string;
+  display: string;
+}
+
+function getFingerprint(): DeployFingerprint {
+  const timestamp =
+    typeof __BUILD_TIMESTAMP__ !== "undefined"
+      ? __BUILD_TIMESTAMP__
+      : new Date().toISOString();
+  const sha = typeof __GIT_SHA__ !== "undefined" ? __GIT_SHA__ : "dev";
+
+  const hash = simpleHash(timestamp + sha);
+  const adjective = ADJECTIVES[hash % ADJECTIVES.length];
+  const animal = ANIMALS[hash % ANIMALS.length];
+  const label = `${adjective} ${animal}`;
+
+  return {
+    label,
+    timestamp,
+    sha,
+    display: `${label} — ${timestamp} (${sha})`,
+  };
+}
+
+/** Computed once on import. */
+export const BUILD_FINGERPRINT: DeployFingerprint = getFingerprint();

--- a/cloud/claws/dispatch-worker/src/handler.ts
+++ b/cloud/claws/dispatch-worker/src/handler.ts
@@ -29,6 +29,7 @@ import {
   reportClawStatus,
 } from "./bootstrap";
 import { getCachedConfig, setCachedConfig } from "./cache";
+import { BUILD_FINGERPRINT } from "./fingerprint";
 import { createLogger, type Logger } from "./logger";
 import {
   findGatewayProcess,
@@ -139,7 +140,10 @@ export async function handleProxy(
   const env = c.env;
 
   const log = createLogger({ clawId, debug: !!env.DEBUG });
-  log.info("req", `${c.req.method} ${c.req.path} (path-based)`);
+  log.info(
+    "req",
+    `${c.req.method} ${c.req.path} [${BUILD_FINGERPRINT.display}]`,
+  );
 
   const sandbox = getSandbox(env.Sandbox, clawId, { keepAlive: true });
   c.set("sandbox", sandbox);

--- a/cloud/claws/dispatch-worker/src/proxy.ts
+++ b/cloud/claws/dispatch-worker/src/proxy.ts
@@ -13,6 +13,7 @@ import type { Logger } from "./logger";
 import type { DispatchEnv, OpenClawDeployConfig } from "./types";
 
 import { GATEWAY_PORT, STARTUP_TIMEOUT_MS } from "./config";
+import { BUILD_FINGERPRINT } from "./fingerprint";
 import { createLogger, redactUrl, summarizeEnvKeys } from "./logger";
 
 /**
@@ -132,7 +133,10 @@ export async function ensureGateway(
   }
 
   // Start new gateway
-  l.info("gateway", `starting new gateway for claw: ${config.clawId}`);
+  l.info(
+    "gateway",
+    `starting new gateway for claw: ${config.clawId} [${BUILD_FINGERPRINT.display}]`,
+  );
   const envVars = buildEnvVars(config, env);
   const command = "bun /opt/openclaw/start-openclaw.ts";
 

--- a/cloud/claws/dispatch-worker/start-openclaw.ts
+++ b/cloud/claws/dispatch-worker/start-openclaw.ts
@@ -362,7 +362,11 @@ export function createOpenClawConfig(
 // Main startup sequence
 // ============================================================
 
+// Import fingerprint for startup logging
+import { BUILD_FINGERPRINT } from "./src/fingerprint";
+
 log("=== OpenClaw startup script begin ===");
+log(`Deploy fingerprint: ${BUILD_FINGERPRINT.display}`);
 
 // ============================================================
 // 0. Configure rclone for R2 (if credentials available)


### PR DESCRIPTION
Adds a deploy fingerprint system for detecting stale or mismatched deployments. Each deploy gets a human-readable label (e.g. "sparkling eagle") derived from the build timestamp and git SHA, plus the raw values for precise comparison.

The fingerprint is logged on every proxied request and gateway startup, making it easy to tell at a glance which version is running and whether a deployment is stale.

**Build-time injection:** The `deploy` script passes `--define` flags to wrangler so `__BUILD_TIMESTAMP__` and `__GIT_SHA__` are compiled in at deploy time. In local dev, falls back to runtime values.