### PR TITLE
fix(ops): preserve function metadata on versioned call wrappers

### DIFF
--- a/python/mirascope/ops/_internal/versioned_calls.py
+++ b/python/mirascope/ops/_internal/versioned_calls.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Concatenate, Generic, cast, overload
 from typing_extensions import TypeIs
 
+from ..._utils import copy_function_metadata
 from ...llm.calls import AsyncCall, AsyncContextCall, Call, ContextCall
 from ...llm.context import Context, DepsT
 from ...llm.formatting import FormattableT
@@ -224,6 +225,7 @@ class VersionedCall(_BaseVersionedCall, Generic[P, FormattableT]):
 
     def __post_init__(self) -> None:
         """Initialize VersionedFunction wrappers for call and stream methods."""
+        copy_function_metadata(self, self._call.prompt.fn)
         self.call = VersionedFunction(
             fn=self._call.call,
             tags=self.tags,
@@ -332,6 +334,7 @@ class VersionedAsyncCall(_BaseVersionedCall, Generic[P, FormattableT]):
 
     def __post_init__(self) -> None:
         """Initialize AsyncVersionedFunction wrappers for call and stream methods."""
+        copy_function_metadata(self, self._call.prompt.fn)
         self.call = AsyncVersionedFunction(
             fn=self._call.call,
             tags=self.tags,
@@ -447,6 +450,7 @@ class VersionedContextCall(_BaseVersionedCall, Generic[P, DepsT, FormattableT]):
 
     def __post_init__(self) -> None:
         """Initialize VersionedFunction wrappers for call and stream methods."""
+        copy_function_metadata(self, self._call.prompt.fn)
         self._call_versioned = VersionedFunction(
             fn=self._call.call,
             tags=self.tags,
@@ -619,6 +623,7 @@ class VersionedAsyncContextCall(_BaseVersionedCall, Generic[P, DepsT, Formattabl
 
     def __post_init__(self) -> None:
         """Initialize AsyncVersionedFunction wrappers for call and stream methods."""
+        copy_function_metadata(self, self._call.prompt.fn)
         self._call_versioned = AsyncVersionedFunction(
             fn=self._call.call,
             tags=self.tags,

--- a/python/tests/ops/_internal/test_metadata_preservation.py
+++ b/python/tests/ops/_internal/test_metadata_preservation.py
@@ -1,7 +1,15 @@
 """Tests for function metadata preservation across decorators."""
 
+import inspect
+
 from mirascope import llm, ops
 from mirascope._utils import copy_function_metadata
+from mirascope.ops._internal.versioned_calls import (
+    VersionedAsyncCall,
+    VersionedAsyncContextCall,
+    VersionedCall,
+    VersionedContextCall,
+)
 
 
 def test_trace_preserves_function_metadata() -> None:
@@ -244,3 +252,66 @@ def test_trace_on_async_context_llm_call_preserves_metadata() -> None:
     assert async_context_recommend.__name__ == "async_context_recommend"
     assert async_context_recommend.__doc__ == "Async context recommend docstring."
     assert hasattr(async_context_recommend, "__wrapped__")
+
+
+def test_versioned_call_wrappers_preserve_metadata_for_trace_application() -> None:
+    """Versioned call wrappers keep function metadata for decorator stacking."""
+
+    @ops.version
+    @llm.call("openai/gpt-4o-mini")
+    def sync_call(topic: str) -> str:
+        """Sync versioned call."""
+        return topic
+
+    @ops.version
+    @llm.call("openai/gpt-4o-mini")
+    async def async_call(topic: str) -> str:
+        """Async versioned call."""
+        return topic
+
+    @ops.version
+    @llm.call("openai/gpt-4o-mini")
+    def context_call(ctx: llm.Context[str], topic: str) -> str:
+        """Context versioned call."""
+        return f"{ctx.deps}:{topic}"
+
+    @ops.version
+    @llm.call("openai/gpt-4o-mini")
+    async def async_context_call(ctx: llm.Context[str], topic: str) -> str:
+        """Async context versioned call."""
+        return f"{ctx.deps}:{topic}"
+
+    cases = (
+        (sync_call, VersionedCall, "sync_call", "Sync versioned call."),
+        (async_call, VersionedAsyncCall, "async_call", "Async versioned call."),
+        (
+            context_call,
+            VersionedContextCall,
+            "context_call",
+            "Context versioned call.",
+        ),
+        (
+            async_context_call,
+            VersionedAsyncContextCall,
+            "async_context_call",
+            "Async context versioned call.",
+        ),
+    )
+    for wrapped, expected_type, expected_name, expected_doc in cases:
+        assert isinstance(wrapped, expected_type)
+        attributes = vars(wrapped)
+        assert attributes["__name__"] == expected_name
+        assert attributes["__module__"] == __name__
+        assert attributes["__qualname__"] == (
+            "test_versioned_call_wrappers_preserve_metadata_for_trace_application"
+            f".<locals>.{expected_name}"
+        )
+        assert attributes["__doc__"] == expected_doc
+        original = attributes["__wrapped__"]
+        assert inspect.isfunction(original)
+        assert original.__name__ == expected_name
+        # `inspect.signature` follows `__wrapped__`, so it now reports the prompt
+        # function's signature rather than the wrapper's `(*args, **kwargs)`.
+        assert inspect.signature(wrapped) == inspect.signature(original)
+        traced = ops.trace(wrapped)
+        assert vars(traced)["__name__"] == expected_name


### PR DESCRIPTION
Closes #2874

## Summary

Stacking `@ops.trace` on top of `@ops.version` crashes at decoration time — the module fails to import, before any LLM call is made:

```python
@ops.trace
@ops.version
@llm.call("openai/gpt-4o-mini")
def recommend_book(genre: str) -> str:
    """Recommends books based on genre."""
    return f"Recommend a {genre} book"
```

```
Traceback (most recent call last):
  File ".../_base_probe.py", line 37, in <module>
    @ops.trace
     ^^^^^^^^^
  File ".../mirascope/ops/_internal/tracing.py", line 353, in trace
    return TracedFunction(fn=__fn, tags=tags, metadata=metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 7, in __init__
  File ".../mirascope/ops/_internal/traced_functions.py", line 181, in __post_init__
    self._qualified_name = get_qualified_name(self.fn)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../mirascope/ops/_internal/utils.py", line 70, in get_qualified_name
    qualified_name = fn.__qualname__
                     ^^^^^^^^^^^^^^^
AttributeError: 'VersionedCall' object has no attribute '__qualname__'
```

The same object is also invisible to ordinary introspection: `__name__`, `__module__`, `__doc__` and `__wrapped__` are all absent, so tooling that walks decorated functions sees an anonymous wrapper instance instead of the user's function.

## Root cause

`VersionedCall`, `VersionedAsyncCall`, `VersionedContextCall` and `VersionedAsyncContextCall` never call the project's existing `copy_function_metadata` utility in `__post_init__` — `python/mirascope/ops/_internal/versioned_calls.py` lines 225, 333, 448 and 620 at `debbd031`. `get_qualified_name` (`python/mirascope/ops/_internal/utils.py:70`) reads `fn.__qualname__` unconditionally, so it raises on any object that never had the attribute copied onto it.

Every other wrapper family in the codebase already does copy that metadata:

- `python/mirascope/llm/calls/calls.py:48`
- `python/mirascope/llm/prompts/prompts.py:45`
- `python/mirascope/llm/tools/tool_schema.py:206`
- `python/mirascope/ops/_internal/traced_calls.py:117`

The four versioned call classes were the only wrappers that skipped it.

## What this change does

Adds a single `copy_function_metadata(self, self._call.prompt.fn)` call at the top of `__post_init__` in each of the four versioned call classes, before the inner `VersionedFunction` / `AsyncVersionedFunction` wrappers are constructed. That reuses the existing utility rather than introducing a new mechanism, so versioned calls now introspect exactly like the rest of the decorator stack.

The diff is 2 files, 76 insertions, 0 deletions: 5 added lines in `versioned_calls.py` (one import, four calls) and 71 lines of new test.

No public API or declared signature changes, and calling a versioned call behaves exactly as before. Two **introspection-level** effects do follow from the copied `__wrapped__` attribute, and both are worth your attention because they mean "nothing changes for code that doesn't stack the decorators" would be too strong a claim:

1. **`inspect.signature` now resolves through `__wrapped__`.** Verified live on both refs, with `@ops.version @llm.call("openai/gpt-4o-mini") def v(genre: str) -> str` and no `@ops.trace` anywhere:

   ```
   debbd031:    inspect.signature(v) = (*args: 'P.args', **kwargs: 'P.kwargs') -> 'Response | Response[FormattableT]'
   this branch: inspect.signature(v) = (genre: str) -> str
   ```

   A plain `@llm.call("openai/gpt-4o-mini") def v(genre: str) -> str` already reports `(genre: str) -> str` on `debbd031`, so this makes versioned calls consistent with every other wrapper — but it is a visible change for anyone introspecting a versioned call today, and it is not gated on stacking `@ops.trace`. The new test asserts it explicitly rather than leaving it implicit.

2. **A loop marked `# pragma: no cover` becomes a live path.** `ops/_internal/utils.py:44-45` is `while hasattr(fn, "__wrapped__"): fn = fn.__wrapped__  # pragma: no cover`, and the comment above it says the loop "is defensive code for edge cases like `@functools.wraps` chains". For versioned calls that is no longer true. Verified on this branch:

   ```
   utils.get_original_fn(v)    = <function v at 0x1005fa520>      # debbd031: the VersionedCall instance itself
   utils.get_qualified_name(v) = 'v'                              # debbd031: AttributeError
   ```

   The consequence is that a real production path is now permanently hidden from coverage (`pragma: no cover` is in `python/.coveragerc`'s `exclude_also`, and that file sets `fail_under = 100`), and the comment is stale. I deliberately did **not** touch `utils.py` — I could not run the full CI coverage job to confirm the loop is covered end-to-end, so removing the pragma would be a guess. Say the word and I will update the comment, drop the pragma, or both.

## Scope — what this does **not** fix

This restores introspection metadata only. `is_call_type()` in `ops/_internal/traced_calls.py` still returns `False` for a `VersionedCall`, so `ops.trace` over an `ops.version`-wrapped call falls through to the generic `TracedFunction` branch and the result has no `.call` / `.stream` surface — unlike `ops.trace` over a plain `@llm.call`, which returns a `TracedCall` that keeps both. Observed on this branch:

```
type(recommend_book) = VersionedCall
vars has __qualname__ = True
is_call_type(recommend_book) = False
type(ops.trace(recommend_book)) = TracedFunction
traced has .call = False | .stream = False
type(ops.trace(plain)) = TracedCall
plain traced has .call = True | .stream = True
```

That dispatch gap is a larger change and is deliberately left out of this PR, which the contributing guide asks to keep to one logical change. Happy to open a follow-up if you would prefer the whole incompatibility resolved at once — or to fold it in here if you would rather not ship a partial fix.

**Trade-off a reviewer should weigh:** the four added calls run `copy_function_metadata` on every `@ops.version` decoration, including for users who never stack `@ops.trace`. That is the same cost the other four wrapper families already pay at import time, but it is not zero.

## Testing

All commands run from `python/`, against the repo's checked-in `.venv` (CPython 3.12.12) rather than `uv run` — see *What was not verified* below.

The new test lives in `tests/ops/_internal/test_metadata_preservation.py`, which is already the dedicated module for this concern (17 tests covering `@ops.trace`, `@llm.call`, `@llm.prompt`, `@llm.tool`, async, context and trace-on-call stacking, plus `copy_function_metadata` itself) and had no `@ops.version` coverage — precisely the gap this PR fills.

`test_versioned_call_wrappers_preserve_metadata_for_trace_application` declares all four versioned wrapper families inside the test body (matching the surrounding tests in that module), asserts the exact copied `__name__`, `__qualname__`, `__module__` and `__doc__` values plus a `__wrapped__` that is the original plain function, asserts that `inspect.signature` now resolves through it, and applies `ops.trace` on top of each one. It makes no provider request.

```
$ python -m pytest \
    "tests/ops/_internal/test_metadata_preservation.py::test_versioned_call_wrappers_preserve_metadata_for_trace_application" \
    -q -p no:randomly
.                                                                        [100%]
1 passed in 11.75s
```

**Revert proof.** Same command each time, with the new test in place and only `versioned_calls.py` mutated. Deleting each of the four added lines *individually* fails the test, so none of them is dead weight:

```
delete ONLY line 228            -> 1 failed   E  KeyError: '__name__'
delete ONLY line 337            -> 1 failed   E  KeyError: '__name__'
delete ONLY line 453            -> 1 failed   E  KeyError: '__name__'
delete ONLY line 626            -> 1 failed   E  KeyError: '__name__'
revert whole file to debbd031   -> 1 failed   E  KeyError: '__name__'
```

The source was restored after each step; `git status --short` is clean.

Coverage of the new source lines:

```
$ python -m pytest "...::test_versioned_call_wrappers_preserve_metadata_for_trace_application" \
    --cov=mirascope.ops._internal.versioned_calls --cov-report=term-missing
mirascope/ops/_internal/versioned_calls.py   139   21   85%   155-156, 161-163,
  257, 273, 294, 366, 385, 407, 488, 510, 534, 558, 582, 661, 683, 708, 732, 757
```

The four added lines are at 228, 337, 453 and 626; none appears in the missing list.

No regressions in the surrounding suites — the delta against `debbd031` is exactly one new pass:

```
$ python -m pytest tests/ops/_internal/test_metadata_preservation.py -q -p no:randomly
18 passed in 13.93s                             # base debbd031: 17 passed

$ python -m pytest tests/ops -q -p no:randomly
178 failed, 259 passed, 1 skipped, 8 errors in 138.31s
                                                # base debbd031: 178 failed, 258 passed, 1 skipped, 8 errors
```

The sorted `FAILED`/`ERROR` name lists from those two `tests/ops` runs are 186 lines each and `diff` between base and this branch is empty — the pre-existing failures are identical, not merely equal in count. They are a local environment problem, not something this branch causes: the checked-in `python/.venv` has `openai` 3.11.0 installed where `uv.lock` pins 2.16.0 and `pyproject.toml` constrains `openai>=2.15.0,<3`. openai 3.x builds its client on `httpx2.Client` (confirmed: `openai._DefaultHttpxClient` subclasses `httpx2.Client`, and `httpx` is never imported), and the installed vcrpy 8.1.1 ships no httpx2/httpcore2 stub (`grep -rl 'httpx2\|httpcore2' .venv/.../vcr/` → no matches), so the `@pytest.mark.vcr` tests never replay their cassettes, reach `api.openai.com` and fail with `openai.AuthenticationError: Error code: 401 — Incorrect API key provided: dummy-op****-key`. Source-closure computation also does not resolve outside a uv-managed environment, which accounts for the `Failed to build closure` warnings and the 8 errors.

Collection of the touched test module is warning-free (`--collect-only -q` → `18 tests collected`, zero `Failed to build closure` lines).

Lint, format, spelling:

```
$ ruff check .
All checks passed!

$ ruff format --check .
930 files already formatted

$ codespell --config .codespellrc
(no output, exit 0)
```

Type check, scoped to the two touched files:

```
$ pyright mirascope/ops/_internal/versioned_calls.py tests/ops/_internal/test_metadata_preservation.py
versioned_calls.py:552:9 - error: Overloaded implementation is not consistent with signature of overload 1
versioned_calls.py:552:9 - error: Overloaded implementation is not consistent with signature of overload 2
versioned_calls.py:576:9 - error: Overloaded implementation is not consistent with signature of overload 1
versioned_calls.py:576:9 - error: Overloaded implementation is not consistent with signature of overload 2
versioned_calls.py:726:15 - error: Overloaded implementation is not consistent with signature of overload 1
versioned_calls.py:726:15 - error: Overloaded implementation is not consistent with signature of overload 2
versioned_calls.py:750:15 - error: Overloaded implementation is not consistent with signature of overload 1
versioned_calls.py:750:15 - error: Overloaded implementation is not consistent with signature of overload 2
8 errors, 0 warnings, 0 informations
```

All eight are pre-existing `reportInconsistentOverload` diagnostics that this PR does not introduce: running the same pyright version against `versioned_calls.py` as it stands at `debbd031` reports the identical eight at lines 548, 572, 721 and 745. The four inserted lines shift them by four. Zero errors in the test file.

## What was **not** verified

- **`uv run pytest tests/` was never run, and cannot be run in this environment.** It aborts during collection on the base commit too: `ERROR tests/e2e - ModuleNotFoundError: No module named 'mlx'` / `Interrupted: 1 error during collection` (`1362 tests collected, 1 error`). What I ran instead is `pytest tests/ops`, plus a grep confirming that is the right blast radius for the **test** suite: no test file outside `tests/ops/` references `mirascope.ops`, `ops.trace`, `ops.version`, `copy_function_metadata`, `traced_functions` or `versioned_calls` (`grep -rlE ... tests --include='*.py' | grep -v '^tests/ops/'` → exit 1, no matches; all 25 matching test files are under `tests/ops/`). Non-test files outside that directory do of course reference these modules — they are the modules being changed.
- **Project-wide `uv run pyright .` was not run**, only the two-file scope shown above.
- **No CI-equivalent environment.** All commands used the checked-in `python/.venv`, which is out of spec with `uv.lock` as described above, invoked directly rather than through `uv run`. `uv lock --check` and `uv sync --all-extras --dev` were not run.
- **Only CPython 3.12.12 was exercised**, not the 3.10–3.13 range the package supports.
- **No live provider request was made.** The new test asserts wrapper metadata only; it never calls an LLM. The `.call` / `.stream` behaviour described under *Scope* was observed by direct introspection, not by executing a request.
- **The full-suite coverage job was not run**, so I cannot say whether `utils.py:44-45` is exercised anywhere outside the new test — which is why the `pragma: no cover` there is left untouched (see item 2 under *What this change does*).
- **The website / TypeScript side was not touched or run.** This diff is confined to `python/mirascope/ops/_internal/` and `python/tests/ops/_internal/`.

## PR Checklist

- [ ] Tests pass: `uv run pytest tests/` — **not ticked.** This command aborts at collection with `ModuleNotFoundError: No module named 'mlx'` on the base commit as well, so I could not run it. `pytest tests/ops` (the full test blast radius) is green relative to base; output above.
- [x] 100% coverage for new code — measured with `--cov=mirascope.ops._internal.versioned_calls --cov-report=term-missing`; none of the four added lines (228, 337, 453, 626) appears in the missing list, and the per-line revert proofs above show each is genuinely exercised rather than incidentally executed.
- [ ] Type check passes: `uv run pyright .` — **not ticked.** I ran pyright only against the two touched files. That scope reports 8 errors, all pre-existing `reportInconsistentOverload` diagnostics present at the same locations on `debbd031`; 0 in the new test file. Project-wide pyright was not run.
- [x] Linting passes: `uv run ruff check .` — `All checks passed!` (ruff invoked from `python/.venv`, not via `uv run`).
- [x] Code formatted: `uv run ruff format .` — `ruff format --check .` reports `930 files already formatted`.
- [x] Conventional commit messages — single commit, `fix(ops): preserve function metadata on versioned call wrappers`.
