### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -262,6 +262,8 @@ const response = await llm.model("grok/grok-4-latest").call("Hello!");
 console.log(response.text())
 ```
 
+> **Note:** The same OpenAI-compatible client pattern (via `base_url` or `apiKey`) works with multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 ## Transform Plugin
 
 The transform plugin extracts type information from TypeScript interfaces at compile time, enabling the native TypeScript patterns (without Zod) for tools and structured output. This is **optional** - you can use Zod schemas without any build configuration.


### PR DESCRIPTION
## Summary

The TypeScript docs already show OpenAI-compatible providers via `registerProvider` and `baseURL`.

This PR adds a one-line note that the same OpenAI-compatible client pattern works with multi-model gateways when you are not self-hosting, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] TypeScript README renders
- [ ] Existing OpenAI-compatible example unchanged
- [ ] Note is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>