### PR TITLE
fix(ops): forward __qualname__/__name__ from VersionedCall to fix @ops.trace stacking

### DIFF
--- a/python/mirascope/ops/_internal/versioned_calls.py
+++ b/python/mirascope/ops/_internal/versioned_calls.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Concatenate, Generic, cast, overload
 from typing_extensions import TypeIs
 
+from ..._utils import copy_function_metadata
 from ...llm.calls import AsyncCall, AsyncContextCall, Call, ContextCall
 from ...llm.context import Context, DepsT
 from ...llm.formatting import FormattableT
@@ -237,6 +238,9 @@ class VersionedCall(_BaseVersionedCall, Generic[P, FormattableT]):
             metadata=self.metadata,
         )
         self._compute_closure(self._call, self.call, self.stream)
+        # Forward __qualname__, __name__, __module__, etc. so that downstream
+        # decorators such as @ops.trace can introspect the original function.
+        copy_function_metadata(self, self._call)
 
     @overload
     def __call__(
@@ -345,6 +349,7 @@ class VersionedAsyncCall(_BaseVersionedCall, Generic[P, FormattableT]):
             metadata=self.metadata,
         )
         self._compute_closure(self._call, self.call, self.stream)
+        copy_function_metadata(self, self._call)
 
     @overload
     async def __call__(
@@ -460,6 +465,7 @@ class VersionedContextCall(_BaseVersionedCall, Generic[P, DepsT, FormattableT]):
             metadata=self.metadata,
         )
         self._compute_closure(self._call, self._call_versioned, self._stream_versioned)
+        copy_function_metadata(self, self._call)
 
     @overload
     def call(
@@ -632,6 +638,7 @@ class VersionedAsyncContextCall(_BaseVersionedCall, Generic[P, DepsT, Formattabl
             metadata=self.metadata,
         )
         self._compute_closure(self._call, self._call_versioned, self._stream_versioned)
+        copy_function_metadata(self, self._call)
 
     @overload
     async def call(

--- a/python/tests/ops/_internal/test_versioning.py
+++ b/python/tests/ops/_internal/test_versioning.py
@@ -1661,3 +1661,47 @@ async def test_async_version_continues_when_closure_is_none(
                 "events": [],
             }
         )
+
+def test_versioned_call_exposes_qualname_for_trace() -> None:
+    """VersionedCall must expose __qualname__ and __name__ so @ops.trace can introspect it.
+
+    Regression test for https://github.com/Mirascope/mirascope/issues/2784:
+    combining @ops.trace + @ops.version + @llm.call raised
+        AttributeError: 'VersionedCall' object has no attribute '__qualname__'
+    because VersionedCall.__post_init__ did not call copy_function_metadata.
+    """
+
+    @ops.version
+    @llm.call("openai/gpt-4o-mini")
+    def my_function(text: str) -> str:
+        return f"Echo: {text}"
+
+    # The VersionedCall must carry __qualname__ and __name__ from the original fn.
+    assert hasattr(my_function, "__qualname__"), (
+        "VersionedCall must expose __qualname__ for @ops.trace to work"
+    )
+    assert hasattr(my_function, "__name__"), (
+        "VersionedCall must expose __name__ for @ops.trace to work"
+    )
+    assert "my_function" in my_function.__qualname__
+
+    # Applying @ops.trace must not raise AttributeError.
+    traced = ops.trace(tags=["test"])(my_function)
+    assert traced is not None
+
+
+@pytest.mark.asyncio
+async def test_versioned_async_call_exposes_qualname_for_trace() -> None:
+    """AsyncVersionedCall must also expose __qualname__ for @ops.trace compatibility."""
+
+    @ops.version
+    @llm.call("openai/gpt-4o-mini")
+    async def my_async_function(text: str) -> str:
+        return f"Echo: {text}"
+
+    assert hasattr(my_async_function, "__qualname__")
+    assert hasattr(my_async_function, "__name__")
+    assert "my_async_function" in my_async_function.__qualname__
+
+    traced = ops.trace(tags=["test"])(my_async_function)
+    assert traced is not None

--- a/python/tests/ops/_internal/test_versioning.py
+++ b/python/tests/ops/_internal/test_versioning.py
@@ -1662,6 +1662,7 @@ async def test_async_version_continues_when_closure_is_none(
             }
         )
 
+
 def test_versioned_call_exposes_qualname_for_trace() -> None:
     """VersionedCall must expose __qualname__ and __name__ so @ops.trace can introspect it.
 


### PR DESCRIPTION
## Summary

Combining `@ops.trace` with `@ops.version` + `@llm.call` raises `AttributeError`
on Python 3.12+ (and was confirmed on 3.14):

```
AttributeError: 'VersionedCall' object has no attribute '__qualname__'
```

The error occurs because `@ops.version` wraps the `Call` object in a
`VersionedCall` dataclass, but `VersionedCall.__post_init__` never calls
`copy_function_metadata` to forward `__qualname__`, `__name__`, etc. from the
underlying `Call`.

`Call.__init__` already calls `copy_function_metadata(self, self.prompt.fn)`,
so the `Call` object carries those attributes. The fix is a single
`copy_function_metadata(self, self._call)` call at the end of `__post_init__`
in all four versioned-call classes: `VersionedCall`, `VersionedAsyncCall`,
`VersionedContextCall`, and `VersionedAsyncContextCall`.

As a bonus, this also sets `__wrapped__`, allowing `get_original_fn()` in
`utils.py` to follow the wrapper chain correctly.

## Reproduction

```python
from mirascope import llm, ops

ops.configure()
ops.instrument_llm()

@ops.trace(tags=["test"])
@ops.version
@llm.call("openai/gpt-4o-mini")
def run(text: str) -> str:
    return f"Echo: {text}"
# AttributeError: 'VersionedCall' object has no attribute '__qualname__'
```

## Tests

Added two regression tests:
- `test_versioned_call_exposes_qualname_for_trace` (sync)
- `test_versioned_async_call_exposes_qualname_for_trace` (async)

Both verify that `__qualname__`/`__name__` are accessible and that
`@ops.trace` can be applied without raising `AttributeError`.

Fixes #2784