### PR TITLE
fix: emit OTel/Langfuse-conventional span attributes for @ops.trace tags and metadata

### DIFF
--- a/python/mirascope/ops/_internal/traced_functions.py
+++ b/python/mirascope/ops/_internal/traced_functions.py
@@ -39,35 +39,25 @@ FunctionT = TypeVar(
 )
 
 
-def _conventional_trace_attributes(
+def _otel_trace_attributes(
     tags: tuple[str, ...],
     metadata: dict[str, str],
 ) -> dict[str, AttributeValue]:
-    """Emit OTel/Langfuse-conventional span attributes for trace tags and metadata.
-
-    Backends like Langfuse map first-class fields from conventional attribute keys,
-    so we emit those alongside the existing ``mirascope.trace.*`` keys (which are
-    kept for backward compatibility).
-    """
+    """Emit plain OTel span attributes for trace tags and metadata."""
     attributes: dict[str, AttributeValue] = {}
     if tags:
-        attributes["langfuse.trace.tags"] = list(tags)
+        attributes["tags"] = list(tags)
     if metadata:
-        # Promote well-known fields to their conventional keys.
         session_id = metadata.get("session_id")
         if session_id is not None:
-            attributes["langfuse.session.id"] = session_id
+            attributes["session.id"] = session_id
         user_id = metadata.get("user_id")
         if user_id is not None:
-            attributes["langfuse.user.id"] = user_id
-        # Flatten remaining metadata entries under the Langfuse-conventional
-        # ``langfuse.trace.metadata.<key>`` prefix so backends surface each as a
-        # first-class, filterable field instead of only exposing the single JSON
-        # blob under ``mirascope.trace.metadata``.
+            attributes["user.id"] = user_id
         for key, value in metadata.items():
             if key in ("session_id", "user_id"):
                 continue
-            attributes[f"langfuse.trace.metadata.{key}"] = value
+            attributes[f"metadata.{key}"] = value
     return attributes
 
 
@@ -237,7 +227,7 @@ class _BaseTracedFunction(_BaseFunction[P, R, FunctionT]):
                 attributes["mirascope.trace.tags"] = list(self.tags)
             if self.metadata:
                 attributes["mirascope.trace.metadata"] = json_dumps(self.metadata)
-            attributes.update(_conventional_trace_attributes(self.tags, self.metadata))
+            attributes.update(_otel_trace_attributes(self.tags, self.metadata))
             span.set(**attributes)
             yield span
 
@@ -352,7 +342,7 @@ class _BaseTracedContextFunction(
                 attributes["mirascope.trace.tags"] = list(self.tags)
             if self.metadata:
                 attributes["mirascope.trace.metadata"] = json_dumps(self.metadata)
-            attributes.update(_conventional_trace_attributes(self.tags, self.metadata))
+            attributes.update(_otel_trace_attributes(self.tags, self.metadata))
             span.set(**attributes)
             yield span
 

--- a/python/mirascope/ops/_internal/traced_functions.py
+++ b/python/mirascope/ops/_internal/traced_functions.py
@@ -39,6 +39,38 @@ FunctionT = TypeVar(
 )
 
 
+def _conventional_trace_attributes(
+    tags: tuple[str, ...],
+    metadata: dict[str, str],
+) -> dict[str, AttributeValue]:
+    """Emit OTel/Langfuse-conventional span attributes for trace tags and metadata.
+
+    Backends like Langfuse map first-class fields from conventional attribute keys,
+    so we emit those alongside the existing ``mirascope.trace.*`` keys (which are
+    kept for backward compatibility).
+    """
+    attributes: dict[str, AttributeValue] = {}
+    if tags:
+        attributes["langfuse.trace.tags"] = list(tags)
+    if metadata:
+        # Promote well-known fields to their conventional keys.
+        session_id = metadata.get("session_id")
+        if session_id is not None:
+            attributes["langfuse.session.id"] = session_id
+        user_id = metadata.get("user_id")
+        if user_id is not None:
+            attributes["langfuse.user.id"] = user_id
+        # Flatten remaining metadata entries under the Langfuse-conventional
+        # ``langfuse.trace.metadata.<key>`` prefix so backends surface each as a
+        # first-class, filterable field instead of only exposing the single JSON
+        # blob under ``mirascope.trace.metadata``.
+        for key, value in metadata.items():
+            if key in ("session_id", "user_id"):
+                continue
+            attributes[f"langfuse.trace.metadata.{key}"] = value
+    return attributes
+
+
 def record_result_to_span(span: Span, result: object) -> None:
     """Records the function result in the given span.
 
@@ -205,6 +237,7 @@ class _BaseTracedFunction(_BaseFunction[P, R, FunctionT]):
                 attributes["mirascope.trace.tags"] = list(self.tags)
             if self.metadata:
                 attributes["mirascope.trace.metadata"] = json_dumps(self.metadata)
+            attributes.update(_conventional_trace_attributes(self.tags, self.metadata))
             span.set(**attributes)
             yield span
 
@@ -319,6 +352,7 @@ class _BaseTracedContextFunction(
                 attributes["mirascope.trace.tags"] = list(self.tags)
             if self.metadata:
                 attributes["mirascope.trace.metadata"] = json_dumps(self.metadata)
+            attributes.update(_conventional_trace_attributes(self.tags, self.metadata))
             span.set(**attributes)
             yield span
 

--- a/python/tests/ops/_internal/test_tracing.py
+++ b/python/tests/ops/_internal/test_tracing.py
@@ -162,6 +162,96 @@ async def test_async_trace_no_return_with_tags(
     assert span_data["attributes"]["mirascope.trace.tags"] == ("async",)
 
 
+def test_trace_emits_conventional_attributes(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Tests that trace tags and metadata emit conventional backend attributes."""
+
+    @ops.trace(
+        tags=["a", "b"],
+        metadata={"session_id": "sess-1", "user_id": "user-9", "foo": "bar"},
+    )
+    def process() -> str:
+        return "done"
+
+    process()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    attributes = extract_span_data(spans[0])["attributes"]
+    assert attributes["mirascope.trace.tags"] == ("a", "b")
+    assert attributes["langfuse.trace.tags"] == ("a", "b")
+    assert attributes["langfuse.session.id"] == "sess-1"
+    assert attributes["langfuse.user.id"] == "user-9"
+    assert attributes["langfuse.trace.metadata.foo"] == "bar"
+    assert attributes["mirascope.trace.metadata"] == (
+        '{"session_id":"sess-1","user_id":"user-9","foo":"bar"}'
+    )
+    assert "langfuse.trace.metadata.session_id" not in attributes
+
+
+def test_trace_tags_only_no_metadata(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Tests that trace tags emit conventional attributes without metadata."""
+
+    @ops.trace(tags=["only-tag"])
+    def tagged() -> None: ...
+
+    tagged()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    attributes = extract_span_data(spans[0])["attributes"]
+    assert attributes["langfuse.trace.tags"] == ("only-tag",)
+    assert "langfuse.session.id" not in attributes
+    assert "langfuse.user.id" not in attributes
+    assert not any(key.startswith("langfuse.trace.metadata.") for key in attributes)
+
+
+def test_trace_metadata_without_session_user(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Tests that metadata emits flat attributes without promoted fields."""
+
+    @ops.trace(metadata={"foo": "bar", "baz": "qux"})
+    def process() -> None: ...
+
+    process()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    attributes = extract_span_data(spans[0])["attributes"]
+    assert "langfuse.session.id" not in attributes
+    assert "langfuse.user.id" not in attributes
+    assert attributes["langfuse.trace.metadata.foo"] == "bar"
+    assert attributes["langfuse.trace.metadata.baz"] == "qux"
+    assert attributes["mirascope.trace.metadata"] == '{"foo":"bar","baz":"qux"}'
+
+
+def test_context_trace_emits_conventional_attributes(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Tests that context trace functions emit conventional attributes."""
+
+    @ops.trace(tags=["ctx-tag"], metadata={"session_id": "ctx-sess"})
+    def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    ctx = llm.Context(deps="As a librarian,")
+    recommend(ctx, "fantasy")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    attributes = extract_span_data(spans[0])["attributes"]
+    assert attributes["langfuse.trace.tags"] == ("ctx-tag",)
+    assert attributes["langfuse.session.id"] == "ctx-sess"
+
+
 def test_trace_complex_serialization(
     span_exporter: InMemorySpanExporter,
 ) -> None:
@@ -1060,6 +1150,7 @@ def test_traced_call_with_tags(span_exporter: InMemorySpanExporter) -> None:
                 "mirascope.trace.arg_types": '{"genre":"str"}',
                 "mirascope.trace.arg_values": '{"genre":"romance"}',
                 "mirascope.trace.tags": ("production", "recommendations"),
+                "langfuse.trace.tags": ("production", "recommendations"),
                 "mirascope.response.provider_id": "openai",
                 "mirascope.response.model_id": "openai/gpt-4o-mini",
                 "mirascope.response.messages": '[{"role":"user","content":[{"type":"text","text":"Recommend a romance book."}],"name":null}]',
@@ -1302,6 +1393,7 @@ def test_traced_context_call_with_tags(span_exporter: InMemorySpanExporter) -> N
                 "mirascope.trace.arg_types": '{"ctx":"llm.Context[str]","genre":"str"}',
                 "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"genre":"science fiction"}',
                 "mirascope.trace.tags": ("context-tag",),
+                "langfuse.trace.tags": ("context-tag",),
                 "mirascope.response.provider_id": "openai",
                 "mirascope.response.model_id": "openai/gpt-4o-mini",
                 "mirascope.response.messages": '[{"role":"user","content":[{"type":"text","text":"As a librarian, Recommend a science fiction book."}],"name":null}]',
@@ -1353,6 +1445,7 @@ async def test_traced_async_context_call_with_tags(
                 "mirascope.trace.arg_types": '{"ctx":"llm.Context[str]","genre":"str"}',
                 "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"genre":"dystopian"}',
                 "mirascope.trace.tags": ("async-context-tag",),
+                "langfuse.trace.tags": ("async-context-tag",),
                 "mirascope.response.provider_id": "openai",
                 "mirascope.response.model_id": "openai/gpt-4o-mini",
                 "mirascope.response.messages": '[{"role":"user","content":[{"type":"text","text":"As a librarian, Recommend a dystopian book."}],"name":null}]',

--- a/python/tests/ops/_internal/test_tracing.py
+++ b/python/tests/ops/_internal/test_tracing.py
@@ -162,10 +162,10 @@ async def test_async_trace_no_return_with_tags(
     assert span_data["attributes"]["mirascope.trace.tags"] == ("async",)
 
 
-def test_trace_emits_conventional_attributes(
+def test_trace_emits_otel_attributes(
     span_exporter: InMemorySpanExporter,
 ) -> None:
-    """Tests that trace tags and metadata emit conventional backend attributes."""
+    """Tests that trace tags and metadata emit plain OTel attributes."""
 
     @ops.trace(
         tags=["a", "b"],
@@ -181,14 +181,16 @@ def test_trace_emits_conventional_attributes(
 
     attributes = extract_span_data(spans[0])["attributes"]
     assert attributes["mirascope.trace.tags"] == ("a", "b")
-    assert attributes["langfuse.trace.tags"] == ("a", "b")
-    assert attributes["langfuse.session.id"] == "sess-1"
-    assert attributes["langfuse.user.id"] == "user-9"
-    assert attributes["langfuse.trace.metadata.foo"] == "bar"
+    assert attributes["tags"] == ("a", "b")
+    assert attributes["session.id"] == "sess-1"
+    assert attributes["user.id"] == "user-9"
+    assert attributes["metadata.foo"] == "bar"
     assert attributes["mirascope.trace.metadata"] == (
         '{"session_id":"sess-1","user_id":"user-9","foo":"bar"}'
     )
-    assert "langfuse.trace.metadata.session_id" not in attributes
+    assert "metadata.session_id" not in attributes
+    assert "metadata.user_id" not in attributes
+    assert not any(key.startswith("langfuse.") for key in attributes)
 
 
 def test_trace_tags_only_no_metadata(
@@ -205,10 +207,11 @@ def test_trace_tags_only_no_metadata(
     assert len(spans) == 1
 
     attributes = extract_span_data(spans[0])["attributes"]
-    assert attributes["langfuse.trace.tags"] == ("only-tag",)
-    assert "langfuse.session.id" not in attributes
-    assert "langfuse.user.id" not in attributes
-    assert not any(key.startswith("langfuse.trace.metadata.") for key in attributes)
+    assert attributes["tags"] == ("only-tag",)
+    assert "session.id" not in attributes
+    assert "user.id" not in attributes
+    assert not any(key.startswith("metadata.") for key in attributes)
+    assert not any(key.startswith("langfuse.") for key in attributes)
 
 
 def test_trace_metadata_without_session_user(
@@ -225,19 +228,23 @@ def test_trace_metadata_without_session_user(
     assert len(spans) == 1
 
     attributes = extract_span_data(spans[0])["attributes"]
-    assert "langfuse.session.id" not in attributes
-    assert "langfuse.user.id" not in attributes
-    assert attributes["langfuse.trace.metadata.foo"] == "bar"
-    assert attributes["langfuse.trace.metadata.baz"] == "qux"
+    assert "session.id" not in attributes
+    assert "user.id" not in attributes
+    assert attributes["metadata.foo"] == "bar"
+    assert attributes["metadata.baz"] == "qux"
     assert attributes["mirascope.trace.metadata"] == '{"foo":"bar","baz":"qux"}'
+    assert not any(key.startswith("langfuse.") for key in attributes)
 
 
-def test_context_trace_emits_conventional_attributes(
+def test_context_trace_emits_otel_attributes(
     span_exporter: InMemorySpanExporter,
 ) -> None:
-    """Tests that context trace functions emit conventional attributes."""
+    """Tests that context trace functions emit plain OTel attributes."""
 
-    @ops.trace(tags=["ctx-tag"], metadata={"session_id": "ctx-sess"})
+    @ops.trace(
+        tags=["ctx-tag"],
+        metadata={"session_id": "ctx-sess", "user_id": "ctx-user", "foo": "bar"},
+    )
     def recommend(ctx: llm.Context[str], genre: str) -> str:
         return f"{ctx.deps} Recommend a {genre} book."
 
@@ -248,8 +255,11 @@ def test_context_trace_emits_conventional_attributes(
     assert len(spans) == 1
 
     attributes = extract_span_data(spans[0])["attributes"]
-    assert attributes["langfuse.trace.tags"] == ("ctx-tag",)
-    assert attributes["langfuse.session.id"] == "ctx-sess"
+    assert attributes["tags"] == ("ctx-tag",)
+    assert attributes["session.id"] == "ctx-sess"
+    assert attributes["user.id"] == "ctx-user"
+    assert attributes["metadata.foo"] == "bar"
+    assert not any(key.startswith("langfuse.") for key in attributes)
 
 
 def test_trace_complex_serialization(
@@ -1150,7 +1160,7 @@ def test_traced_call_with_tags(span_exporter: InMemorySpanExporter) -> None:
                 "mirascope.trace.arg_types": '{"genre":"str"}',
                 "mirascope.trace.arg_values": '{"genre":"romance"}',
                 "mirascope.trace.tags": ("production", "recommendations"),
-                "langfuse.trace.tags": ("production", "recommendations"),
+                "tags": ("production", "recommendations"),
                 "mirascope.response.provider_id": "openai",
                 "mirascope.response.model_id": "openai/gpt-4o-mini",
                 "mirascope.response.messages": '[{"role":"user","content":[{"type":"text","text":"Recommend a romance book."}],"name":null}]',
@@ -1393,7 +1403,7 @@ def test_traced_context_call_with_tags(span_exporter: InMemorySpanExporter) -> N
                 "mirascope.trace.arg_types": '{"ctx":"llm.Context[str]","genre":"str"}',
                 "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"genre":"science fiction"}',
                 "mirascope.trace.tags": ("context-tag",),
-                "langfuse.trace.tags": ("context-tag",),
+                "tags": ("context-tag",),
                 "mirascope.response.provider_id": "openai",
                 "mirascope.response.model_id": "openai/gpt-4o-mini",
                 "mirascope.response.messages": '[{"role":"user","content":[{"type":"text","text":"As a librarian, Recommend a science fiction book."}],"name":null}]',
@@ -1445,7 +1455,7 @@ async def test_traced_async_context_call_with_tags(
                 "mirascope.trace.arg_types": '{"ctx":"llm.Context[str]","genre":"str"}',
                 "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"genre":"dystopian"}',
                 "mirascope.trace.tags": ("async-context-tag",),
-                "langfuse.trace.tags": ("async-context-tag",),
+                "tags": ("async-context-tag",),
                 "mirascope.response.provider_id": "openai",
                 "mirascope.response.model_id": "openai/gpt-4o-mini",
                 "mirascope.response.messages": '[{"role":"user","content":[{"type":"text","text":"As a librarian, Recommend a dystopian book."}],"name":null}]',


### PR DESCRIPTION
## Summary

The `@ops.trace` decorator emits its `tags` and `metadata` as OTLP span attributes under Mirascope-specific keys (`mirascope.trace.tags` and a single JSON-serialized `mirascope.trace.metadata` blob). This PR additionally emits the equivalent OTel/Langfuse-conventional attribute keys so downstream observability backends can map them to first-class fields, while keeping the existing keys untouched for backward compatibility.

## Why this matters

Per #2862, Langfuse (and similar backends) map span attributes onto native trace fields using their own conventional keys (`langfuse.trace.tags`, `langfuse.session.id`, `langfuse.user.id`). Because Mirascope only emitted `mirascope.trace.*` keys, none of the tags/session/user values surfaced as native, filterable fields -- everything ended up buried under `metadata.attributes.mirascope.trace.*`. The maintainer confirmed this should be configurable and invited a PR.

## Changes

- Added a small module-level helper `_conventional_trace_attributes(tags, metadata)` in `python/mirascope/ops/_internal/traced_functions.py` so both `_span` context managers (`_BaseTracedFunction._span` and `_BaseTracedContextFunction._span`) stay in sync.
- Alongside the existing `mirascope.trace.*` attributes, spans now also emit:
  - `langfuse.trace.tags` -- the same tag list, when tags are present.
  - `langfuse.session.id` / `langfuse.user.id` -- promoted from the `session_id` / `user_id` metadata keys when present.
  - `langfuse.trace.metadata.<key>` -- remaining metadata entries flattened as individual scalar attributes so each can surface as a first-class, filterable field, instead of only the single JSON blob.
- The change is purely additive: `mirascope.trace.tags` and the `mirascope.trace.metadata` JSON blob are unchanged, so existing consumers keep working.

## Testing

- Added focused tests in `python/tests/ops/_internal/test_tracing.py` covering: conventional attribute emission (tags + promoted session/user + flattened metadata), tags-only (no metadata keys), metadata-without-session/user, and the `Context`-traced function variant. Existing full-snapshot tests were updated to include the new `langfuse.trace.tags` attribute.
- `cd python && uv run pytest tests/ops/_internal/test_tracing.py -q` -> 50 passed.
- `uv run ruff check` / `ruff format --check` / `pyright` on the changed files -> clean (0 errors).

These tests are deterministic and require no live LLM/provider call.

Fixes #2862

AI was used for assistance.
