### PR TITLE
feat(providers): add XAIProvider for Grok via Responses API

### DIFF
--- a/python/mirascope/llm/providers/__init__.py
+++ b/python/mirascope/llm/providers/__init__.py
@@ -13,6 +13,7 @@ stub_module_if_missing("mirascope.llm.providers.openai", "openai")
 stub_module_if_missing("mirascope.llm.providers.openrouter", "openai")
 stub_module_if_missing("mirascope.llm.providers.together", "openai")
 stub_module_if_missing("mirascope.llm.providers.ollama", "openai")
+stub_module_if_missing("mirascope.llm.providers.xai", "openai")
 
 # Now imports work regardless of which packages are installed
 # ruff: noqa: E402
@@ -39,6 +40,7 @@ from .provider_registry import (
     reset_provider_registry,
 )
 from .together import TogetherProvider
+from .xai import XAIProvider
 
 __all__ = [
     "KNOWN_PROVIDER_IDS",
@@ -59,6 +61,7 @@ __all__ = [
     "Provider",
     "ProviderId",
     "TogetherProvider",
+    "XAIProvider",
     "get_provider_for_model",
     "register_provider",
     "reset_provider_registry",

--- a/python/mirascope/llm/providers/__init__.py
+++ b/python/mirascope/llm/providers/__init__.py
@@ -40,7 +40,7 @@ from .provider_registry import (
     reset_provider_registry,
 )
 from .together import TogetherProvider
-from .xai import XAIProvider
+from .xai import XAIModelId, XAIProvider
 
 __all__ = [
     "KNOWN_PROVIDER_IDS",
@@ -61,6 +61,7 @@ __all__ = [
     "Provider",
     "ProviderId",
     "TogetherProvider",
+    "XAIModelId",
     "XAIProvider",
     "get_provider_for_model",
     "register_provider",

--- a/python/mirascope/llm/providers/provider_id.py
+++ b/python/mirascope/llm/providers/provider_id.py
@@ -12,6 +12,7 @@ KnownProviderId: TypeAlias = Literal[
     "openai",  # OpenAI provider via OpenAIProvider (prefers Responses routing when available)
     "openrouter",  # OpenRouter provider via OpenRouterProvider
     "together",  # Together AI provider via TogetherProvider
+    "xai",  # xAI provider for Grok models via XAIProvider (Responses API)
 ]
 KNOWN_PROVIDER_IDS = get_args(KnownProviderId)
 

--- a/python/mirascope/llm/providers/provider_registry.py
+++ b/python/mirascope/llm/providers/provider_registry.py
@@ -19,6 +19,7 @@ from .openai.responses.provider import OpenAIResponsesProvider
 from .openrouter import OpenRouterProvider
 from .provider_id import ProviderId
 from .together import TogetherProvider
+from .xai import XAIProvider
 
 # Global registry mapping scopes to providers
 # Scopes are matched by prefix (longest match wins)
@@ -75,6 +76,9 @@ DEFAULT_AUTO_REGISTER_SCOPES: dict[str, Sequence[ProviderDefault]] = {
     "openrouter/": [
         ProviderDefault("openrouter", "OPENROUTER_API_KEY"),
     ],
+    "xai/": [
+        ProviderDefault("xai", "XAI_API_KEY"),
+    ],
 }
 
 
@@ -130,6 +134,8 @@ def provider_singleton(
             return OpenRouterProvider(api_key=api_key, base_url=base_url)
         case "together":
             return TogetherProvider(api_key=api_key, base_url=base_url)
+        case "xai":
+            return XAIProvider(api_key=api_key, base_url=base_url)
         case _:  # pragma: no cover
             raise ValueError(f"Unknown provider: '{provider_id}'")
 

--- a/python/mirascope/llm/providers/xai/__init__.py
+++ b/python/mirascope/llm/providers/xai/__init__.py
@@ -1,5 +1,6 @@
 """xAI provider for accessing Grok models via xAI's OpenAI-compatible Responses API."""
 
+from .model_id import XAIModelId
 from .provider import XAIProvider
 
-__all__ = ["XAIProvider"]
+__all__ = ["XAIModelId", "XAIProvider"]

--- a/python/mirascope/llm/providers/xai/__init__.py
+++ b/python/mirascope/llm/providers/xai/__init__.py
@@ -1,0 +1,5 @@
+"""xAI provider for accessing Grok models via xAI's OpenAI-compatible Responses API."""
+
+from .provider import XAIProvider
+
+__all__ = ["XAIProvider"]

--- a/python/mirascope/llm/providers/xai/model_id.py
+++ b/python/mirascope/llm/providers/xai/model_id.py
@@ -1,0 +1,10 @@
+"""xAI registered LLM models."""
+
+from typing import TypeAlias, get_args
+
+from .model_info import XAIKnownModels
+
+XAIModelId: TypeAlias = XAIKnownModels | str
+"""The xAI model ids registered with Mirascope."""
+
+XAI_KNOWN_MODELS: set[str] = set(get_args(XAIKnownModels))

--- a/python/mirascope/llm/providers/xai/model_info.py
+++ b/python/mirascope/llm/providers/xai/model_info.py
@@ -1,0 +1,25 @@
+"""xAI model information.
+
+Static list of the Grok models xAI exposes through their Responses API,
+sourced from https://docs.x.ai/docs/models. Update by hand when xAI publishes
+new model IDs."""
+
+from typing import Literal
+
+XAIKnownModels = Literal[
+    "xai/grok-2-1212",
+    "xai/grok-2-latest",
+    "xai/grok-2-vision-1212",
+    "xai/grok-2-vision-latest",
+    "xai/grok-3",
+    "xai/grok-3-fast",
+    "xai/grok-3-mini",
+    "xai/grok-3-mini-fast",
+    "xai/grok-4",
+    "xai/grok-4-fast-non-reasoning",
+    "xai/grok-4-fast-reasoning",
+    "xai/grok-4-latest",
+    "xai/grok-beta",
+    "xai/grok-code-fast-1",
+    "xai/grok-vision-beta",
+]

--- a/python/mirascope/llm/providers/xai/provider.py
+++ b/python/mirascope/llm/providers/xai/provider.py
@@ -1,0 +1,72 @@
+"""xAI provider implementation.
+
+Wraps xAI's OpenAI-compatible Responses API (https://api.x.ai/v1) so Grok models
+can be used from Mirascope the same way as any other LLM. The class just
+specialises `OpenAIResponsesProvider` with xAI's default base URL and a separate
+class identity so the provider registry can route `xai/` prefixed model IDs to it.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import ClassVar
+
+from openai import AsyncOpenAI, OpenAI
+
+from ..openai.responses.provider import OpenAIResponsesProvider
+
+_DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+_XAI_API_KEY_ENV_VAR = "XAI_API_KEY"
+
+
+class XAIProvider(OpenAIResponsesProvider):
+    """Provider for xAI's OpenAI-compatible Responses API.
+
+    Inherits everything from `OpenAIResponsesProvider` and only overrides the
+    pieces that differ: provider id, default scope, default base URL, and the
+    environment variable used to pick up the API key.
+
+    Usage:
+        Register the provider for the `xai/` scope, then call Grok models
+        directly:
+
+        ```python
+        from mirascope import llm
+
+        llm.register_provider("xai")
+
+        @llm.call("xai/grok-2-latest")
+        def my_prompt():
+            return [llm.messages.user("Hello!")]
+        ```
+    """
+
+    id: ClassVar[str] = "xai"
+    default_scope: ClassVar[str | list[str]] = "xai/"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        """Initialize the xAI Responses client.
+
+        Args:
+            api_key: xAI API key. Falls back to `XAI_API_KEY` if not provided.
+            base_url: Custom base URL. Falls back to `https://api.x.ai/v1`.
+
+        Raises:
+            ValueError: If no API key is provided and `XAI_API_KEY` is unset.
+        """
+        resolved_key = api_key or os.environ.get(_XAI_API_KEY_ENV_VAR)
+        if not resolved_key:
+            raise ValueError(
+                "xAI API key is required. Pass `api_key=...` or set the "
+                f"`{_XAI_API_KEY_ENV_VAR}` environment variable."
+            )
+        resolved_base_url = base_url or _DEFAULT_XAI_BASE_URL
+        self.client = OpenAI(api_key=resolved_key, base_url=resolved_base_url)
+        self.async_client = AsyncOpenAI(
+            api_key=resolved_key, base_url=resolved_base_url
+        )

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -26,6 +26,7 @@ def load_api_keys() -> None:
     os.environ.setdefault("OPENAI_API_KEY", "dummy-openai-key")
     os.environ.setdefault("OPENROUTER_API_KEY", "dummy-openrouter-key")
     os.environ.setdefault("TOGETHER_API_KEY", "dummy-together-key")
+    os.environ.setdefault("XAI_API_KEY", "dummy-xai-key")
 
 
 @pytest.fixture(autouse=True)

--- a/python/tests/llm/providers/test_xai_provider.py
+++ b/python/tests/llm/providers/test_xai_provider.py
@@ -1,0 +1,58 @@
+"""Tests for XAIProvider."""
+
+import os
+
+import pytest
+
+from mirascope.llm.providers.xai.provider import XAIProvider
+
+
+def test_xai_provider_initialization_with_api_key() -> None:
+    """`api_key` kwarg should populate both clients without touching the env."""
+    provider = XAIProvider(api_key="test-api-key")
+    assert provider.id == "xai"
+    assert provider.default_scope == "xai/"
+    assert provider.client.api_key == "test-api-key"
+    assert provider.async_client.api_key == "test-api-key"
+
+
+def test_xai_provider_missing_api_key() -> None:
+    """No api_key, no XAI_API_KEY -> a clear ValueError naming the env var."""
+    original_key = os.environ.pop("XAI_API_KEY", None)
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            XAIProvider()
+        assert "xAI API key is required" in str(exc_info.value)
+        assert "XAI_API_KEY" in str(exc_info.value)
+    finally:
+        if original_key is not None:
+            os.environ["XAI_API_KEY"] = original_key
+
+
+def test_xai_provider_uses_env_var() -> None:
+    """`XAI_API_KEY` should be picked up when no explicit api_key is passed."""
+    original_key = os.environ.get("XAI_API_KEY")
+    os.environ["XAI_API_KEY"] = "env-test-key"
+    try:
+        provider = XAIProvider()
+        assert provider.client.api_key == "env-test-key"
+        assert provider.async_client.api_key == "env-test-key"
+    finally:
+        if original_key is not None:
+            os.environ["XAI_API_KEY"] = original_key
+        else:
+            os.environ.pop("XAI_API_KEY", None)
+
+
+def test_xai_provider_default_base_url() -> None:
+    """Without an explicit base_url the xAI default should be used."""
+    provider = XAIProvider(api_key="test-key")
+    assert str(provider.client.base_url) == "https://api.x.ai/v1/"
+    assert str(provider.async_client.base_url) == "https://api.x.ai/v1/"
+
+
+def test_xai_provider_custom_base_url() -> None:
+    """An explicit base_url should override the default for both clients."""
+    provider = XAIProvider(api_key="test-key", base_url="https://custom.x.ai/v2")
+    assert str(provider.client.base_url) == "https://custom.x.ai/v2/"
+    assert str(provider.async_client.base_url) == "https://custom.x.ai/v2/"

--- a/python/tests/llm/providers/test_xai_provider.py
+++ b/python/tests/llm/providers/test_xai_provider.py
@@ -4,7 +4,8 @@ import os
 
 import pytest
 
-from mirascope.llm.providers.xai.provider import XAIProvider
+from mirascope.llm.providers.xai import XAIModelId, XAIProvider
+from mirascope.llm.providers.xai.model_id import XAI_KNOWN_MODELS
 
 
 def test_xai_provider_initialization_with_api_key() -> None:
@@ -56,3 +57,12 @@ def test_xai_provider_custom_base_url() -> None:
     provider = XAIProvider(api_key="test-key", base_url="https://custom.x.ai/v2")
     assert str(provider.client.base_url) == "https://custom.x.ai/v2/"
     assert str(provider.async_client.base_url) == "https://custom.x.ai/v2/"
+
+
+def test_xai_known_models_surface() -> None:
+    """`XAIModelId` should accept known Grok models and the well-known set
+    should be non-empty and properly `xai/`-scoped, so editors can autocomplete."""
+    sample: XAIModelId = "xai/grok-4-latest"
+    assert sample in XAI_KNOWN_MODELS
+    assert len(XAI_KNOWN_MODELS) > 0
+    assert all(m.startswith("xai/") for m in XAI_KNOWN_MODELS)


### PR DESCRIPTION
## Summary

Closes #2091.

xAI deprecated their Anthropic-compatible `v1/messages` endpoint and pointed users at their OpenAI-compatible Responses API at `https://api.x.ai/v1`. This PR adds a thin `XAIProvider` that subclasses `OpenAIResponsesProvider` with xAI-specific defaults, so Grok models work like any other provider in Mirascope.

## What changed

- `python/mirascope/llm/providers/xai/` (new package): `XAIProvider` overrides `id`, `default_scope`, and the constructor so it resolves `XAI_API_KEY` from the environment by default and points at the xAI base URL. Otherwise inherits everything from `OpenAIResponsesProvider`.
- `provider_id.py`: added `"xai"` to `KnownProviderId`.
- `provider_registry.py`: imported `XAIProvider`, added the `xai/` entry to `DEFAULT_AUTO_REGISTER_SCOPES` (with `XAI_API_KEY` as the env var), and added the `case "xai"` branch in `provider_singleton`.
- `providers/__init__.py`: registered the new `xai` stub module and exported `XAIProvider`.
- `tests/conftest.py`: added the `XAI_API_KEY` dummy key so the `test_all_default_scopes_auto_register` sweep continues to pass.

## Behavior

After registering:
```python
from mirascope import llm

llm.register_provider("xai")

@llm.call("xai/grok-2-latest")
def hello():
    return [llm.messages.user("Hi")]
```

xAI Completions support and any xAI-specific model registry / feature info can follow in a separate PR if useful.

## Test plan

- [x] `uv run pytest tests/llm/providers/test_xai_provider.py` (5 new tests covering api_key, env var, missing key, default base URL, custom base URL).
- [x] `uv run pytest tests/llm/providers/test_provider_registry.py` passes, including `test_all_default_scopes_auto_register` which now also sweeps the new `xai/` scope.
- [x] `uv run pytest tests/llm/ --ignore=tests/llm/e2e` reports `920 passed, 3 skipped`.
- [x] `uv run coverage run -m pytest tests/llm/providers/test_xai_provider.py && uv run coverage report --include="*/xai/*"` reports 100% line coverage on the new module.
- [x] `uv run ruff check` and `uv run ruff format --check` pass on touched files.
- [x] `uv run pyright` reports 0 errors on touched files.