### PR TITLE
fix(dispatch-worker): include dispatch worker domain in allowed origins

### DIFF
--- a/cloud/claws/dispatch-worker/src/proxy.ts
+++ b/cloud/claws/dispatch-worker/src/proxy.ts
@@ -75,7 +75,10 @@ export function buildEnvVars(
     envVars.CLOUDFLARE_ACCOUNT_ID = env.CLOUDFLARE_ACCOUNT_ID;
   if (env.SITE_URL) {
     envVars.OPENCLAW_SITE_URL = env.SITE_URL;
-    envVars.OPENCLAW_ALLOWED_ORIGINS = env.SITE_URL;
+    // Allow both the main site and the dispatch worker domain (openclaw.{domain})
+    const siteUrl = new URL(env.SITE_URL);
+    const dispatchOrigin = `${siteUrl.protocol}//openclaw.${siteUrl.host}`;
+    envVars.OPENCLAW_ALLOWED_ORIGINS = `${env.SITE_URL},${dispatchOrigin}`;
   }
 
   // R2 persistence credentials (used by rclone in start-openclaw.ts)


### PR DESCRIPTION
The gateway's `allowedOrigins` was only set to `SITE_URL` (the main app domain). WebSocket upgrades that arrive directly at the dispatch worker domain (`openclaw.{domain}`) were rejected because their Origin didn't match.

Now computes the dispatch worker's origin from `SITE_URL` and includes both in `OPENCLAW_ALLOWED_ORIGINS`.