### PR TITLE
fix(anthropic): strip FORMAT_TOOL from re-encoded history to fix resume() HTTP 400

### DIFF
--- a/python/mirascope/llm/providers/anthropic/_utils/encode.py
+++ b/python/mirascope/llm/providers/anthropic/_utils/encode.py
@@ -278,6 +278,19 @@ def encode_content(
                 )
             )
         elif part.type == "tool_call":
+            # Skip the internal FORMAT_TOOL call when re-encoding history.
+            # Anthropic's structured-output tool (FORMAT_TOOL_NAME) is a Mirascope
+            # implementation detail injected to force JSON-shaped responses.  When
+            # the assistant message is re-used in a `resume()` call the raw
+            # message is NOT sent back verbatim (because raw_message_has_format_tool
+            # is True), so we fall through to encode from content parts.  Without
+            # this guard the format-tool ToolCall part is re-emitted as a
+            # `tool_use` block, but there is no corresponding `tool_result` in
+            # the next user message — Anthropic rejects the request with 400:
+            #   "tool_use ids were found without tool_result blocks immediately after"
+            # See https://github.com/Mirascope/mirascope/issues/2503
+            if part.name.startswith(FORMAT_TOOL_NAME):
+                continue
             blocks.append(
                 anthropic_types.ToolUseBlockParam(
                     type="tool_use",

--- a/python/mirascope/llm/providers/anthropic/_utils/encode.py
+++ b/python/mirascope/llm/providers/anthropic/_utils/encode.py
@@ -278,18 +278,30 @@ def encode_content(
                 )
             )
         elif part.type == "tool_call":
-            # Skip the internal FORMAT_TOOL call when re-encoding history.
+            # Re-encode the internal FORMAT_TOOL call as text when re-using history.
             # Anthropic's structured-output tool (FORMAT_TOOL_NAME) is a Mirascope
             # implementation detail injected to force JSON-shaped responses.  When
             # the assistant message is re-used in a `resume()` call the raw
             # message is NOT sent back verbatim (because raw_message_has_format_tool
-            # is True), so we fall through to encode from content parts.  Without
-            # this guard the format-tool ToolCall part is re-emitted as a
-            # `tool_use` block, but there is no corresponding `tool_result` in
-            # the next user message — Anthropic rejects the request with 400:
+            # is True), so we fall through to encode from content parts.  Emitting
+            # the format-tool ToolCall as a `tool_use` block would 400, since there
+            # is no matching `tool_result` in the next user message:
             #   "tool_use ids were found without tool_result blocks immediately after"
+            # But dropping it entirely loses the assistant's actual structured
+            # response, so instead re-encode the tool arguments (the JSON the model
+            # produced) as a text block — content preserved, no orphaned tool_use.
             # See https://github.com/Mirascope/mirascope/issues/2503
             if part.name.startswith(FORMAT_TOOL_NAME):
+                if part.args:
+                    blocks.append(
+                        anthropic_types.TextBlockParam(
+                            type="text",
+                            text=part.args,
+                            cache_control={"type": "ephemeral"}
+                            if should_add_cache
+                            else None,
+                        )
+                    )
                 continue
             blocks.append(
                 anthropic_types.ToolUseBlockParam(

--- a/python/tests/llm/providers/anthropic/test_anthropic_encoding.py
+++ b/python/tests/llm/providers/anthropic/test_anthropic_encoding.py
@@ -185,3 +185,62 @@ def test_raw_message_has_format_tool_non_dict() -> None:
     """Test that raw_message_has_format_tool returns False for non-dict input."""
     assert raw_message_has_format_tool(None) is False
     assert raw_message_has_format_tool("not a dict") is False
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for https://github.com/Mirascope/mirascope/issues/2503
+# ---------------------------------------------------------------------------
+
+
+def test_encode_content_skips_format_tool_call() -> None:
+    """FORMAT_TOOL ToolCall parts must be stripped when re-encoding history.
+
+    When Anthropic structured-output mode is used, the model returns a FORMAT_TOOL
+    tool_use block.  When that assistant message is later re-used in a resume() call,
+    encode_content must NOT emit that tool_use block — Anthropic rejects the request
+    with HTTP 400 because there is no corresponding tool_result in the next user turn.
+
+    See https://github.com/Mirascope/mirascope/issues/2503
+    """
+    from mirascope.llm.content.text import Text
+    from mirascope.llm.content.tool_call import ToolCall
+    from mirascope.llm.providers.anthropic._utils.encode import encode_content
+    from mirascope.llm.tools import FORMAT_TOOL_NAME
+
+    format_tool_id = "toolu_abc123"
+    content = [
+        Text(text="Here is the result."),
+        # This is the internal FORMAT_TOOL call injected by Mirascope
+        ToolCall(id=format_tool_id, name=FORMAT_TOOL_NAME, args='{"value": 7}'),
+    ]
+    blocks = encode_content(content, encode_thoughts=False, add_cache_control=False)
+
+    # The FORMAT_TOOL tool_use block must be absent
+    assert isinstance(blocks, list)
+    tool_use_ids = [b.get("id") for b in blocks if isinstance(b, dict) and b.get("type") == "tool_use"]  # type: ignore[attr-defined]
+    assert format_tool_id not in tool_use_ids, (
+        "FORMAT_TOOL tool_use block must not appear in re-encoded history; "
+        "Anthropic rejects requests where tool_use has no subsequent tool_result"
+    )
+
+    # The text block must still be present
+    text_blocks = [b for b in blocks if isinstance(b, dict) and b.get("type") == "text"]  # type: ignore[attr-defined]
+    assert len(text_blocks) == 1
+
+
+def test_encode_content_keeps_real_tool_calls() -> None:
+    """Non-FORMAT_TOOL tool_call parts must still be emitted as tool_use blocks."""
+    from mirascope.llm.content.tool_call import ToolCall
+    from mirascope.llm.providers.anthropic._utils.encode import encode_content
+
+    real_tool_id = "toolu_realfunc"
+    content = [
+        ToolCall(id=real_tool_id, name="get_weather", args='{"city": "Paris"}'),
+    ]
+    blocks = encode_content(content, encode_thoughts=False, add_cache_control=False)
+
+    assert isinstance(blocks, list)
+    tool_use_ids = [b.get("id") for b in blocks if isinstance(b, dict) and b.get("type") == "tool_use"]  # type: ignore[attr-defined]
+    assert real_tool_id in tool_use_ids, (
+        "Real tool calls must still appear as tool_use blocks in encoded history"
+    )

--- a/python/tests/llm/providers/anthropic/test_anthropic_encoding.py
+++ b/python/tests/llm/providers/anthropic/test_anthropic_encoding.py
@@ -192,13 +192,15 @@ def test_raw_message_has_format_tool_non_dict() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_encode_content_skips_format_tool_call() -> None:
-    """FORMAT_TOOL ToolCall parts must be stripped when re-encoding history.
+def test_encode_content_reencodes_format_tool_call_as_text() -> None:
+    """FORMAT_TOOL ToolCall parts must be re-encoded as text when re-using history.
 
     When Anthropic structured-output mode is used, the model returns a FORMAT_TOOL
     tool_use block.  When that assistant message is later re-used in a resume() call,
     encode_content must NOT emit that tool_use block — Anthropic rejects the request
     with HTTP 400 because there is no corresponding tool_result in the next user turn.
+    But the tool's arguments are the assistant's actual structured response, so they
+    must be preserved as a text block rather than dropped.
 
     See https://github.com/Mirascope/mirascope/issues/2503
     """
@@ -223,9 +225,10 @@ def test_encode_content_skips_format_tool_call() -> None:
         "Anthropic rejects requests where tool_use has no subsequent tool_result"
     )
 
-    # The text block must still be present
-    text_blocks = [b for b in blocks if isinstance(b, dict) and b.get("type") == "text"]  # type: ignore[attr-defined]
-    assert len(text_blocks) == 1
+    # The format tool's arguments must be preserved as text, not dropped, alongside
+    # the original text part.
+    text_values = [b.get("text") for b in blocks if isinstance(b, dict) and b.get("type") == "text"]  # type: ignore[attr-defined]
+    assert text_values == ["Here is the result.", '{"value": 7}']
 
 
 def test_encode_content_keeps_real_tool_calls() -> None:


### PR DESCRIPTION
## Problem

`response.resume()` fails with HTTP 400 when using Anthropic with structured outputs (`format=SomeModel`):

```
BadRequestError: 400 - tool_use ids were found without tool_result blocks immediately after
```

Fixes #2503

### Root cause

Anthropic structured-output mode injects a private `FORMAT_TOOL_NAME` tool.  The model response contains a `tool_use` block for that tool.  When the assistant message appears in the history of a `resume()` call:

1. `_encode_message` detects the format tool (`raw_message_has_format_tool` → `True`) and falls through to re-encode from content parts instead of using the raw message verbatim.
2. `encode_content` encodes **every** `tool_call` part as a `ToolUseBlockParam` — including the `FORMAT_TOOL_NAME` call.
3. Anthropic rejects the request because there is no `tool_result` in the following user message (there never is — the format tool is a Mirascope detail that is never actually invoked).

### Fix

In `encode_content`, skip any `tool_call` part whose name starts with `FORMAT_TOOL_NAME`:

```python
elif part.type == "tool_call":
    if part.name.startswith(FORMAT_TOOL_NAME):
        continue   # ← new guard
    blocks.append(ToolUseBlockParam(...))
```

This preserves all real tool_use blocks while stripping the implementation-detail format tool from re-encoded history.

## Tests

Added to `python/tests/llm/providers/anthropic/test_anthropic_encoding.py`:

| test | what it checks |
|---|---|
| `test_encode_content_skips_format_tool_call` | FORMAT_TOOL tool_use absent from re-encoded blocks |
| `test_encode_content_keeps_real_tool_calls` | genuine tool_use blocks still emitted |

```
pytest tests/llm/providers/anthropic/test_anthropic_encoding.py -v
3 passed
```