### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,18 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@753ca4d1150c74169b52a843439049b65e256d2b  # v0.6.1


### PR DESCRIPTION
## Summary

Add [tokentoll](https://github.com/Jwrede/tokentoll) GitHub Action to analyze LLM API cost changes on pull requests.

When a PR modifies code that makes LLM API calls (model swaps, max_tokens changes, new call sites), tokentoll posts a comment showing the projected cost impact. It stays silent on PRs that don't touch LLM code.

## What it detects

tokentoll uses Python AST analysis (zero runtime dependencies) to find calls to:
- OpenAI (`chat.completions.create`, `responses.create`, `embeddings.create`)
- Anthropic (`messages.create`)
- Google GenAI (`generate_content`)
- LiteLLM (`completion`, `embedding`)
- LangChain (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`)
- Zhipu AI / GLM (`ZhipuAiClient`, `ZhipuAI`)

## Current scan of this project

## tokentoll Scan Report

| File | Line | SDK | Model | Est. Cost/Call | Monthly |
|------|------|-----|-------|---------------|---------|
| `python/mirascope/llm/providers/anthropic/beta_provider.py` | 220 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/beta_provider.py` | 254 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/beta_provider.py` | 287 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/beta_provider.py` | 324 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/provider.py` | 122 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/provider.py` | 169 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/provider.py` | 306 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/provider.py` | 350 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/provider.py` | 391 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/provider.py` | 438 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/provider.py` | 214 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/anthropic/provider.py` | 261 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `python/mirascope/llm/providers/google/provider.py` | 91 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `python/mirascope/llm/providers/google/provider.py` | 142 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `python/mirascope/llm/providers/google/provider.py` | 292 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `python/mirascope/llm/providers/google/provider.py` | 341 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `python/mirascope/llm/providers/google/provider.py` | 191 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `python/mirascope/llm/providers/google/provider.py` | 242 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `python/mirascope/llm/providers/google/provider.py` | 388 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `python/mirascope/llm/providers/google/provider.py` | 440 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `python/mirascope/llm/providers/openai/completions/base_provider.py` | 126 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/completions/base_provider.py` | 182 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/completions/base_provider.py` | 346 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/completions/base_provider.py` | 399 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/completions/base_provider.py` | 236 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/completions/base_provider.py` | 292 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/completions/base_provider.py` | 449 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/completions/base_provider.py` | 505 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/responses/provider.py` | 89 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/responses/provider.py` | 189 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/responses/provider.py` | 291 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/responses/provider.py` | 396 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/responses/provider.py` | 139 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/responses/provider.py` | 239 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/responses/provider.py` | 343 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/mirascope/llm/providers/openai/responses/provider.py` | 452 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/scripts/model_features/test_anthropic.py` | 141 | anthropic | claude-sonnet-4-20250514 (default) | $0.001521 | $1.52 |
| `python/scripts/model_features/test_google.py` | 107 | google_genai | gemini-2.0-flash (default) | $0.000819 | $0.82 |
| `python/scripts/model_features/test_google.py` | 191 | google_genai | gemini-2.0-flash (default) | $0.000822 | $0.82 |
| `python/scripts/model_features/test_openai.py` | 103 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/scripts/model_features/test_openai.py` | 130 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/scripts/model_features/test_openai.py` | 162 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `python/scripts/model_features/test_openai.py` | 253 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `python/tests/ops/_internal/closure_test_functions/main.py` | 210 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `python/tests/ops/_internal/closure_test_functions/main.py` | 218 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `python/tests/ops/_internal/closure_test_functions/main.py` | 266 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/getting-started/quickstart/sdk/anthropic.py` | 15 | anthropic | claude-3-5-sonnet-latest | N/A | N/A |
| `website/public/examples/v1/getting-started/quickstart/sdk/google.py` | 17 | google_genai | gemini-2.0-flash | $0.000869 | $0.87 |
| `website/public/examples/v1/getting-started/quickstart/sdk/litellm.py` | 13 | litellm | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/getting-started/quickstart/sdk/openai.py` | 15 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/learn/calls/basic_usage/sdk/anthropic.py` | 8 | anthropic | claude-3-5-sonnet-latest | N/A | N/A |
| `website/public/examples/v1/learn/calls/basic_usage/sdk/google.py` | 8 | google_genai | gemini-2.0-flash | $0.000869 | $0.87 |
| `website/public/examples/v1/learn/calls/basic_usage/sdk/litellm.py` | 6 | litellm | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/learn/calls/basic_usage/sdk/openai.py` | 8 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/learn/calls/basic_usage/sdk/xai.py` | 8 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/learn/response_models/basic_usage/official_sdk/anthropic.py` | 15 | anthropic | claude-3-5-sonnet-latest | N/A | N/A |
| `website/public/examples/v1/learn/response_models/basic_usage/official_sdk/google.py` | 17 | google_genai | gemini-2.0-flash | $0.000869 | $0.87 |
| `website/public/examples/v1/learn/response_models/basic_usage/official_sdk/litellm.py` | 13 | litellm | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/learn/response_models/basic_usage/official_sdk/openai.py` | 15 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/learn/response_models/basic_usage/official_sdk/xai.py` | 15 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/learn/tools/basic_usage/sdk/anthropic.py` | 17 | anthropic | claude-3-5-sonnet-latest | N/A | N/A |
| `website/public/examples/v1/learn/tools/basic_usage/sdk/google.py` | 18 | google_genai | gemini-2.0-flash | $0.000869 | $0.87 |
| `website/public/examples/v1/learn/tools/basic_usage/sdk/litellm.py` | 17 | litellm | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/learn/tools/basic_usage/sdk/openai.py` | 19 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `website/public/examples/v1/learn/tools/basic_usage/sdk/xai.py` | 19 | openai | gpt-4o-mini | $0.002458 | $2.46 |

**Total estimated monthly cost: $3788.95**

<details>
<summary>Assumptions</summary>

- 1000 calls/month per call site

</details>

*Generated by [tokentoll](https://github.com/Jwrede/tokentoll)*

## How it works

- Runs only on PRs, compares base vs head
- Posts a sticky comment (updates in place, no duplicates)
- Only comments when LLM calls are added, removed, or modified
- First run posts an initial scan (this PR) so you can see the output
- Zero runtime dependencies, ~1s scan time for most projects
- [PyPI](https://pypi.org/project/tokentoll/) | [GitHub](https://github.com/Jwrede/tokentoll)

## Changes

- Adds `.github/workflows/llm-costs.yml` (17 lines)
- No code changes, no new dependencies
