### PR TITLE
fix(dispatch-worker): disable device auth for managed containers

### DIFF
--- a/cloud/claws/dispatch-worker/start-openclaw.ts
+++ b/cloud/claws/dispatch-worker/start-openclaw.ts
@@ -242,7 +242,11 @@ export function createOpenClawConfig(
     allowedOrigins.push(env.OPENCLAW_SITE_URL);
   }
 
-  config.gateway.controlUi = { allowedOrigins };
+  config.gateway.controlUi = {
+    ...((config.gateway.controlUi as object) ?? {}),
+    dangerouslyDisableDeviceAuth: true,
+    allowedOrigins,
+  };
 
   // Anthropic provider configuration
   const baseUrl = env.ANTHROPIC_BASE_URL.replace(/\/+$/, "");


### PR DESCRIPTION
Managed containers run behind the dispatch worker's auth layer — users are already authenticated before traffic reaches the gateway. The gateway's device auth flow (pairing codes) is designed for direct-access scenarios and doesn't make sense here.

Sets `dangerouslyDisableDeviceAuth: true` in the generated OpenClaw config so managed claws skip the device pairing step.