### PR TITLE
fix(ops): forward function metadata in VersionedCall for decorator stacking

### DIFF
--- a/python/mirascope/ops/_internal/versioned_calls.py
+++ b/python/mirascope/ops/_internal/versioned_calls.py
@@ -21,6 +21,7 @@ from ...llm.responses import (
     StreamResponse,
 )
 from ...llm.types import P
+from ..._utils import copy_function_metadata
 from ..exceptions import ClosureComputationError
 from .closure import Closure
 from .protocols import (
@@ -137,7 +138,7 @@ class _BaseVersionedCall:
     closure: Closure | None = field(init=False, default=None)
     """Cached closure for the original function."""
 
-    def _compute_closure(
+    def _init_from_call(
         self,
         wrapped_call: (
             ContextCall[P, DepsT, FormattableT]
@@ -148,7 +149,19 @@ class _BaseVersionedCall:
         versioned_call: _BaseVersionedFunction[..., object],
         versioned_stream: _BaseVersionedFunction[..., object],
     ) -> None:
-        """Initialize closure from wrapped call and assign to versioned wrappers."""
+        """Copy function metadata and initialize closure from wrapped call.
+
+        Copies __qualname__, __name__, __module__, __doc__, and __annotations__
+        from the original function to this VersionedCall, enabling decorator
+        stacking (e.g. @ops.trace on top of @ops.version).
+
+        Also computes and assigns the closure for version tracking.
+        """
+        # Preserve standard function attributes for decorator stacking
+        original_fn = wrapped_call.prompt.fn
+        copy_function_metadata(self, original_fn)
+
+        # Compute and assign closure for version tracking
         self.closure = _compute_closure_from_call(wrapped_call)
         if self.closure is not None:
             versioned_call.closure = self.closure
@@ -236,7 +249,7 @@ class VersionedCall(_BaseVersionedCall, Generic[P, FormattableT]):
             name=self.name,
             metadata=self.metadata,
         )
-        self._compute_closure(self._call, self.call, self.stream)
+        self._init_from_call(self._call, self.call, self.stream)
 
     @overload
     def __call__(
@@ -344,7 +357,7 @@ class VersionedAsyncCall(_BaseVersionedCall, Generic[P, FormattableT]):
             name=self.name,
             metadata=self.metadata,
         )
-        self._compute_closure(self._call, self.call, self.stream)
+        self._init_from_call(self._call, self.call, self.stream)
 
     @overload
     async def __call__(
@@ -459,7 +472,7 @@ class VersionedContextCall(_BaseVersionedCall, Generic[P, DepsT, FormattableT]):
             name=self.name,
             metadata=self.metadata,
         )
-        self._compute_closure(self._call, self._call_versioned, self._stream_versioned)
+        self._init_from_call(self._call, self._call_versioned, self._stream_versioned)
 
     @overload
     def call(
@@ -631,7 +644,7 @@ class VersionedAsyncContextCall(_BaseVersionedCall, Generic[P, DepsT, Formattabl
             name=self.name,
             metadata=self.metadata,
         )
-        self._compute_closure(self._call, self._call_versioned, self._stream_versioned)
+        self._init_from_call(self._call, self._call_versioned, self._stream_versioned)
 
     @overload
     async def call(

--- a/python/tests/ops/_internal/test_versioning.py
+++ b/python/tests/ops/_internal/test_versioning.py
@@ -722,6 +722,69 @@ def recommend(genre: str) -> str:
     )
 
 
+def test_versioned_call_preserves_function_metadata() -> None:
+    """Test that VersionedCall copies __qualname__, __name__, __module__ from original fn.
+
+    Regression test for https://github.com/Mirascope/mirascope/issues/2784.
+    Without metadata forwarding, stacking @ops.trace on @ops.version raises
+    AttributeError: 'VersionedCall' object has no attribute '__qualname__'
+    on Python 3.14+.
+    """
+
+    @ops.version
+    @llm.call("openai/gpt-4o-mini")
+    def recommend_book(genre: str) -> str:
+        """Recommends books based on genre."""
+        return f"Recommend a {genre} book."
+
+    assert isinstance(recommend_book, ops.VersionedCall)
+
+    # These attributes must be present for decorator stacking to work
+    assert hasattr(recommend_book, "__qualname__")
+    assert hasattr(recommend_book, "__name__")
+    assert hasattr(recommend_book, "__module__")
+    assert recommend_book.__name__ == "recommend_book"
+    assert "recommend_book" in recommend_book.__qualname__
+
+
+def test_trace_on_versioned_call_does_not_crash() -> None:
+    """Test that @ops.trace can be stacked on @ops.version on @llm.call.
+
+    Regression test for https://github.com/Mirascope/mirascope/issues/2784.
+    Previously, this raised AttributeError because VersionedCall lacked __qualname__.
+    """
+
+    # This decorator application itself was crashing before the fix
+    @ops.trace(tags=["test"])
+    @ops.version
+    @llm.call("openai/gpt-4o-mini")
+    def recommend_book(genre: str) -> str:
+        """Recommends books based on genre."""
+        return f"Recommend a {genre} book."
+
+    # Verify the outer decorator created a TracedFunction wrapping the VersionedCall
+    assert hasattr(recommend_book, "_qualified_name")
+    assert "recommend_book" in recommend_book._qualified_name
+
+
+@pytest.mark.asyncio
+async def test_trace_on_versioned_async_call_does_not_crash() -> None:
+    """Test that @ops.trace can be stacked on @ops.version on async @llm.call.
+
+    Regression test for https://github.com/Mirascope/mirascope/issues/2784 (async variant).
+    """
+
+    @ops.trace(tags=["test"])
+    @ops.version
+    @llm.call("openai/gpt-4o-mini")
+    async def recommend_book(genre: str) -> str:
+        """Recommends books based on genre."""
+        return f"Recommend a {genre} book."
+
+    assert hasattr(recommend_book, "_qualified_name")
+    assert "recommend_book" in recommend_book._qualified_name
+
+
 @pytest.mark.vcr()
 def test_versioned_call_sync(span_exporter: InMemorySpanExporter) -> None:
     """Test @ops.version on @llm.call creates VersionedCall and returns Response directly."""


### PR DESCRIPTION
## Summary

Fixes #2784.

`VersionedCall` (and its async/context variants) did not copy `__qualname__`, `__name__`, `__module__`, `__doc__`, or `__annotations__` from the underlying function. This caused `@ops.trace` stacked on `@ops.version` on `@llm.call` to crash with:

```
AttributeError: 'VersionedCall' object has no attribute '__qualname__'
```

## Root Cause

`_BaseTracedCall.__post_init__` already calls `copy_function_metadata(self, original_fn)` to preserve standard function attributes for decorator stacking. But `_BaseVersionedCall` did not — its `_compute_closure` method only handled closure computation, not metadata forwarding.

When `@ops.trace` is applied on top of `@ops.version`, it receives a `VersionedCall` that isn't an instance of `Call`, so it falls through to the generic `TracedFunction` path. `TracedFunction.__post_init__` calls `get_qualified_name(self.fn)`, which accesses `fn.__qualname__` — and crashes because `VersionedCall` (a dataclass) doesn't have that attribute.

## Fix

Renamed `_BaseVersionedCall._compute_closure` → `_init_from_call` and added `copy_function_metadata(self, original_fn)` before closure computation. This mirrors `_BaseTracedCall.__post_init__`'s approach using the same `copy_function_metadata` utility.

All 4 `__post_init__` methods (`VersionedCall`, `VersionedAsyncCall`, `VersionedContextCall`, `VersionedAsyncContextCall`) now forward metadata from the original function.

## Tests

Added 3 regression tests:
- `test_versioned_call_preserves_function_metadata` — verifies `__qualname__`, `__name__`, `__module__` are present on `VersionedCall`
- `test_trace_on_versioned_call_does_not_crash` — stacks `@ops.trace` on `@ops.version` on `@llm.call` (sync)
- `test_trace_on_versioned_async_call_does_not_crash` — same for async

All 55 tests in `test_versioning.py` pass.