### PR TITLE
feat: add dedicated workspace provisioning via Google Admin SDK

### DIFF
--- a/cloud/integrations/dedicated-workspace/auth.test.ts
+++ b/cloud/integrations/dedicated-workspace/auth.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect } from "@effect/vitest";
+import { Effect, Either } from "effect";
+import { afterEach, beforeEach, vi } from "vitest";
+
+import {
+  DedicatedWorkspaceAuthError,
+  MissingConfigError,
+  getAccessToken,
+} from "@/integrations/dedicated-workspace/auth";
+import { MockSettingsLayer } from "@/tests/settings";
+
+// Valid RSA private key in PKCS8 PEM format generated for unit tests only.
+const TEST_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCV0J6OqdZtDWtc
+ZTHfey9xVwZn4Ja+3MSPtkM93MxqaQYutkNoLeY89K7DedQnYTcAv4I4Z4USjmxp
+8IecJTvEzNwFWm2GWoJeVQHyMScDqymW/qNrJSumM1a+qutLKITK+IK8aTsVOwi2
+0KpD1hjryIR7zAkNA7rW7WtwATRgd1V8EZrQ3DaNd1rBHtRnCyHGPxjjNYGCXDf9
+BenTlFH+Sg/6uPTkHlzDEnfHU70NcXTRwz5XchGy8uqGG1J0h+bO1KD9XUFy6xP0
+VBcqxeYDy6MIjrN2R0uoVGPJXyiJuHPukH35Kwh40UIcpo8t31XHjQujHZKx1I/C
+Jy5yJq5vAgMBAAECggEAStybBqYGoKrGfb6Re9+V9vhqGolHOqudy0Rj+Gs3eGrv
+rHLmXw4kkUwhckuUAHObJRQNcbsE659gvFV1pkiSw8Ysob4soajjoViwJsJ6AOLM
+XwfySC2kUKIx1AgbmIxwQu6IgbbBz9uWgKfnlQtMm7Gwxh3QXgEBobm06JypfBQR
+SFDpeLSOnvcAPmTKFT6J4oJuEYpTk8ysigfqYwSxdHMByFaKVgknaG4U+E/7DByW
+vkIFHjrZHJ9VuQDLHcb7Jtyf5Y7/ep/046Sx8L7X7Q5dYbmxQ7vy9GcQXKSQ8mX9
+W+1R8kEeH3JDbwS8J7nhpgbagsxQJhfRpEvJngYzRQKBgQDTXRPdmXrIuDdQlrYG
+fmAjuttObcQNrrZ7lbQrr/JDMOqEoKI4Cpl1GqLzfN4pHv9rgTaMZqcc/chkvqYv
+WponAORsVPxHdeJMHK24BBUTpzqiGIMRkwOLpuN1d+k++JAJSTwsLlMUZyQ5Mw+c
+8VPRwR0lr8NoHDbZSRxUg7umZQKBgQC1dAtOtU+OdS0o30xLnMAvA8D/gJVcD8Zk
+s4xyPzQZGqhk/I3XpXL+Cq2A7yjEgqlYB9kX09Cb4rGQqXCIKS7g3kok15phqJUL
+LrV3SHxnCGqaNjcsiojOJeRyYyrA8An/fywl7QMH4JDH2R0ZU5Pzj5zKtuZPCluP
+7PCmHOZ6QwKBgQDImfZYw2n9Rpl5KxDnaNnmD1pFPXhtY/xdnt+49ux/SNXLuok7
+lxO+SOGPJlvTu0+/wIr9BhBlO5gNxcQD/YGAsyAYkTA+wmtcwXs+wuEeHgFQBuOe
+smETEfmfa4c79Lz/kzpA1FaVbq66evO+iGx9D0OSmRZkoSKNZw40SDK44QKBgAf+
+R6088Xc+FDIzvAGssw6fJLZcrLe0fjHbcvlpbVsZwIdKVNlGEY29XK1MW8hkVR9q
+oRaanxru3pGX1Tw6TDVdtXhwAv4AVih680WA7PIA/ekzMDUHGUWzh5++XJjJOjeG
+G6TEDxkevGIBX3XJJ8BX+Dk522Vp+GSbtHIs3b5PAoGBALjstbgj+PQF1re94WgY
+wo6hiqgnepR96zOOduNsoRYMbdZquTLsRyRNr5tN4xA6xhI6akaFN6ONaZXFKeLm
+Tw6zChcGe676iDDVMLUx1Hs+uEB020DW0jwT+PSoFGAqWy3endvslDzhz3OCn02d
+AXkRlstVmZ+ojaI5zpG80Alt
+-----END PRIVATE KEY-----`;
+
+const validSaKeyJson = JSON.stringify({
+  client_email: "sa@test.iam.gserviceaccount.com",
+  private_key: TEST_PRIVATE_KEY,
+  token_uri: "https://oauth2.googleapis.com/token",
+});
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Dedicated Workspace Auth", () => {
+  describe("error classes", () => {
+    it("DedicatedWorkspaceAuthError has correct tag", () => {
+      const error = new DedicatedWorkspaceAuthError({ message: "test" });
+      expect(error._tag).toBe("DedicatedWorkspaceAuthError");
+    });
+
+    it("MissingConfigError has correct tag", () => {
+      const error = new MissingConfigError({ message: "test" });
+      expect(error._tag).toBe("MissingConfigError");
+    });
+  });
+
+  describe("getAccessToken", () => {
+    it.effect("returns MissingConfigError when saKeyJson is not set", () =>
+      Effect.gen(function* () {
+        const result = yield* getAccessToken().pipe(Effect.either);
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("MissingConfigError");
+          expect(result.left.message).toContain(
+            "DEDICATED_WORKSPACE_SA_KEY_JSON",
+          );
+        }
+      }).pipe(
+        Effect.provide(
+          MockSettingsLayer({
+            dedicatedWorkspace: {
+              saKeyJson: undefined,
+              adminEmail: "admin@example.com",
+              domain: "example.com",
+            },
+          }),
+        ),
+      ),
+    );
+
+    it.effect("returns MissingConfigError when adminEmail is not set", () =>
+      Effect.gen(function* () {
+        const result = yield* getAccessToken().pipe(Effect.either);
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("MissingConfigError");
+          expect(result.left.message).toContain(
+            "DEDICATED_WORKSPACE_ADMIN_EMAIL",
+          );
+        }
+      }).pipe(
+        Effect.provide(
+          MockSettingsLayer({
+            dedicatedWorkspace: {
+              saKeyJson: validSaKeyJson,
+              adminEmail: undefined,
+              domain: "example.com",
+            },
+          }),
+        ),
+      ),
+    );
+
+    it.effect("returns MissingConfigError when domain is not set", () =>
+      Effect.gen(function* () {
+        const result = yield* getAccessToken().pipe(Effect.either);
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("MissingConfigError");
+          expect(result.left.message).toContain("DEDICATED_WORKSPACE_DOMAIN");
+        }
+      }).pipe(
+        Effect.provide(
+          MockSettingsLayer({
+            dedicatedWorkspace: {
+              saKeyJson: validSaKeyJson,
+              adminEmail: "admin@example.com",
+              domain: undefined,
+            },
+          }),
+        ),
+      ),
+    );
+
+    it.effect(
+      "returns MissingConfigError listing all missing fields when none are set",
+      () =>
+        Effect.gen(function* () {
+          const result = yield* getAccessToken().pipe(Effect.either);
+          expect(Either.isLeft(result)).toBe(true);
+          if (Either.isLeft(result)) {
+            expect(result.left._tag).toBe("MissingConfigError");
+            expect(result.left.message).toContain(
+              "DEDICATED_WORKSPACE_SA_KEY_JSON",
+            );
+            expect(result.left.message).toContain(
+              "DEDICATED_WORKSPACE_ADMIN_EMAIL",
+            );
+            expect(result.left.message).toContain("DEDICATED_WORKSPACE_DOMAIN");
+          }
+        }).pipe(
+          Effect.provide(
+            MockSettingsLayer({
+              dedicatedWorkspace: {
+                saKeyJson: undefined,
+                adminEmail: undefined,
+                domain: undefined,
+              },
+            }),
+          ),
+        ),
+    );
+
+    it.effect(
+      "returns DedicatedWorkspaceAuthError when saKeyJson is invalid JSON",
+      () =>
+        Effect.gen(function* () {
+          const result = yield* getAccessToken().pipe(Effect.either);
+          expect(Either.isLeft(result)).toBe(true);
+          if (Either.isLeft(result)) {
+            expect(result.left._tag).toBe("DedicatedWorkspaceAuthError");
+            expect(result.left.message).toContain("Failed to parse");
+          }
+        }).pipe(
+          Effect.provide(
+            MockSettingsLayer({
+              dedicatedWorkspace: {
+                saKeyJson: "not-valid-json{{{",
+                adminEmail: "admin@example.com",
+                domain: "example.com",
+              },
+            }),
+          ),
+        ),
+    );
+
+    it.effect(
+      "returns DedicatedWorkspaceAuthError when saKeyJson is missing required fields",
+      () =>
+        Effect.gen(function* () {
+          const result = yield* getAccessToken().pipe(Effect.either);
+          expect(Either.isLeft(result)).toBe(true);
+          if (Either.isLeft(result)) {
+            expect(result.left._tag).toBe("DedicatedWorkspaceAuthError");
+            expect(result.left.message).toContain("missing required fields");
+          }
+        }).pipe(
+          Effect.provide(
+            MockSettingsLayer({
+              dedicatedWorkspace: {
+                saKeyJson: JSON.stringify({ client_email: "test@test.com" }),
+                adminEmail: "admin@example.com",
+                domain: "example.com",
+              },
+            }),
+          ),
+        ),
+    );
+
+    it.effect("returns access token on successful exchange", () =>
+      Effect.gen(function* () {
+        mockFetch.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: "ya29.test-access-token",
+              expires_in: 3600,
+            }),
+          ),
+        );
+
+        const result = yield* getAccessToken();
+        expect(result.accessToken).toBe("ya29.test-access-token");
+        expect(result.expiresIn).toBe(3600);
+
+        // Verify fetch was called with correct endpoint and grant type
+        expect(mockFetch).toHaveBeenCalledWith(
+          "https://oauth2.googleapis.com/token",
+          expect.objectContaining({ method: "POST" }),
+        );
+
+        const callArgs = mockFetch.mock.calls[0] as [string, RequestInit];
+        const body = callArgs[1].body as URLSearchParams;
+        expect(body.get("grant_type")).toBe(
+          "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        );
+        expect(body.get("assertion")).toBeTruthy();
+      }).pipe(
+        Effect.provide(
+          MockSettingsLayer({
+            dedicatedWorkspace: {
+              saKeyJson: validSaKeyJson,
+              adminEmail: "admin@example.com",
+              domain: "example.com",
+            },
+          }),
+        ),
+      ),
+    );
+
+    it.effect("defaults expiresIn to 3600 when not provided", () =>
+      Effect.gen(function* () {
+        mockFetch.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: "ya29.test-access-token",
+            }),
+          ),
+        );
+
+        const result = yield* getAccessToken();
+        expect(result.expiresIn).toBe(3600);
+      }).pipe(
+        Effect.provide(
+          MockSettingsLayer({
+            dedicatedWorkspace: {
+              saKeyJson: validSaKeyJson,
+              adminEmail: "admin@example.com",
+              domain: "example.com",
+            },
+          }),
+        ),
+      ),
+    );
+
+    it.effect(
+      "returns DedicatedWorkspaceAuthError when token exchange returns error",
+      () =>
+        Effect.gen(function* () {
+          mockFetch.mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                error: "invalid_grant",
+                error_description: "Service account not authorized",
+              }),
+            ),
+          );
+
+          const result = yield* getAccessToken().pipe(Effect.either);
+          expect(Either.isLeft(result)).toBe(true);
+          if (Either.isLeft(result)) {
+            expect(result.left._tag).toBe("DedicatedWorkspaceAuthError");
+            expect(result.left.message).toContain(
+              "Service account not authorized",
+            );
+          }
+        }).pipe(
+          Effect.provide(
+            MockSettingsLayer({
+              dedicatedWorkspace: {
+                saKeyJson: validSaKeyJson,
+                adminEmail: "admin@example.com",
+                domain: "example.com",
+              },
+            }),
+          ),
+        ),
+    );
+
+    it.effect(
+      "returns DedicatedWorkspaceAuthError when token exchange returns no access_token",
+      () =>
+        Effect.gen(function* () {
+          mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({})));
+
+          const result = yield* getAccessToken().pipe(Effect.either);
+          expect(Either.isLeft(result)).toBe(true);
+          if (Either.isLeft(result)) {
+            expect(result.left._tag).toBe("DedicatedWorkspaceAuthError");
+            expect(result.left.message).toContain("No access token");
+          }
+        }).pipe(
+          Effect.provide(
+            MockSettingsLayer({
+              dedicatedWorkspace: {
+                saKeyJson: validSaKeyJson,
+                adminEmail: "admin@example.com",
+                domain: "example.com",
+              },
+            }),
+          ),
+        ),
+    );
+
+    it.effect("returns DedicatedWorkspaceAuthError when fetch throws", () =>
+      Effect.gen(function* () {
+        mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+        const result = yield* getAccessToken().pipe(Effect.either);
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("DedicatedWorkspaceAuthError");
+          expect(result.left.message).toContain(
+            "Failed to call token endpoint",
+          );
+        }
+      }).pipe(
+        Effect.provide(
+          MockSettingsLayer({
+            dedicatedWorkspace: {
+              saKeyJson: validSaKeyJson,
+              adminEmail: "admin@example.com",
+              domain: "example.com",
+            },
+          }),
+        ),
+      ),
+    );
+  });
+});

--- a/cloud/integrations/dedicated-workspace/auth.ts
+++ b/cloud/integrations/dedicated-workspace/auth.ts
@@ -1,0 +1,194 @@
+import { Data, Effect } from "effect";
+
+import { Settings } from "@/settings";
+
+export class DedicatedWorkspaceAuthError extends Data.TaggedError(
+  "DedicatedWorkspaceAuthError",
+)<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export class MissingConfigError extends Data.TaggedError("MissingConfigError")<{
+  readonly message: string;
+}> {}
+
+/**
+ * Parsed service account key JSON structure.
+ */
+type ServiceAccountKey = {
+  readonly client_email: string;
+  readonly private_key: string;
+  readonly token_uri: string;
+};
+
+/**
+ * Converts a PEM-encoded RSA private key to a CryptoKey for RS256 signing.
+ */
+function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const pemContents = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, "")
+    .replace(/-----END PRIVATE KEY-----/, "")
+    .replace(/\s/g, "");
+  const binaryDer = Uint8Array.from(atob(pemContents), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    "pkcs8",
+    binaryDer,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+/**
+ * Base64url-encodes a string (no padding).
+ */
+function base64url(input: string): string {
+  return btoa(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Base64url-encodes a Uint8Array (no padding).
+ */
+function base64urlBytes(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Mints an access token for the Google Admin SDK Directory API
+ * using a GCP service account with domain-wide delegation.
+ *
+ * Steps:
+ * 1. Parse the service account JSON from settings
+ * 2. Build a JWT with domain-wide delegation claims (sub = admin email)
+ * 3. Sign with RS256 using Web Crypto API
+ * 4. Exchange for an access token via Google's token endpoint
+ */
+export function getAccessToken(): Effect.Effect<
+  { accessToken: string; expiresIn: number },
+  MissingConfigError | DedicatedWorkspaceAuthError,
+  Settings
+> {
+  return Effect.gen(function* () {
+    const settings = yield* Settings;
+
+    const missingFields: string[] = [];
+    if (!settings.dedicatedWorkspace.saKeyJson) {
+      missingFields.push(
+        "DEDICATED_WORKSPACE_SA_KEY_JSON (dedicatedWorkspace.saKeyJson)",
+      );
+    }
+    if (!settings.dedicatedWorkspace.adminEmail) {
+      missingFields.push(
+        "DEDICATED_WORKSPACE_ADMIN_EMAIL (dedicatedWorkspace.adminEmail)",
+      );
+    }
+    if (!settings.dedicatedWorkspace.domain) {
+      missingFields.push(
+        "DEDICATED_WORKSPACE_DOMAIN (dedicatedWorkspace.domain)",
+      );
+    }
+    if (missingFields.length > 0) {
+      return yield* Effect.fail(
+        new MissingConfigError({
+          message: `Dedicated workspace configuration is incomplete. Missing: ${missingFields.join(", ")}`,
+        }),
+      );
+    }
+
+    // Parse service account key
+    const saKey = yield* Effect.try({
+      try: () =>
+        JSON.parse(settings.dedicatedWorkspace.saKeyJson!) as ServiceAccountKey,
+      catch: () =>
+        new DedicatedWorkspaceAuthError({
+          message: "Failed to parse DEDICATED_WORKSPACE_SA_KEY_JSON",
+        }),
+    });
+
+    if (!saKey.client_email || !saKey.private_key || !saKey.token_uri) {
+      return yield* Effect.fail(
+        new DedicatedWorkspaceAuthError({
+          message:
+            "Service account key missing required fields: client_email, private_key, token_uri",
+        }),
+      );
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const header = { alg: "RS256", typ: "JWT" };
+    const payload = {
+      iss: saKey.client_email,
+      scope: "https://www.googleapis.com/auth/admin.directory.user",
+      sub: settings.dedicatedWorkspace.adminEmail,
+      aud: saKey.token_uri,
+      iat: now,
+      exp: now + 3600,
+    };
+
+    const headerB64 = base64url(JSON.stringify(header));
+    const payloadB64 = base64url(JSON.stringify(payload));
+    const signingInput = `${headerB64}.${payloadB64}`;
+
+    // Sign with RS256
+    const signature = yield* Effect.tryPromise({
+      try: async () => {
+        const key = await importPrivateKey(saKey.private_key);
+        const sig = await crypto.subtle.sign(
+          "RSASSA-PKCS1-v1_5",
+          key,
+          new TextEncoder().encode(signingInput),
+        );
+        return base64urlBytes(new Uint8Array(sig));
+      },
+      catch: (e) =>
+        new DedicatedWorkspaceAuthError({
+          message: "Failed to sign JWT",
+          cause: e,
+        }),
+    });
+
+    const jwt = `${signingInput}.${signature}`;
+
+    // Exchange JWT for access token
+    const tokenResponse = yield* Effect.tryPromise({
+      try: async () => {
+        const response = await fetch(saKey.token_uri, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            assertion: jwt,
+          }),
+        });
+        return (await response.json()) as {
+          access_token?: string;
+          expires_in?: number;
+          error?: string;
+          error_description?: string;
+        };
+      },
+      catch: (e) =>
+        new DedicatedWorkspaceAuthError({
+          message: "Failed to call token endpoint",
+          cause: e,
+        }),
+    });
+
+    if (tokenResponse.error || !tokenResponse.access_token) {
+      return yield* Effect.fail(
+        new DedicatedWorkspaceAuthError({
+          message: `Token exchange failed: ${tokenResponse.error_description || tokenResponse.error || "No access token"}`,
+        }),
+      );
+    }
+
+    return {
+      accessToken: tokenResponse.access_token,
+      expiresIn: tokenResponse.expires_in || 3600,
+    };
+  });
+}

--- a/cloud/integrations/dedicated-workspace/provisioning.test.ts
+++ b/cloud/integrations/dedicated-workspace/provisioning.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect } from "@effect/vitest";
+import { Effect, Either } from "effect";
+import { afterEach, beforeEach, vi } from "vitest";
+
+import {
+  DedicatedWorkspaceProvisioningError,
+  createAccount,
+  deleteAccount,
+  getAccount,
+  listAccounts,
+  suspendAccount,
+} from "@/integrations/dedicated-workspace/provisioning";
+import { MockSettingsLayer } from "@/tests/settings";
+
+// Valid RSA private key in PKCS8 PEM format generated for unit tests only.
+const TEST_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCV0J6OqdZtDWtc
+ZTHfey9xVwZn4Ja+3MSPtkM93MxqaQYutkNoLeY89K7DedQnYTcAv4I4Z4USjmxp
+8IecJTvEzNwFWm2GWoJeVQHyMScDqymW/qNrJSumM1a+qutLKITK+IK8aTsVOwi2
+0KpD1hjryIR7zAkNA7rW7WtwATRgd1V8EZrQ3DaNd1rBHtRnCyHGPxjjNYGCXDf9
+BenTlFH+Sg/6uPTkHlzDEnfHU70NcXTRwz5XchGy8uqGG1J0h+bO1KD9XUFy6xP0
+VBcqxeYDy6MIjrN2R0uoVGPJXyiJuHPukH35Kwh40UIcpo8t31XHjQujHZKx1I/C
+Jy5yJq5vAgMBAAECggEAStybBqYGoKrGfb6Re9+V9vhqGolHOqudy0Rj+Gs3eGrv
+rHLmXw4kkUwhckuUAHObJRQNcbsE659gvFV1pkiSw8Ysob4soajjoViwJsJ6AOLM
+XwfySC2kUKIx1AgbmIxwQu6IgbbBz9uWgKfnlQtMm7Gwxh3QXgEBobm06JypfBQR
+SFDpeLSOnvcAPmTKFT6J4oJuEYpTk8ysigfqYwSxdHMByFaKVgknaG4U+E/7DByW
+vkIFHjrZHJ9VuQDLHcb7Jtyf5Y7/ep/046Sx8L7X7Q5dYbmxQ7vy9GcQXKSQ8mX9
+W+1R8kEeH3JDbwS8J7nhpgbagsxQJhfRpEvJngYzRQKBgQDTXRPdmXrIuDdQlrYG
+fmAjuttObcQNrrZ7lbQrr/JDMOqEoKI4Cpl1GqLzfN4pHv9rgTaMZqcc/chkvqYv
+WponAORsVPxHdeJMHK24BBUTpzqiGIMRkwOLpuN1d+k++JAJSTwsLlMUZyQ5Mw+c
+8VPRwR0lr8NoHDbZSRxUg7umZQKBgQC1dAtOtU+OdS0o30xLnMAvA8D/gJVcD8Zk
+s4xyPzQZGqhk/I3XpXL+Cq2A7yjEgqlYB9kX09Cb4rGQqXCIKS7g3kok15phqJUL
+LrV3SHxnCGqaNjcsiojOJeRyYyrA8An/fywl7QMH4JDH2R0ZU5Pzj5zKtuZPCluP
+7PCmHOZ6QwKBgQDImfZYw2n9Rpl5KxDnaNnmD1pFPXhtY/xdnt+49ux/SNXLuok7
+lxO+SOGPJlvTu0+/wIr9BhBlO5gNxcQD/YGAsyAYkTA+wmtcwXs+wuEeHgFQBuOe
+smETEfmfa4c79Lz/kzpA1FaVbq66evO+iGx9D0OSmRZkoSKNZw40SDK44QKBgAf+
+R6088Xc+FDIzvAGssw6fJLZcrLe0fjHbcvlpbVsZwIdKVNlGEY29XK1MW8hkVR9q
+oRaanxru3pGX1Tw6TDVdtXhwAv4AVih680WA7PIA/ekzMDUHGUWzh5++XJjJOjeG
+G6TEDxkevGIBX3XJJ8BX+Dk522Vp+GSbtHIs3b5PAoGBALjstbgj+PQF1re94WgY
+wo6hiqgnepR96zOOduNsoRYMbdZquTLsRyRNr5tN4xA6xhI6akaFN6ONaZXFKeLm
+Tw6zChcGe676iDDVMLUx1Hs+uEB020DW0jwT+PSoFGAqWy3endvslDzhz3OCn02d
+AXkRlstVmZ+ojaI5zpG80Alt
+-----END PRIVATE KEY-----`;
+
+const validSaKeyJson = JSON.stringify({
+  client_email: "sa@test.iam.gserviceaccount.com",
+  private_key: TEST_PRIVATE_KEY,
+  token_uri: "https://oauth2.googleapis.com/token",
+});
+
+const dedicatedWorkspaceSettings = MockSettingsLayer({
+  dedicatedWorkspace: {
+    saKeyJson: validSaKeyJson,
+    adminEmail: "admin@example.com",
+    domain: "example.com",
+  },
+});
+
+const mockFetch = vi.fn();
+
+/**
+ * Helper: mock the first fetch call (token exchange) to succeed,
+ * then let subsequent calls be handled by individual tests.
+ */
+function mockTokenExchange() {
+  mockFetch.mockResolvedValueOnce(
+    new Response(
+      JSON.stringify({
+        access_token: "ya29.test-token",
+        expires_in: 3600,
+      }),
+    ),
+  );
+}
+
+const mockUser = {
+  id: "user-123",
+  primaryEmail: "my-claw@example.com",
+  name: { fullName: "my-claw Claw" },
+  suspended: false,
+  isAdmin: false,
+  creationTime: "2026-01-01T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Dedicated Workspace Provisioning", () => {
+  describe("error classes", () => {
+    it("DedicatedWorkspaceProvisioningError has correct tag", () => {
+      const error = new DedicatedWorkspaceProvisioningError({
+        message: "test",
+      });
+      expect(error._tag).toBe("DedicatedWorkspaceProvisioningError");
+    });
+  });
+
+  describe("createAccount", () => {
+    it.effect("creates account successfully", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(
+          new Response(JSON.stringify(mockUser), { status: 200 }),
+        );
+
+        const result = yield* createAccount("my-claw");
+        expect(result.email).toBe("my-claw@example.com");
+        expect(result.password).toBeTruthy();
+
+        // Verify the create call was made to the right endpoint
+        const createCall = mockFetch.mock.calls[1] as [string, RequestInit];
+        expect(createCall[0]).toBe(
+          "https://admin.googleapis.com/admin/directory/v1/users",
+        );
+        expect(createCall[1].method).toBe("POST");
+        const body = JSON.parse(createCall[1].body as string) as {
+          primaryEmail: string;
+        };
+        expect(body.primaryEmail).toBe("my-claw@example.com");
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("handles collision by appending suffix", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        // First attempt returns 409 (conflict)
+        mockFetch.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              error: { message: "Entity already exists.", code: 409 },
+            }),
+            { status: 409 },
+          ),
+        );
+        // Second attempt succeeds
+        const user2 = {
+          ...mockUser,
+          primaryEmail: "my-claw-2@example.com",
+        };
+        mockFetch.mockResolvedValueOnce(
+          new Response(JSON.stringify(user2), { status: 200 }),
+        );
+
+        const result = yield* createAccount("my-claw");
+        expect(result.email).toBe("my-claw-2@example.com");
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("returns error when all collision attempts are exhausted", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        // All 10 attempts return 409
+        for (let i = 0; i < 10; i++) {
+          mockFetch.mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                error: { message: "Entity already exists.", code: 409 },
+              }),
+              { status: 409 },
+            ),
+          );
+        }
+
+        const result = yield* createAccount("popular-slug").pipe(Effect.either);
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("DedicatedWorkspaceProvisioningError");
+          expect(result.left.message).toContain("variations");
+        }
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("returns error when API returns non-409 error", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              error: { message: "Quota exceeded", code: 403 },
+            }),
+            { status: 403 },
+          ),
+        );
+
+        const result = yield* createAccount("my-claw").pipe(Effect.either);
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("DedicatedWorkspaceProvisioningError");
+          expect(result.left.message).toContain("Quota exceeded");
+        }
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("returns error when fetch throws", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+        const result = yield* createAccount("my-claw").pipe(Effect.either);
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("DedicatedWorkspaceProvisioningError");
+        }
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+  });
+
+  describe("listAccounts", () => {
+    it.effect("lists accounts successfully", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(
+          new Response(JSON.stringify({ users: [mockUser] })),
+        );
+
+        const result = yield* listAccounts();
+        expect(result).toHaveLength(1);
+        expect(result[0]!.primaryEmail).toBe("my-claw@example.com");
+
+        // Verify domain query parameter
+        const listCall = mockFetch.mock.calls[1] as [string, RequestInit];
+        expect(listCall[0]).toContain("domain=example.com");
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("returns empty array when no users exist", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({})));
+
+        const result = yield* listAccounts();
+        expect(result).toHaveLength(0);
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("returns error when API fails", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              error: { message: "Forbidden", code: 403 },
+            }),
+          ),
+        );
+
+        const result = yield* listAccounts().pipe(Effect.either);
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("DedicatedWorkspaceProvisioningError");
+        }
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+  });
+
+  describe("getAccount", () => {
+    it.effect("gets account successfully", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(mockUser)));
+
+        const result = yield* getAccount("my-claw@example.com");
+        expect(result.primaryEmail).toBe("my-claw@example.com");
+
+        const getCall = mockFetch.mock.calls[1] as [string, RequestInit];
+        expect(getCall[0]).toContain("my-claw%40example.com");
+        expect(getCall[1].method).toBe("GET");
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("returns error when user not found", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              error: { message: "Resource Not Found: userKey", code: 404 },
+            }),
+          ),
+        );
+
+        const result = yield* getAccount("missing@example.com").pipe(
+          Effect.either,
+        );
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("DedicatedWorkspaceProvisioningError");
+          expect(result.left.message).toContain("Resource Not Found");
+        }
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+  });
+
+  describe("suspendAccount", () => {
+    it.effect("suspends account successfully", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        const suspendedUser = { ...mockUser, suspended: true };
+        mockFetch.mockResolvedValueOnce(
+          new Response(JSON.stringify(suspendedUser)),
+        );
+
+        const result = yield* suspendAccount("my-claw@example.com");
+        expect(result.suspended).toBe(true);
+
+        const putCall = mockFetch.mock.calls[1] as [string, RequestInit];
+        expect(putCall[1].method).toBe("PUT");
+        const body = JSON.parse(putCall[1].body as string) as {
+          suspended: boolean;
+        };
+        expect(body.suspended).toBe(true);
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("returns error when suspend fails", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              error: { message: "Forbidden", code: 403 },
+            }),
+          ),
+        );
+
+        const result = yield* suspendAccount("my-claw@example.com").pipe(
+          Effect.either,
+        );
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("DedicatedWorkspaceProvisioningError");
+        }
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+  });
+
+  describe("deleteAccount", () => {
+    it.effect("deletes account successfully", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+        yield* deleteAccount("my-claw@example.com");
+
+        const deleteCall = mockFetch.mock.calls[1] as [string, RequestInit];
+        expect(deleteCall[0]).toContain("my-claw%40example.com");
+        expect(deleteCall[1].method).toBe("DELETE");
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("returns error when delete fails", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              error: { message: "Resource Not Found: userKey", code: 404 },
+            }),
+          ),
+        );
+
+        const result = yield* deleteAccount("missing@example.com").pipe(
+          Effect.either,
+        );
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("DedicatedWorkspaceProvisioningError");
+        }
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+
+    it.effect("returns error when fetch throws during delete", () =>
+      Effect.gen(function* () {
+        mockTokenExchange();
+        mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+        const result = yield* deleteAccount("my-claw@example.com").pipe(
+          Effect.either,
+        );
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe("DedicatedWorkspaceProvisioningError");
+        }
+      }).pipe(Effect.provide(dedicatedWorkspaceSettings)),
+    );
+  });
+});

--- a/cloud/integrations/dedicated-workspace/provisioning.ts
+++ b/cloud/integrations/dedicated-workspace/provisioning.ts
@@ -1,0 +1,272 @@
+import { Data, Effect } from "effect";
+
+import {
+  DedicatedWorkspaceAuthError,
+  MissingConfigError,
+  getAccessToken,
+} from "@/integrations/dedicated-workspace/auth";
+import { Settings } from "@/settings";
+
+export class DedicatedWorkspaceProvisioningError extends Data.TaggedError(
+  "DedicatedWorkspaceProvisioningError",
+)<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+const ADMIN_API_BASE = "https://admin.googleapis.com/admin/directory/v1/users";
+
+type AdminUser = {
+  readonly id: string;
+  readonly primaryEmail: string;
+  readonly name: { readonly fullName: string };
+  readonly suspended: boolean;
+  readonly isAdmin: boolean;
+  readonly creationTime: string;
+};
+
+type AdminUserListResponse = {
+  readonly users?: AdminUser[];
+  readonly nextPageToken?: string;
+};
+
+/**
+ * Generates a random password suitable for provisioned accounts.
+ */
+function generatePassword(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes));
+}
+
+/**
+ * Helper to make an authenticated Admin SDK request.
+ */
+function adminRequest<T>(
+  method: string,
+  url: string,
+  accessToken: string,
+  body?: unknown,
+): Effect.Effect<T, DedicatedWorkspaceProvisioningError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const init: RequestInit = {
+        method,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      };
+      if (body !== undefined) {
+        init.body = JSON.stringify(body);
+      }
+      const response = await fetch(url, init);
+
+      if (method === "DELETE" && response.status === 204) {
+        return undefined as T;
+      }
+
+      const json = (await response.json()) as
+        | T
+        | { error: { message: string; code: number } };
+
+      if (
+        json !== null &&
+        typeof json === "object" &&
+        "error" in json &&
+        json.error
+      ) {
+        throw new Error(
+          `Admin API ${response.status}: ${(json as { error: { message: string } }).error.message}`,
+        );
+      }
+
+      return json as T;
+    },
+    catch: (e) =>
+      new DedicatedWorkspaceProvisioningError({
+        message:
+          e instanceof Error
+            ? e.message
+            : `Admin API request failed: ${method} ${url}`,
+        cause: e,
+      }),
+  });
+}
+
+/**
+ * Creates an account in the dedicated workspace for the given claw slug.
+ *
+ * Generates `<slug>@<domain>` and if taken, tries `<slug>-2`, `<slug>-3`, etc.
+ * Returns the created email address.
+ */
+export function createAccount(
+  clawSlug: string,
+): Effect.Effect<
+  { email: string; password: string },
+  | MissingConfigError
+  | DedicatedWorkspaceAuthError
+  | DedicatedWorkspaceProvisioningError,
+  Settings
+> {
+  return Effect.gen(function* () {
+    const settings = yield* Settings;
+    const { accessToken } = yield* getAccessToken();
+    const domain = settings.dedicatedWorkspace.domain;
+
+    let email = `${clawSlug}@${domain}`;
+    let attempt = 1;
+    const maxAttempts = 10;
+    const password = generatePassword();
+
+    while (attempt <= maxAttempts) {
+      const result = yield* Effect.tryPromise({
+        try: async () => {
+          const response = await fetch(ADMIN_API_BASE, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              primaryEmail: email,
+              name: {
+                givenName: clawSlug,
+                familyName: "Claw",
+              },
+              password,
+              changePasswordAtNextLogin: false,
+            }),
+          });
+
+          const json = (await response.json()) as
+            | AdminUser
+            | { error: { message: string; code: number } };
+
+          return { status: response.status, body: json };
+        },
+        catch: (e) =>
+          new DedicatedWorkspaceProvisioningError({
+            message: "Failed to create account",
+            cause: e,
+          }),
+      });
+
+      // 409 = entity already exists, try next suffix
+      if (result.status === 409) {
+        attempt++;
+        email = `${clawSlug}-${attempt}@${domain}`;
+        continue;
+      }
+
+      if (
+        result.body !== null &&
+        typeof result.body === "object" &&
+        "error" in result.body &&
+        result.body.error
+      ) {
+        return yield* Effect.fail(
+          new DedicatedWorkspaceProvisioningError({
+            message: `Failed to create account ${email}: ${result.body.error.message}`,
+          }),
+        );
+      }
+
+      return { email: (result.body as AdminUser).primaryEmail, password };
+    }
+
+    return yield* Effect.fail(
+      new DedicatedWorkspaceProvisioningError({
+        message: `All ${maxAttempts} email variations for slug "${clawSlug}" are taken`,
+      }),
+    );
+  });
+}
+
+/**
+ * Lists all users in the dedicated workspace domain.
+ */
+export function listAccounts(): Effect.Effect<
+  AdminUser[],
+  | MissingConfigError
+  | DedicatedWorkspaceAuthError
+  | DedicatedWorkspaceProvisioningError,
+  Settings
+> {
+  return Effect.gen(function* () {
+    const settings = yield* Settings;
+    const { accessToken } = yield* getAccessToken();
+    const domain = settings.dedicatedWorkspace.domain;
+
+    const url = `${ADMIN_API_BASE}?domain=${domain}&maxResults=500`;
+    const result = yield* adminRequest<AdminUserListResponse>(
+      "GET",
+      url,
+      accessToken,
+    );
+
+    return result.users ?? [];
+  });
+}
+
+/**
+ * Gets details of a specific account by email.
+ */
+export function getAccount(
+  email: string,
+): Effect.Effect<
+  AdminUser,
+  | MissingConfigError
+  | DedicatedWorkspaceAuthError
+  | DedicatedWorkspaceProvisioningError,
+  Settings
+> {
+  return Effect.gen(function* () {
+    const { accessToken } = yield* getAccessToken();
+
+    const url = `${ADMIN_API_BASE}/${encodeURIComponent(email)}`;
+    return yield* adminRequest<AdminUser>("GET", url, accessToken);
+  });
+}
+
+/**
+ * Suspends a user account in the dedicated workspace.
+ */
+export function suspendAccount(
+  email: string,
+): Effect.Effect<
+  AdminUser,
+  | MissingConfigError
+  | DedicatedWorkspaceAuthError
+  | DedicatedWorkspaceProvisioningError,
+  Settings
+> {
+  return Effect.gen(function* () {
+    const { accessToken } = yield* getAccessToken();
+
+    const url = `${ADMIN_API_BASE}/${encodeURIComponent(email)}`;
+    return yield* adminRequest<AdminUser>("PUT", url, accessToken, {
+      suspended: true,
+    });
+  });
+}
+
+/**
+ * Deletes a user account from the dedicated workspace.
+ */
+export function deleteAccount(
+  email: string,
+): Effect.Effect<
+  void,
+  | MissingConfigError
+  | DedicatedWorkspaceAuthError
+  | DedicatedWorkspaceProvisioningError,
+  Settings
+> {
+  return Effect.gen(function* () {
+    const { accessToken } = yield* getAccessToken();
+
+    const url = `${ADMIN_API_BASE}/${encodeURIComponent(email)}`;
+    yield* adminRequest<void>("DELETE", url, accessToken);
+  });
+}

--- a/cloud/settings.ts
+++ b/cloud/settings.ts
@@ -70,6 +70,17 @@ export type GoogleWorkspaceConfig = {
 };
 
 /**
+ * Dedicated workspace provisioning configuration.
+ * Uses a GCP service account with domain-wide delegation to provision
+ * dedicated workspace accounts via the Google Admin SDK Directory API.
+ */
+export type DedicatedWorkspaceConfig = {
+  readonly saKeyJson: string | undefined;
+  readonly adminEmail: string | undefined;
+  readonly domain: string | undefined;
+};
+
+/**
  * Stripe payments configuration.
  * Used by Settings and Stripe.layer().
  */
@@ -185,6 +196,7 @@ export type SettingsConfig = {
 
   // Integrations
   readonly googleWorkspace: GoogleWorkspaceConfig;
+  readonly dedicatedWorkspace: DedicatedWorkspaceConfig;
 
   // Payments
   readonly stripe: StripeConfig;
@@ -260,6 +272,9 @@ export type CloudflareEnvironment = {
   GOOGLE_WORKSPACE_CLIENT_ID?: string;
   GOOGLE_WORKSPACE_CLIENT_SECRET?: string;
   GOOGLE_WORKSPACE_CALLBACK_URL?: string;
+  DEDICATED_WORKSPACE_SA_KEY_JSON?: string;
+  DEDICATED_WORKSPACE_ADMIN_EMAIL?: string;
+  DEDICATED_WORKSPACE_DOMAIN?: string;
   STRIPE_SECRET_KEY?: string;
   STRIPE_WEBHOOK_SECRET?: string;
   STRIPE_ROUTER_PRICE_ID?: string;
@@ -383,6 +398,12 @@ function validateSettingsFromSource(
         clientId: optional("GOOGLE_WORKSPACE_CLIENT_ID") || undefined,
         clientSecret: optional("GOOGLE_WORKSPACE_CLIENT_SECRET") || undefined,
         callbackUrl: optional("GOOGLE_WORKSPACE_CALLBACK_URL") || undefined,
+      },
+
+      dedicatedWorkspace: {
+        saKeyJson: optional("DEDICATED_WORKSPACE_SA_KEY_JSON") || undefined,
+        adminEmail: optional("DEDICATED_WORKSPACE_ADMIN_EMAIL") || undefined,
+        domain: optional("DEDICATED_WORKSPACE_DOMAIN") || undefined,
       },
 
       stripe: {

--- a/cloud/tests/settings.ts
+++ b/cloud/tests/settings.ts
@@ -121,6 +121,12 @@ export function createMockSettings(
           | undefined,
     },
 
+    dedicatedWorkspace: {
+      saKeyJson: undefined as string | undefined,
+      adminEmail: undefined as string | undefined,
+      domain: undefined as string | undefined,
+    },
+
     encryptionKeys: {
       CLAW_SECRETS_ENCRYPTION_KEY_V1:
         "S0YrcgEScoOL1ALp/w+xI90P9O8h4s3OzEXtzlhBbHQ=",
@@ -154,6 +160,10 @@ export function createMockSettings(
     googleWorkspace: {
       ...defaults.googleWorkspace,
       ...overrides.googleWorkspace,
+    },
+    dedicatedWorkspace: {
+      ...defaults.dedicatedWorkspace,
+      ...overrides.dedicatedWorkspace,
     },
     cloudflare: { ...defaults.cloudflare, ...overrides.cloudflare },
     encryptionKeys: {


### PR DESCRIPTION
Add domain-wide delegation auth and account CRUD for @chelae.ai:
- cloud/integrations/dedicated-workspace/auth.ts — JWT + RS256 via Web Crypto API
- cloud/integrations/dedicated-workspace/provisioning.ts — create/list/get/suspend/delete accounts
- Settings: DEDICATED_WORKSPACE_SA_KEY_JSON, DEDICATED_WORKSPACE_ADMIN_EMAIL, DEDICATED_WORKSPACE_DOMAIN
- 29 tests passing, all config required at runtime (no defaults)