### PR TITLE
fix(ops): emit Langfuse-compatible OpenTelemetry trace attributes

### DIFF
--- a/content/docs/learn/ops/configuration.mdx
+++ b/content/docs/learn/ops/configuration.mdx
@@ -41,6 +41,17 @@ provider.add_span_processor(BatchSpanProcessor(exporter))
 ops.configure(tracer_provider=provider)
 ```
 
+Tags and metadata passed to [`@ops.trace`](/docs/ops/tracing) are additionally emitted under the attribute keys Langfuse reads, so they show up as first-class, filterable fields:
+
+| `@ops.trace` argument | Langfuse span attribute |
+| --- | --- |
+| `tags=[...]` | `langfuse.trace.tags` |
+| `metadata={"user_id": ...}` (or `"userId"`) | `langfuse.user.id` |
+| `metadata={"session_id": ...}` (or `"sessionId"`) | `langfuse.session.id` |
+| any other `metadata` key | `langfuse.trace.metadata.<key>` |
+
+If both spellings of an identity key are present, the snake_case one is promoted and the camelCase one is kept under `langfuse.trace.metadata.<key>`. Metadata values that are not one of the OpenTelemetry attribute types (`bool`, `str`, `bytes`, `int`, `float`) are JSON-serialized, and `None` values are omitted. The `mirascope.*` attributes are always emitted unchanged, so other backends are unaffected.
+
 ### OTLP Exporter
 
 Export to any OpenTelemetry collector (Jaeger, Zipkin, Grafana Tempo, Datadog, etc.):

--- a/python/mirascope/ops/_internal/traced_functions.py
+++ b/python/mirascope/ops/_internal/traced_functions.py
@@ -205,6 +205,7 @@ class _BaseTracedFunction(_BaseFunction[P, R, FunctionT]):
                 attributes["mirascope.trace.tags"] = list(self.tags)
             if self.metadata:
                 attributes["mirascope.trace.metadata"] = json_dumps(self.metadata)
+            attributes.update(_langfuse_trace_attributes(self.tags, self.metadata))
             span.set(**attributes)
             yield span
 
@@ -319,6 +320,7 @@ class _BaseTracedContextFunction(
                 attributes["mirascope.trace.tags"] = list(self.tags)
             if self.metadata:
                 attributes["mirascope.trace.metadata"] = json_dumps(self.metadata)
+            attributes.update(_langfuse_trace_attributes(self.tags, self.metadata))
             span.set(**attributes)
             yield span
 
@@ -523,3 +525,50 @@ class AsyncTracedSpanFunction(BaseAsyncTracedSpanFunction[P, R]):
             result = await self.fn(span, *args, **kwargs)
             record_result_to_span(span, result)
             return AsyncTrace(result=result, span=span)
+
+
+_LANGFUSE_IDENTITY_KEYS: tuple[tuple[str, tuple[str, str]], ...] = (
+    ("langfuse.user.id", ("user_id", "userId")),
+    ("langfuse.session.id", ("session_id", "sessionId")),
+)
+
+
+def _langfuse_attribute_value(value: object) -> AttributeValue | None:
+    """Coerce a metadata value into a type OpenTelemetry accepts as an attribute.
+
+    `metadata` is annotated `dict[str, str]` but nothing enforces that at runtime.
+    OpenTelemetry accepts only bool/str/bytes/int/float (or sequences of those); for
+    anything else it drops the attribute and logs a warning on every span. `None` is
+    omitted, and any other non-primitive is serialized the same way the existing
+    `mirascope.trace.metadata` attribute already serializes it.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool | str | bytes | int | float):
+        return value
+    return json_dumps(value)
+
+
+def _langfuse_trace_attributes(
+    tags: tuple[str, ...], metadata: dict[str, str]
+) -> dict[str, AttributeValue]:
+    """Return Langfuse-compatible trace attributes without changing legacy metadata."""
+    attributes: dict[str, AttributeValue] = {}
+    if tags:
+        attributes["langfuse.trace.tags"] = list(tags)
+    promoted: set[str] = set()
+    for langfuse_key, candidates in _LANGFUSE_IDENTITY_KEYS:
+        for candidate in candidates:
+            if candidate in metadata:
+                promoted.add(candidate)
+                if (
+                    value := _langfuse_attribute_value(metadata[candidate])
+                ) is not None:
+                    attributes[langfuse_key] = value
+                break
+    for key, raw_value in metadata.items():
+        if key in promoted:
+            continue
+        if (value := _langfuse_attribute_value(raw_value)) is not None:
+            attributes[f"langfuse.trace.metadata.{key}"] = value
+    return attributes

--- a/python/tests/ops/_internal/test_tracing.py
+++ b/python/tests/ops/_internal/test_tracing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Generator
 from typing import Any, TypeVar
 from unittest.mock import patch
@@ -13,6 +14,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import format_span_id, format_trace_id
 
 from mirascope import llm, ops
+from mirascope.ops._internal.traced_functions import TracedContextFunction
 
 from ..utils import extract_span_data
 
@@ -73,6 +75,112 @@ def test_sync_trace(
     call_span = spans[1]
     call_span_data = extract_span_data(call_span)
     assert call_span_data == span_data
+
+
+def test_trace_emits_langfuse_attributes_without_changing_legacy_metadata(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Trace metadata preserves Mirascope JSON and adds Langfuse mappings."""
+
+    @ops.trace(tags=["tag"], metadata={"user_id": "u", "session_id": "s", "team": "ml"})
+    def traced() -> str:
+        return "ok"
+
+    traced()
+    attributes = span_exporter.get_finished_spans()[0].attributes
+    assert attributes is not None
+    assert (
+        attributes["mirascope.trace.metadata"]
+        == '{"user_id":"u","session_id":"s","team":"ml"}'
+    )
+    assert attributes["langfuse.trace.tags"] == ("tag",)
+    assert attributes["langfuse.user.id"] == "u"
+    assert attributes["langfuse.session.id"] == "s"
+    assert attributes["langfuse.trace.metadata.team"] == "ml"
+
+
+def test_context_trace_emits_camel_case_langfuse_identity_attributes(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """The context span builder promotes camelCase IDs and keeps legacy metadata.
+
+    `TracedContextFunction` is constructed directly because `ops.trace` only ever
+    reaches the context span builder via `TracedContextCall`, which requires a
+    provider request.
+    """
+
+    def echo(ctx: llm.Context[str]) -> str:
+        return ctx.deps
+
+    traced = TracedContextFunction(
+        fn=echo,
+        tags=("tag",),
+        metadata={"userId": "u", "sessionId": "s", "region": "eu"},
+    )
+
+    assert traced(llm.Context(deps="ok")) == "ok"
+    attributes = span_exporter.get_finished_spans()[0].attributes
+    assert attributes is not None
+    assert (
+        attributes["mirascope.trace.metadata"]
+        == '{"userId":"u","sessionId":"s","region":"eu"}'
+    )
+    assert attributes["mirascope.trace.tags"] == ("tag",)
+    assert attributes["langfuse.trace.tags"] == ("tag",)
+    assert attributes["langfuse.user.id"] == "u"
+    assert attributes["langfuse.session.id"] == "s"
+    assert attributes["langfuse.trace.metadata.region"] == "eu"
+
+
+def test_trace_langfuse_attributes_keep_both_identity_key_spellings(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Only the promoted spelling is consumed; the other still reaches Langfuse."""
+
+    @ops.trace(metadata={"user_id": "snake", "userId": "camel"})
+    def traced() -> str:
+        return "ok"
+
+    traced()
+    attributes = span_exporter.get_finished_spans()[0].attributes
+    assert attributes is not None
+    assert attributes["langfuse.user.id"] == "snake"
+    assert attributes["langfuse.trace.metadata.userId"] == "camel"
+    assert "langfuse.trace.metadata.user_id" not in attributes
+    assert "langfuse.session.id" not in attributes
+
+
+def test_trace_langfuse_attributes_coerce_non_primitive_metadata_values(
+    span_exporter: InMemorySpanExporter,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-primitive metadata values are coerced instead of dropped with a warning."""
+
+    @ops.trace(
+        metadata={  # pyright: ignore[reportArgumentType]
+            "user_id": None,
+            "nested": {"a": 1},
+            "count": 5,
+            "note": "anon",
+        }
+    )
+    def traced() -> str:
+        return "ok"
+
+    with caplog.at_level(logging.WARNING, logger="opentelemetry.attributes"):
+        traced()
+
+    assert caplog.records == []
+    attributes = span_exporter.get_finished_spans()[0].attributes
+    assert attributes is not None
+    assert (
+        attributes["mirascope.trace.metadata"]
+        == '{"user_id":null,"nested":{"a":1},"count":5,"note":"anon"}'
+    )
+    assert "langfuse.user.id" not in attributes
+    assert attributes["langfuse.trace.metadata.nested"] == '{"a":1}'
+    assert attributes["langfuse.trace.metadata.count"] == 5
+    assert attributes["langfuse.trace.metadata.note"] == "anon"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2875

## Summary

When you point Mirascope's OpenTelemetry output at Langfuse, the tags and metadata you pass to `@ops.trace` do not show up as tags, user or session on the Langfuse trace. They arrive as opaque span attributes and have to be read by hand.

The reason is a naming mismatch, not a bug in the export path. Mirascope writes `mirascope.trace.tags` and a single JSON blob at `mirascope.trace.metadata`; Langfuse's OpenTelemetry ingestion reads `langfuse.trace.tags`, `langfuse.user.id`, `langfuse.session.id` and `langfuse.trace.metadata.<key>` ([Langfuse OpenTelemetry docs](https://langfuse.com/integrations/native/opentelemetry)). Nothing in Mirascope emits the second set, so Langfuse has nothing to map.

Exported span attributes on `debbd031`, from a script that installs an `InMemorySpanExporter`, calls `ops.configure(tracer_provider=...)`, and runs a function decorated with `@ops.trace(tags=["production"], metadata={"user_id": "u-1", "session_id": "s-1", "team": "ml"})`:

```
mirascope.fn.is_async = False
mirascope.fn.module = '__main__'
mirascope.fn.qualname = 'greet'
mirascope.trace.arg_types = '{}'
mirascope.trace.arg_values = '{}'
mirascope.trace.metadata = '{"user_id":"u-1","session_id":"s-1","team":"ml"}'
mirascope.trace.output = 'hi'
mirascope.trace.tags = ('production',)
mirascope.type = 'trace'
```

No `langfuse.*` attribute is present. In the Langfuse UI the trace therefore has no tags, no user and no session, and the metadata is a single JSON string rather than filterable keys.

## Root cause

Both trace span builders write only the `mirascope.*` namespace, at `debbd031`:

- `python/mirascope/ops/_internal/traced_functions.py:205,207` — `_BaseTracedFunction._span`, the ordinary path
- `python/mirascope/ops/_internal/traced_functions.py:319,321` — `_BaseTracedContextFunction._span`, the context path

## What this change does

Adds a small helper, `_langfuse_trace_attributes`, and calls it from both span builders so each span carries the Langfuse-readable names **in addition to** the existing ones. The `mirascope.*` attributes are untouched, so anything already reading them keeps working.

The mapping:

| source | emitted as |
| --- | --- |
| `tags` | `langfuse.trace.tags` |
| `metadata["user_id"]` or `metadata["userId"]` | `langfuse.user.id` |
| `metadata["session_id"]` or `metadata["sessionId"]` | `langfuse.session.id` |
| every other metadata key | `langfuse.trace.metadata.<key>` |

Same script, same input, on this branch:

```
langfuse.session.id = 's-1'
langfuse.trace.metadata.team = 'ml'
langfuse.trace.tags = ('production',)
langfuse.user.id = 'u-1'
mirascope.fn.is_async = False
mirascope.fn.module = '__main__'
mirascope.fn.qualname = 'greet'
mirascope.trace.arg_types = '{}'
mirascope.trace.arg_values = '{}'
mirascope.trace.metadata = '{"user_id":"u-1","session_id":"s-1","team":"ml"}'
mirascope.trace.output = 'hi'
mirascope.trace.tags = ('production',)
mirascope.type = 'trace'
```

Only the spelling that is actually consumed is removed from the metadata expansion. If a user supplies both `user_id` and `userId`, one is promoted to `langfuse.user.id` and the other still reaches `langfuse.trace.metadata.userId` rather than being silently dropped. There is a dedicated test for that.

**Value coercion, and the log-noise regression it exists to prevent.** OpenTelemetry accepts only `bool`/`str`/`bytes`/`int`/`float` (or sequences of those) as attribute values; for anything else it drops the attribute *and logs a `WARNING`*. `metadata` is annotated `dict[str, str]`, but that is not enforced at runtime, and `metadata={"user_id": maybe_none}` for an optional identity is an ordinary pattern — and `user_id` is exactly the key this PR newly promotes to a first-class attribute. Before I added coercion, this branch produced one warning **per span**, where `debbd031` produced none (it only ever emitted the single JSON blob, which serializes `None` happily):

```
$ python repro.py none       # @ops.trace(metadata={"user_id": None, "note": "anon"}), called twice
WARNING:opentelemetry.attributes:Invalid type NoneType for attribute 'langfuse.user.id' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
WARNING:opentelemetry.attributes:Invalid type NoneType for attribute 'langfuse.user.id' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
NUM SPANS: 2
{'mirascope.trace.metadata': '{"user_id":null,"note":"anon"}', 'langfuse.trace.metadata.note': 'anon'}
{'mirascope.trace.metadata': '{"user_id":null,"note":"anon"}', 'langfuse.trace.metadata.note': 'anon'}

$ python repro.py nested     # metadata={"nested": {"a": 1}, "num": 5, "ok": "s"}, called three times
WARNING:opentelemetry.attributes:Invalid type dict for attribute 'langfuse.trace.metadata.nested' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
   (x3 - once per span; `num` and `ok` pass through fine)
NUM SPANS: 3
{'mirascope.trace.metadata': '{"nested":{"a":1},"num":5,"ok":"s"}', 'langfuse.trace.metadata.num': 5, 'langfuse.trace.metadata.ok': 's'}
   (x3)
```

`opentelemetry.attributes` does not dedupe or rate-limit, so that scales linearly with traced traffic. `_langfuse_attribute_value` therefore omits `None` and JSON-serializes any other non-primitive, using the same `json_dumps` that `mirascope.trace.metadata` already uses — so a value that would break `json_dumps` was already breaking the existing attribute, and no new failure mode is introduced. Same two inputs on this branch, warning-free and with the nested value now preserved:

```
$ python repro.py none
NUM SPANS: 2
{'mirascope.trace.metadata': '{"user_id":null,"note":"anon"}', 'langfuse.trace.metadata.note': 'anon'}
{'mirascope.trace.metadata': '{"user_id":null,"note":"anon"}', 'langfuse.trace.metadata.note': 'anon'}

$ python repro.py nested
NUM SPANS: 3
{'mirascope.trace.metadata': '{"nested":{"a":1},"num":5,"ok":"s"}', 'langfuse.trace.metadata.nested': '{"a":1}', 'langfuse.trace.metadata.num': 5, 'langfuse.trace.metadata.ok': 's'}
   (x3)
```

Note the deliberate asymmetry this introduces: a `None` metadata value still appears inside `mirascope.trace.metadata` as `null`, but has no `langfuse.*` counterpart. Emitting the string `"null"` as a user ID seemed worse than omitting the attribute, which is also what OpenTelemetry itself was doing — just without the warning.

Diff is 3 files, 168 insertions, 0 deletions: 49 lines in `traced_functions.py`, 108 lines of new test, and 11 lines of documentation.

**Trade-offs a reviewer should weigh:**

- **The change is unconditional.** Every traced span with tags or metadata now carries both namespaces, which roughly doubles the trace-level attribute count for those spans, even for users who do not use Langfuse. If you would rather this were opt-in — an `ops.configure` flag, or a pluggable attribute mapper — I am happy to rework it that way; I did not want to guess at a public API surface unprompted.
- **The precedence rule is mine, not yours.** Where both `user_id` and `userId` are present, snake_case wins because it is checked first. That is an arbitrary choice; say the word if you would prefer camelCase precedence or an error.
- **The coercion rule is also mine.** Dropping `None` and JSON-encoding nested values is a judgement call made to avoid the per-span warning described above. Raising on a non-`str` value, or coercing with `str()` instead of `json_dumps`, are both defensible alternatives.
- **This special-cases one vendor inside core tracing code.** A reasonable alternative is a separate exporter or processor. That is a bigger design decision than a bug fix, so this PR takes the smaller path.

## Documentation

`content/docs/learn/ops/configuration.mdx` already documents Langfuse as a recommended backend with a full OTLP snippet, so the new mapping table, the snake_case-over-camelCase precedence rule and the value-coercion rule are documented in that section. `content/docs/learn/ops/tracing.mdx` is left alone — its options table describes the `@ops.trace` arguments themselves, which are unchanged.

## Testing

All commands run from `python/`, against the repo's checked-in `.venv` (CPython 3.12.12) rather than `uv run` — see *What was not verified* below.

Four new tests in `tests/ops/_internal/test_tracing.py`, all using the existing `span_exporter` (`InMemorySpanExporter`) fixture, none making a provider request:

- `test_trace_emits_langfuse_attributes_without_changing_legacy_metadata` — ordinary path; asserts the legacy JSON blob is byte-identical *and* the four new attributes are present.
- `test_context_trace_emits_camel_case_langfuse_identity_attributes` — context path, with camelCase identity keys.
- `test_trace_langfuse_attributes_keep_both_identity_key_spellings` — both spellings supplied; asserts `langfuse.user.id == 'snake'`, `langfuse.trace.metadata.userId == 'camel'`, and that neither `langfuse.trace.metadata.user_id` nor `langfuse.session.id` is emitted.
- `test_trace_langfuse_attributes_coerce_non_primitive_metadata_values` — `None`, nested-dict and `int` metadata values; asserts `caplog.records == []` at `WARNING` for the `opentelemetry.attributes` logger, that no `langfuse.user.id` is emitted for the `None`, that the nested value arrives as `'{"a":1}'` and the `int` arrives as `5`, and that `mirascope.trace.metadata` is unchanged.

That last test deliberately passes values outside the declared `dict[str, str]`, so it carries a `# pyright: ignore[reportArgumentType]` on the `metadata=` literal. AGENTS.md asks that the type system not be circumvented without approval, so flagging it: it is one comment, in a test, on an argument whose whole point is to be off-type at runtime, and it matches the existing pattern in this repo (`tests/llm/providers/test_missing_dependencies.py` and `tests/llm/formatting/test_format.py` use the same suppression for the same reason). If you would rather the test built the dict without a suppression, or would rather `metadata` were validated at the API boundary instead, say so.

```
$ python -m pytest tests/ops/_internal/test_tracing.py -k langfuse -q -p no:randomly
....                                                                     [100%]
4 passed, 46 deselected in 0.11s
```

**A note on the context test.** It constructs `TracedContextFunction(...)` directly rather than going through `ops.trace`. That is deliberate and worth your judgement: `ops.trace`'s dispatch (`ops/_internal/tracing.py:343-353`) never returns a `TracedContextFunction`. A function whose first parameter is `ctx: llm.Context[str]` falls into the final `else` branch — verified at runtime, `type = TracedFunction`. The only code that constructs `TracedContextFunction` is `TracedContextCall.__post_init__` (`ops/_internal/traced_calls.py:292,295`), which requires a live provider request. Direct construction is therefore the only network-free route to the context span builder, but it does mean the test bypasses public-API dispatch. If you would prefer a VCR-backed `TracedContextCall` test, that is easy to add in an environment where cassettes replay (mine does not — see below).

**Revert proof.** All four runs use `pytest tests/ops/_internal/test_tracing.py -k langfuse -q -p no:randomly`, with the new tests in place and only the source mutated.

1. `traced_functions.py` restored wholesale to `debbd031` — all four fail:

```
FAILED tests/ops/_internal/test_tracing.py::test_trace_emits_langfuse_attributes_without_changing_legacy_metadata
FAILED tests/ops/_internal/test_tracing.py::test_context_trace_emits_camel_case_langfuse_identity_attributes
FAILED tests/ops/_internal/test_tracing.py::test_trace_langfuse_attributes_keep_both_identity_key_spellings
FAILED tests/ops/_internal/test_tracing.py::test_trace_langfuse_attributes_coerce_non_primitive_metadata_values
4 failed, 46 deselected in 0.21s
```

2. Only the new line in `_BaseTracedContextFunction._span` (line 323) deleted — the context test, and only the context test, fails:

```
FAILED tests/ops/_internal/test_tracing.py::test_context_trace_emits_camel_case_langfuse_identity_attributes
1 failed, 3 passed, 46 deselected in 0.18s
```

3. Only the new line in `_BaseTracedFunction._span` (line 208) deleted — the three ordinary-path tests fail and the context test still passes:

```
FAILED tests/ops/_internal/test_tracing.py::test_trace_emits_langfuse_attributes_without_changing_legacy_metadata
FAILED tests/ops/_internal/test_tracing.py::test_trace_langfuse_attributes_keep_both_identity_key_spellings
FAILED tests/ops/_internal/test_tracing.py::test_trace_langfuse_attributes_coerce_non_primitive_metadata_values
3 failed, 1 passed, 46 deselected in 0.18s
```

4. `_langfuse_attribute_value` mutated to return its argument unchanged — the coercion test, and only it, fails:

```
FAILED tests/ops/_internal/test_tracing.py::test_trace_langfuse_attributes_coerce_non_primitive_metadata_values
1 failed, 3 passed, 46 deselected in 0.17s
```

The source was restored after each step; `git status --short` is clean.

Coverage of the new source lines:

```
$ python -m pytest tests/ops/_internal/test_tracing.py -k langfuse \
    --cov=mirascope.ops._internal.traced_functions --cov-report=term-missing
mirascope/ops/_internal/traced_functions.py   235   62   74%   49, 52-59, 76, 81,
  100-108, 135-143, 248-251, 282-285, 289-292, 369-372, 411-414, 420-423,
  465-468, 472-475, 517-520, 524-527
```

New code sits at lines 208, 323 and 528-574; none of those appears in the missing list. (517-520 and 524-527 are pre-existing `AsyncTracedSpanFunction` lines, not part of this diff.)

No regressions — the delta against `debbd031` is exactly four new passes:

```
$ python -m pytest tests/ops/_internal/test_tracing.py -q -p no:randomly
24 failed, 26 passed in 17.92s                  # base debbd031: 24 failed, 22 passed

$ python -m pytest tests/ops -q -p no:randomly
178 failed, 262 passed, 1 skipped, 8 errors in 235.51s
                                                # base debbd031: 178 failed, 258 passed, 1 skipped, 8 errors
```

The sorted `FAILED`/`ERROR` name lists from those two `tests/ops` runs are 186 lines each and `diff` between base and this branch is empty — the pre-existing failures are identical, not merely equal in count. They are a local environment problem, not something this branch causes: the checked-in `python/.venv` has `openai` 3.11.0 installed where `uv.lock` pins 2.16.0 and `pyproject.toml` constrains `openai>=2.15.0,<3`. openai 3.x builds its client on `httpx2.Client` (confirmed: `openai._DefaultHttpxClient` subclasses `httpx2.Client`, and `httpx` is never imported), and the installed vcrpy 8.1.1 ships no httpx2/httpcore2 stub (`grep -rl 'httpx2\|httpcore2' .venv/.../vcr/` → no matches), so the `@pytest.mark.vcr` tests never replay their cassettes, reach `api.openai.com` and fail with `openai.AuthenticationError: Error code: 401 — Incorrect API key provided: dummy-op****-key`.

Lint, format, type, spelling:

```
$ ruff check .
All checks passed!

$ ruff format --check .
930 files already formatted

$ pyright mirascope/ops/_internal/traced_functions.py tests/ops/_internal/test_tracing.py
0 errors, 0 warnings, 0 informations            # identical to base debbd031

$ codespell --config .codespellrc
(no output, exit 0)
```

## What was **not** verified

- **No live Langfuse project was used.** Everything here is asserted against an in-memory OpenTelemetry exporter. I have shown that Mirascope now *emits* the attributes and that the names match [Langfuse's published OpenTelemetry documentation](https://langfuse.com/integrations/native/opentelemetry); I have **not** shown that a real Langfuse instance ingests and renders them. If you have a project to point this at before merging, that is the check I could not run.
- **`uv run pytest tests/` was never run, and cannot be run in this environment.** It aborts during collection on the base commit too: `ERROR tests/e2e - ModuleNotFoundError: No module named 'mlx'` / `Interrupted: 1 error during collection` (`1362 tests collected, 1 error`). What I ran instead is `pytest tests/ops`, plus a grep confirming that is the right blast radius for the **test** suite: no test file outside `tests/ops/` references `mirascope.ops`, `ops.trace`, `ops.version`, `traced_functions` or `versioned_calls` (`grep -rlE ... tests --include='*.py' | grep -v '^tests/ops/'` → exit 1, no matches; all 25 matching test files are under `tests/ops/`). Non-test files outside that directory do of course reference these modules — they are the modules being changed.
- **The website was not built or tested**, so the one documentation hunk in `content/docs/learn/ops/configuration.mdx` is unrendered. It is plain MDX prose and a table, with an internal link (`/docs/ops/tracing`) in the same form used elsewhere in that file, and the repo's lint-staged and `lint:website` steps cover `.ts`/`.tsx` only.
- **Project-wide `uv run pyright .` was not run**, only the two-file scope shown above.
- **No CI-equivalent environment.** All commands used the checked-in `python/.venv`, which is out of spec with `uv.lock` as described above, invoked directly rather than through `uv run`. `uv lock --check` and `uv sync --all-extras --dev` were not run.
- **Only CPython 3.12.12 was exercised**, not the 3.10–3.13 range the package supports.
- **No provider request was made.** All four new tests are provider-free, and the context path was exercised by direct construction rather than through `TracedContextCall`.
- **No performance measurement.** I did not benchmark the added per-span attribute work, so the "roughly doubles the trace-level attribute count" trade-off above is a count of attributes, not a measured cost.

## PR Checklist

- [ ] Tests pass: `uv run pytest tests/` — **not ticked.** This command aborts at collection with `ModuleNotFoundError: No module named 'mlx'` on the base commit as well, so I could not run it. `pytest tests/ops` (the full test blast radius) is green relative to base; output above.
- [x] 100% coverage for new code — measured with `--cov=mirascope.ops._internal.traced_functions --cov-report=term-missing`; none of the new lines (208, 323, 528-574) appears in the missing list, and the per-line revert proofs above show each is genuinely exercised rather than incidentally executed.
- [ ] Type check passes: `uv run pyright .` — **not ticked.** I ran pyright only against the two touched Python files, where it reports `0 errors, 0 warnings, 0 informations`. Project-wide pyright was not run.
- [x] Linting passes: `uv run ruff check .` — `All checks passed!` (ruff invoked from `python/.venv`, not via `uv run`).
- [x] Code formatted: `uv run ruff format .` — `ruff format --check .` reports `930 files already formatted`.
- [x] Conventional commit messages — single commit, `fix(ops): emit Langfuse-compatible OpenTelemetry trace attributes`.
